### PR TITLE
バックエンドの環境をコンテナ化

### DIFF
--- a/reimi/backend/reimi_app/Dockerfile
+++ b/reimi/backend/reimi_app/Dockerfile
@@ -1,0 +1,21 @@
+FROM eclipse-temurin:17-jdk AS build
+
+WORKDIR /app
+
+COPY pom.xml .
+COPY src ./src
+COPY .mvn/ .mvn
+COPY mvnw ./
+
+RUN ./mvnw dependency:go-offline -B
+RUN ./mvnw clean package -DskipTests
+
+FROM eclipse-temurin:17-jre
+
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar /app/app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/reimi/backend/reimi_app/docker-compose.yml
+++ b/reimi/backend/reimi_app/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: reimi-app
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/reimi_db
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15.5
+    container_name: reimi-db
+    restart: always
+    environment:
+      POSTGRES_DB: reimi_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## 対応Issue

- #13 

close #13 

## 対応したこと

 - バックエンドの環境（Spring BootとPostgreSQL）をコンテナ化した

   - Spring BootのDockerfile作成
  
     - マルチビルドで軽量化
  
   - YAMLファイル作成
 
     - Spring BootとPostgreSQLのコンテナを管理
   
     - VolumeでPostgreSQLのデータを残せる様にした
  
## 参考資料

Dockerfileの書き方
- https://qiita.com/gon0821/items/f9e3bcbb6cb01d4ef7fa
- https://qiita.com/Yasushi-Mo/items/17f755b9160767947d3e
- https://www.issoh.co.jp/tech/details/1929/#Spring_BootVscode

## 対応しきれなかったこと

 - データベースをマイグレーション管理
