### PR TITLE
OpenAPI作成とAPIドキュメントの自動生成

### DIFF
--- a/reimi/backend/reimi_app/pom.xml
+++ b/reimi/backend/reimi_app/pom.xml
@@ -72,6 +72,12 @@
 			<artifactId>flyway-database-postgresql</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.14</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
@@ -3,6 +3,24 @@ package com.reimi.reimi_app;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@OpenAPIDefinition(
+	info = @Info(
+		title = "Reimi",
+		version = "1.0",
+		description = "天気で繋がる、出会いのアプリ"
+	),
+	servers = {
+        @Server(
+            description = "ローカル環境",
+            url = "http://localhost:8080"
+		)
+	}
+)
+
 @SpringBootApplication
 public class ReimiAppApplication {
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.servers.Server;
 	),
 	servers = {
         @Server(
-            description = "ローカル環境",
+            description = "ローカルサーバー",
             url = "http://localhost:8080"
 		)
 	}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/controller/TestController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/controller/TestController.java
@@ -1,0 +1,16 @@
+package com.reimi.reimi_app.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path="/")
+public class TestController {
+
+    @RequestMapping(path="/hello", method=RequestMethod.GET)
+    public String hello() {
+        return "HelloWorld";
+    }
+
+}


### PR DESCRIPTION
## 対応Issue

- #31 

close #31 

## 対応したこと

- OpenAPIを作成した

- Springdoc-openapiを使ってAPIドキュメントを自動生成できる様にした

  - 必要な依存関係の設定
 
    - springdoc-openapi-starter-webmvc-ui

  - 開発環境用の設定（application-dev.properties）

  - mainメソッドにOpenAPIドキュメントに関するメタ情報を定義

- API実際に作成して実行

## 参考資料
Springdoc-openapiとAPIドキュメントの作成

- https://springdoc.org/
- https://zenn.dev/rehabforjapan/articles/488bc5c185551f
- https://qiita.com/thashi/items/72a2bb20e202ae293abe
- https://qiita.com/Omi354/items/e52401971354cf2b4317
- https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations#openapi-annotations
- https://qiita.com/crml1206/items/e47ec484af750d301953

## 対応しきれなかったこと
