### PR TITLE
【UI】いいね画面のUIを実装Feat/53 like page UI

### DIFF
--- a/reimi/frontend/reimi_app/lib/core/di/data_providers.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/data_providers.dart
@@ -1,14 +1,18 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:reimi_app/core/firebase/firebase_auth_provider.dart';
 import 'package:reimi_app/data/datasources/auth_remote_datasource.dart';
+import 'package:reimi_app/data/datasources/like_remote_datasource.dart';
+import 'package:reimi_app/data/datasources/mocks/like_mock_datasource.dart';
 import 'package:reimi_app/data/datasources/mocks/profile_mock_datasource.dart';
 import 'package:reimi_app/data/datasources/mocks/user_mock_datasource.dart';
 import 'package:reimi_app/data/datasources/profile_remote_datasource.dart';
 import 'package:reimi_app/data/datasources/user_remote_datasource.dart';
 import 'package:reimi_app/data/repositories/auth_repository_impl.dart';
+import 'package:reimi_app/data/repositories/like_repository_impl.dart';
 import 'package:reimi_app/data/repositories/profile_repository_impl.dart';
 import 'package:reimi_app/data/repositories/user_repository_impl.dart';
 import 'package:reimi_app/domain/repositories/auth_repository.dart';
+import 'package:reimi_app/domain/repositories/like_repository.dart';
 import 'package:reimi_app/domain/repositories/profile_repository.dart';
 import 'package:reimi_app/domain/repositories/user_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -40,7 +44,6 @@ UserRepository userRepository(Ref ref) {
   return UserRepositoryImpl(ref.watch(userRemoteDataSourceProvider));
 }
 
-
 // profile関連
 @riverpod
 ProfileRemoteDataSource profileRemoteDataSource(Ref ref) {
@@ -51,4 +54,16 @@ ProfileRemoteDataSource profileRemoteDataSource(Ref ref) {
 @riverpod
 ProfileRepository profileRepository(Ref ref) {
   return ProfileRepositoryImpl(ref.watch(profileRemoteDataSourceProvider));
+}
+
+// like関連
+@riverpod
+LikeRemoteDataSource likeRemoteDataSource(Ref ref) {
+  if (useMock) return const LikeMockDataSource();
+  return const LikeRemoteDataSourceImpl();
+}
+
+@riverpod
+LikeRepository likeRepository(Ref ref) {
+  return LikeRepositoryImpl(ref.watch(likeRemoteDataSourceProvider));
 }

--- a/reimi/frontend/reimi_app/lib/core/di/data_providers.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/data_providers.g.dart
@@ -116,5 +116,41 @@ final profileRepositoryProvider =
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef ProfileRepositoryRef = AutoDisposeProviderRef<ProfileRepository>;
+String _$likeRemoteDataSourceHash() =>
+    r'8cfd5563d76e465f5c013176bd1a802d65bd256e';
+
+/// See also [likeRemoteDataSource].
+@ProviderFor(likeRemoteDataSource)
+final likeRemoteDataSourceProvider =
+    AutoDisposeProvider<LikeRemoteDataSource>.internal(
+  likeRemoteDataSource,
+  name: r'likeRemoteDataSourceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$likeRemoteDataSourceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef LikeRemoteDataSourceRef = AutoDisposeProviderRef<LikeRemoteDataSource>;
+String _$likeRepositoryHash() => r'4fdc6a16b92896780a50e71e7d4e2d6f821b41a4';
+
+/// See also [likeRepository].
+@ProviderFor(likeRepository)
+final likeRepositoryProvider = AutoDisposeProvider<LikeRepository>.internal(
+  likeRepository,
+  name: r'likeRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$likeRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef LikeRepositoryRef = AutoDisposeProviderRef<LikeRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/core/di/domain_providers.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/domain_providers.dart
@@ -2,6 +2,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:reimi_app/core/di/data_providers.dart';
 import 'package:reimi_app/domain/usecases/get_current_user_usecase.dart';
 import 'package:reimi_app/domain/usecases/get_home_users_usecase.dart';
+import 'package:reimi_app/domain/usecases/get_like_users_from_user_usecase.dart';
+import 'package:reimi_app/domain/usecases/get_like_users_to_user_usecase.dart';
 import 'package:reimi_app/domain/usecases/get_user_profile_usecase.dart';
 import 'package:reimi_app/domain/usecases/sign_in_with_provider_usecase.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -38,4 +40,15 @@ GetUserProfileUseCase getUserProfileUseCase(Ref ref) {
     userRepository: ref.watch(userRepositoryProvider),
     profileRepository: ref.watch(profileRepositoryProvider),
   );
+}
+
+// like関連
+@riverpod
+GetLikeUsersFromUserUseCase getLikeUsersFromUserUseCase(Ref ref) {
+  return GetLikeUsersFromUserUseCase(ref.watch(likeRepositoryProvider));
+}
+
+@riverpod
+GetLikeUsersToUserUseCase getLikeUsersToUserUseCase(Ref ref) {
+  return GetLikeUsersToUserUseCase(ref.watch(likeRepositoryProvider));
 }

--- a/reimi/frontend/reimi_app/lib/core/di/domain_providers.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/domain_providers.g.dart
@@ -85,5 +85,45 @@ final getUserProfileUseCaseProvider =
 // ignore: unused_element
 typedef GetUserProfileUseCaseRef
     = AutoDisposeProviderRef<GetUserProfileUseCase>;
+String _$getLikeUsersFromUserUseCaseHash() =>
+    r'798e5d96398b28563f53cc80b9b409f10b7befcc';
+
+/// See also [getLikeUsersFromUserUseCase].
+@ProviderFor(getLikeUsersFromUserUseCase)
+final getLikeUsersFromUserUseCaseProvider =
+    AutoDisposeProvider<GetLikeUsersFromUserUseCase>.internal(
+  getLikeUsersFromUserUseCase,
+  name: r'getLikeUsersFromUserUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getLikeUsersFromUserUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetLikeUsersFromUserUseCaseRef
+    = AutoDisposeProviderRef<GetLikeUsersFromUserUseCase>;
+String _$getLikeUsersToUserUseCaseHash() =>
+    r'89e934ec3946930d3f867a9b287330091f06ccba';
+
+/// See also [getLikeUsersToUserUseCase].
+@ProviderFor(getLikeUsersToUserUseCase)
+final getLikeUsersToUserUseCaseProvider =
+    AutoDisposeProvider<GetLikeUsersToUserUseCase>.internal(
+  getLikeUsersToUserUseCase,
+  name: r'getLikeUsersToUserUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getLikeUsersToUserUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetLikeUsersToUserUseCaseRef
+    = AutoDisposeProviderRef<GetLikeUsersToUserUseCase>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/core/extensions/datetime_extensions.dart
+++ b/reimi/frontend/reimi_app/lib/core/extensions/datetime_extensions.dart
@@ -16,4 +16,7 @@ extension DateTimeFormatExtension on DateTime {
   // 曜日付き
   String get toJapaneseDateWithWeekday =>
       DateFormat('yyyy年MM月dd日(E)', 'ja').format(this);
+
+  // 年齢
+  String get toAge => '(${DateTime.now().year - year})';
 }

--- a/reimi/frontend/reimi_app/lib/data/datasources/like_remote_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/like_remote_datasource.dart
@@ -1,0 +1,44 @@
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/entities/like_entity.dart';
+
+abstract class LikeRemoteDataSource {
+  Future<bool> isLiked({
+    required String fromUserId,
+    required String toUserId,
+  });
+  Future<LikeEntity> like({
+    required String fromUserId,
+    required String toUserId,
+  });
+  Future<List<LikeUserModel>?> getLikeUsersFromUser(String userId);
+  Future<List<LikeUserModel>?> getLikeUsersToUser(String userId);
+}
+
+class LikeRemoteDataSourceImpl implements LikeRemoteDataSource {
+  const LikeRemoteDataSourceImpl();
+
+  @override
+  Future<List<LikeUserModel>?> getLikeUsersFromUser(String userId) {
+    // TODO: implement getLikesFromUser
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<LikeUserModel>?> getLikeUsersToUser(String userId) {
+    // TODO: implement getLikesToUser
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> isLiked({required String fromUserId, required String toUserId}) {
+    // TODO: implement isLiked
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<LikeEntity> like(
+      {required String fromUserId, required String toUserId}) {
+    // TODO: implement like
+    throw UnimplementedError();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/data/datasources/mocks/like_mock_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/mocks/like_mock_datasource.dart
@@ -1,0 +1,70 @@
+import 'package:reimi_app/data/datasources/like_remote_datasource.dart';
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/entities/like_entity.dart';
+import 'package:reimi_app/domain/value_objects/address.dart';
+import 'package:reimi_app/gen/assets.gen.dart';
+
+class LikeMockDataSource implements LikeRemoteDataSource {
+  const LikeMockDataSource();
+
+  @override
+  Future<List<LikeUserModel>?> getLikeUsersFromUser(String userId) async {
+    return mockLikeUsersFromUser;
+  }
+
+  @override
+  Future<List<LikeUserModel>?> getLikeUsersToUser(String userId) async {
+    return mockLikeUsersToUser;
+  }
+
+  @override
+  Future<bool> isLiked({required String fromUserId, required String toUserId}) {
+    // TODO: implement isLiked
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<LikeEntity> like(
+      {required String fromUserId, required String toUserId}) {
+    // TODO: implement like
+    throw UnimplementedError();
+  }
+}
+
+final List<LikeUserModel> mockLikeUsersFromUser = [
+  // 佐藤 葵 (001) - あなたに「いいね」してくれたユーザー
+  LikeUserModel(
+    userId: 'user_001',
+    birthDate: DateTime(1995, 5, 15),
+    address: Address.tokyo,
+    mainPhotoUrl: Assets.images.sample.user001SampleImage.path,
+    lastLoginAt: DateTime.now().subtract(const Duration(hours: 2)),
+  ),
+  // 高橋 美咲 (004) - あなたに「いいね」してくれたユーザー
+  LikeUserModel(
+    userId: 'user_004',
+    birthDate: DateTime(1988, 7, 12),
+    address: Address.fukuoka,
+    mainPhotoUrl: Assets.images.sample.user004SampleImage.path,
+    lastLoginAt: DateTime.now().subtract(const Duration(hours: 5)),
+  ),
+];
+
+final List<LikeUserModel> mockLikeUsersToUser = [
+  // 田中 健 (002) - あなたが「いいね」を送ったユーザー
+  LikeUserModel(
+    userId: 'user_002',
+    birthDate: DateTime(1978, 11, 3),
+    address: Address.osaka,
+    mainPhotoUrl: Assets.images.sample.user002SampleImage.path,
+    lastLoginAt: DateTime.now().subtract(const Duration(days: 1)),
+  ),
+  // 渡辺 由美子 (006) - ログインが少し前のユーザー
+  LikeUserModel(
+    userId: 'user_006',
+    birthDate: DateTime(1965, 2, 28),
+    address: Address.tokyo,
+    mainPhotoUrl: Assets.images.sample.user006SampleImage.path,
+    lastLoginAt: DateTime.now().subtract(const Duration(days: 10)),
+  ),
+];

--- a/reimi/frontend/reimi_app/lib/data/models/like_user_model.dart
+++ b/reimi/frontend/reimi_app/lib/data/models/like_user_model.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/core/utils/iso_date_time_converter.dart';
+import 'package:reimi_app/domain/value_objects/address.dart';
+part 'like_user_model.freezed.dart';
+part 'like_user_model.g.dart';
+
+@freezed
+abstract class LikeUserModel with _$LikeUserModel {
+  @JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+  const factory LikeUserModel({
+    required String userId,
+    @IsoDateTimeConverter() required DateTime birthDate,
+    required Address address,
+    required String mainPhotoUrl,
+    @IsoDateTimeOrNullConverter() DateTime? lastLoginAt,
+  }) = _LikeUserModel;
+
+  factory LikeUserModel.fromJson(Map<String, dynamic> json) =>
+      _$LikeUserModelFromJson(json);
+}

--- a/reimi/frontend/reimi_app/lib/data/models/like_user_model.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/data/models/like_user_model.freezed.dart
@@ -1,0 +1,425 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'like_user_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$LikeUserModel {
+  String get userId;
+  @IsoDateTimeConverter()
+  DateTime get birthDate;
+  Address get address;
+  String get mainPhotoUrl;
+  @IsoDateTimeOrNullConverter()
+  DateTime? get lastLoginAt;
+
+  /// Create a copy of LikeUserModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $LikeUserModelCopyWith<LikeUserModel> get copyWith =>
+      _$LikeUserModelCopyWithImpl<LikeUserModel>(
+          this as LikeUserModel, _$identity);
+
+  /// Serializes this LikeUserModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is LikeUserModel &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.lastLoginAt, lastLoginAt) ||
+                other.lastLoginAt == lastLoginAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, userId, birthDate, address, mainPhotoUrl, lastLoginAt);
+
+  @override
+  String toString() {
+    return 'LikeUserModel(userId: $userId, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, lastLoginAt: $lastLoginAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $LikeUserModelCopyWith<$Res> {
+  factory $LikeUserModelCopyWith(
+          LikeUserModel value, $Res Function(LikeUserModel) _then) =
+      _$LikeUserModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String userId,
+      @IsoDateTimeConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      @IsoDateTimeOrNullConverter() DateTime? lastLoginAt});
+}
+
+/// @nodoc
+class _$LikeUserModelCopyWithImpl<$Res>
+    implements $LikeUserModelCopyWith<$Res> {
+  _$LikeUserModelCopyWithImpl(this._self, this._then);
+
+  final LikeUserModel _self;
+  final $Res Function(LikeUserModel) _then;
+
+  /// Create a copy of LikeUserModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? userId = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? lastLoginAt = freezed,
+  }) {
+    return _then(_self.copyWith(
+      userId: null == userId
+          ? _self.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      lastLoginAt: freezed == lastLoginAt
+          ? _self.lastLoginAt
+          : lastLoginAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [LikeUserModel].
+extension LikeUserModelPatterns on LikeUserModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_LikeUserModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_LikeUserModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_LikeUserModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String userId,
+            @IsoDateTimeConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            @IsoDateTimeOrNullConverter() DateTime? lastLoginAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserModel() when $default != null:
+        return $default(_that.userId, _that.birthDate, _that.address,
+            _that.mainPhotoUrl, _that.lastLoginAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String userId,
+            @IsoDateTimeConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            @IsoDateTimeOrNullConverter() DateTime? lastLoginAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserModel():
+        return $default(_that.userId, _that.birthDate, _that.address,
+            _that.mainPhotoUrl, _that.lastLoginAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String userId,
+            @IsoDateTimeConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            @IsoDateTimeOrNullConverter() DateTime? lastLoginAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserModel() when $default != null:
+        return $default(_that.userId, _that.birthDate, _that.address,
+            _that.mainPhotoUrl, _that.lastLoginAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(fieldRename: FieldRename.snake, explicitToJson: true)
+class _LikeUserModel implements LikeUserModel {
+  const _LikeUserModel(
+      {required this.userId,
+      @IsoDateTimeConverter() required this.birthDate,
+      required this.address,
+      required this.mainPhotoUrl,
+      @IsoDateTimeOrNullConverter() this.lastLoginAt});
+  factory _LikeUserModel.fromJson(Map<String, dynamic> json) =>
+      _$LikeUserModelFromJson(json);
+
+  @override
+  final String userId;
+  @override
+  @IsoDateTimeConverter()
+  final DateTime birthDate;
+  @override
+  final Address address;
+  @override
+  final String mainPhotoUrl;
+  @override
+  @IsoDateTimeOrNullConverter()
+  final DateTime? lastLoginAt;
+
+  /// Create a copy of LikeUserModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$LikeUserModelCopyWith<_LikeUserModel> get copyWith =>
+      __$LikeUserModelCopyWithImpl<_LikeUserModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$LikeUserModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LikeUserModel &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.lastLoginAt, lastLoginAt) ||
+                other.lastLoginAt == lastLoginAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, userId, birthDate, address, mainPhotoUrl, lastLoginAt);
+
+  @override
+  String toString() {
+    return 'LikeUserModel(userId: $userId, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, lastLoginAt: $lastLoginAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$LikeUserModelCopyWith<$Res>
+    implements $LikeUserModelCopyWith<$Res> {
+  factory _$LikeUserModelCopyWith(
+          _LikeUserModel value, $Res Function(_LikeUserModel) _then) =
+      __$LikeUserModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String userId,
+      @IsoDateTimeConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      @IsoDateTimeOrNullConverter() DateTime? lastLoginAt});
+}
+
+/// @nodoc
+class __$LikeUserModelCopyWithImpl<$Res>
+    implements _$LikeUserModelCopyWith<$Res> {
+  __$LikeUserModelCopyWithImpl(this._self, this._then);
+
+  final _LikeUserModel _self;
+  final $Res Function(_LikeUserModel) _then;
+
+  /// Create a copy of LikeUserModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? userId = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? lastLoginAt = freezed,
+  }) {
+    return _then(_LikeUserModel(
+      userId: null == userId
+          ? _self.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      lastLoginAt: freezed == lastLoginAt
+          ? _self.lastLoginAt
+          : lastLoginAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/data/models/like_user_model.g.dart
+++ b/reimi/frontend/reimi_app/lib/data/models/like_user_model.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'like_user_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_LikeUserModel _$LikeUserModelFromJson(Map<String, dynamic> json) =>
+    _LikeUserModel(
+      userId: json['user_id'] as String,
+      birthDate:
+          const IsoDateTimeConverter().fromJson(json['birth_date'] as String),
+      address: $enumDecode(_$AddressEnumMap, json['address']),
+      mainPhotoUrl: json['main_photo_url'] as String,
+      lastLoginAt: const IsoDateTimeOrNullConverter()
+          .fromJson(json['last_login_at'] as String?),
+    );
+
+Map<String, dynamic> _$LikeUserModelToJson(_LikeUserModel instance) =>
+    <String, dynamic>{
+      'user_id': instance.userId,
+      'birth_date': const IsoDateTimeConverter().toJson(instance.birthDate),
+      'address': _$AddressEnumMap[instance.address]!,
+      'main_photo_url': instance.mainPhotoUrl,
+      'last_login_at':
+          const IsoDateTimeOrNullConverter().toJson(instance.lastLoginAt),
+    };
+
+const _$AddressEnumMap = {
+  Address.hokkaido: 'HOKKAIDO',
+  Address.aomori: 'AOMORI',
+  Address.iwate: 'IWATE',
+  Address.miyagi: 'MIYAGI',
+  Address.akita: 'AKITA',
+  Address.yamagata: 'YAMAGATA',
+  Address.fukushima: 'FUKUSHIMA',
+  Address.ibaraki: 'IBARAKI',
+  Address.tochigi: 'TOCHIGI',
+  Address.gunma: 'GUNMA',
+  Address.saitama: 'SAITAMA',
+  Address.chiba: 'CHIBA',
+  Address.tokyo: 'TOKYO',
+  Address.kanagawa: 'KANAGAWA',
+  Address.niigata: 'NIIGATA',
+  Address.toyama: 'TOYAMA',
+  Address.ishikawa: 'ISHIKAWA',
+  Address.fukui: 'FUKUI',
+  Address.yamanashi: 'YAMANASHI',
+  Address.nagano: 'NAGANO',
+  Address.gifu: 'GIFU',
+  Address.shizuoka: 'SHIZUOKA',
+  Address.aichi: 'AICHI',
+  Address.mie: 'MIE',
+  Address.shiga: 'SHIGA',
+  Address.kyoto: 'KYOTO',
+  Address.osaka: 'OSAKA',
+  Address.hyogo: 'HYOGO',
+  Address.nara: 'NARA',
+  Address.wakayama: 'WAKAYAMA',
+  Address.tottori: 'TOTTORI',
+  Address.shimane: 'SHIMANE',
+  Address.okayama: 'OKAYAMA',
+  Address.hiroshima: 'HIROSHIMA',
+  Address.yamaguchi: 'YAMAGUCHI',
+  Address.tokushima: 'TOKUSHIMA',
+  Address.kagawa: 'KAGAWA',
+  Address.ehime: 'EHIME',
+  Address.kochi: 'KOCHI',
+  Address.fukuoka: 'FUKUOKA',
+  Address.saga: 'SAGA',
+  Address.nagasaki: 'NAGASAKI',
+  Address.kumamoto: 'KUMAMOTO',
+  Address.oita: 'OITA',
+  Address.miyazaki: 'MIYAZAKI',
+  Address.kagoshima: 'KAGOSHIMA',
+  Address.okinawa: 'OKINAWA',
+  Address.other: 'OTHER',
+};

--- a/reimi/frontend/reimi_app/lib/data/repositories/like_repository_impl.dart
+++ b/reimi/frontend/reimi_app/lib/data/repositories/like_repository_impl.dart
@@ -1,0 +1,37 @@
+import 'package:reimi_app/data/datasources/like_remote_datasource.dart';
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/entities/like_entity.dart';
+import 'package:reimi_app/domain/repositories/like_repository.dart';
+
+class LikeRepositoryImpl implements LikeRepository {
+  const LikeRepositoryImpl(this._remote);
+  final LikeRemoteDataSource _remote;
+
+  @override
+  Future<List<LikeUserModel>?> getLikeUsersFromUser(String userId) {
+    return _remote.getLikeUsersFromUser(userId);
+  }
+
+  @override
+  Future<List<LikeUserModel>?> getLikeUsersToUser(String userId) {
+    return _remote.getLikeUsersToUser(userId);
+  }
+
+  @override
+  Future<bool> isLiked({
+    required String fromUserId,
+    required String toUserId,
+  }) {
+    // TODO: implement like
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<LikeEntity> like({
+    required String fromUserId,
+    required String toUserId,
+  }) {
+    // TODO: implement like
+    throw UnimplementedError();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/domain/repositories/like_repository.dart
+++ b/reimi/frontend/reimi_app/lib/domain/repositories/like_repository.dart
@@ -1,0 +1,15 @@
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/entities/like_entity.dart';
+
+abstract class LikeRepository {
+  Future<bool> isLiked({
+    required String fromUserId,
+    required String toUserId,
+  });
+  Future<LikeEntity> like({
+    required String fromUserId,
+    required String toUserId,
+  });
+  Future<List<LikeUserModel>?> getLikeUsersFromUser(String userId);
+  Future<List<LikeUserModel>?> getLikeUsersToUser(String userId);
+}

--- a/reimi/frontend/reimi_app/lib/domain/usecases/get_like_users_from_user_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/domain/usecases/get_like_users_from_user_usecase.dart
@@ -1,0 +1,15 @@
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/repositories/like_repository.dart';
+
+class GetLikeUsersFromUserUseCase {
+  const GetLikeUsersFromUserUseCase(this._repository);
+  final LikeRepository _repository;
+
+  Future<List<LikeUserModel>?> call(String userId) async {
+    final likeUsers = await _repository.getLikeUsersFromUser(userId);
+    if (likeUsers == null) {
+      return null;
+    }
+    return likeUsers;
+  }
+}

--- a/reimi/frontend/reimi_app/lib/domain/usecases/get_like_users_to_user_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/domain/usecases/get_like_users_to_user_usecase.dart
@@ -1,0 +1,15 @@
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/repositories/like_repository.dart';
+
+class GetLikeUsersToUserUseCase {
+  const GetLikeUsersToUserUseCase(this._repository);
+  final LikeRepository _repository;
+
+  Future<List<LikeUserModel>?> call(String userId) async {
+    final likeUsers = await _repository.getLikeUsersToUser(userId);
+    if (likeUsers == null) {
+      return null;
+    }
+    return likeUsers;
+  }
+}

--- a/reimi/frontend/reimi_app/lib/domain/value_objects/like_segment.dart
+++ b/reimi/frontend/reimi_app/lib/domain/value_objects/like_segment.dart
@@ -1,0 +1,4 @@
+enum LikeSegment {
+  fromUser,
+  toUser,
+}

--- a/reimi/frontend/reimi_app/lib/i18n/en.i18n.json
+++ b/reimi/frontend/reimi_app/lib/i18n/en.i18n.json
@@ -81,6 +81,12 @@
       }
     }
   },
+  "likePage": {
+    "segment": {
+      "fromUser": "FromUser",
+      "toUser": "ToUser"
+    }
+  },
   "profileDetailPage": {
     "title": "Profile Details"
   },

--- a/reimi/frontend/reimi_app/lib/i18n/ja.i18n.json
+++ b/reimi/frontend/reimi_app/lib/i18n/ja.i18n.json
@@ -81,6 +81,12 @@
       }
     }
   },
+  "likePage": {
+    "segment": {
+      "fromUser": "相手から",
+      "toUser": "自分から"
+    }
+  },
   "profileDetailPage": {
     "title": "プロフィール詳細"
   },

--- a/reimi/frontend/reimi_app/lib/i18n/strings.g.dart
+++ b/reimi/frontend/reimi_app/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 756 (378 per locale)
+/// Strings: 760 (380 per locale)
 ///
-/// Built on 2025-12-21 at 16:37 UTC
+/// Built on 2025-12-22 at 15:03 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/reimi/frontend/reimi_app/lib/i18n/strings_en.g.dart
+++ b/reimi/frontend/reimi_app/lib/i18n/strings_en.g.dart
@@ -45,6 +45,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsSignInPageEn signInPage = TranslationsSignInPageEn._(_root);
 	late final TranslationsErrorPageEn errorPage = TranslationsErrorPageEn._(_root);
 	late final TranslationsUserRegistrationPageEn userRegistrationPage = TranslationsUserRegistrationPageEn._(_root);
+	late final TranslationsLikePageEn likePage = TranslationsLikePageEn._(_root);
 	late final TranslationsProfileDetailPageEn profileDetailPage = TranslationsProfileDetailPageEn._(_root);
 	late final TranslationsProfilePageEn profilePage = TranslationsProfilePageEn._(_root);
 	late final TranslationsSettingPageEn settingPage = TranslationsSettingPageEn._(_root);
@@ -144,6 +145,16 @@ class TranslationsUserRegistrationPageEn {
 	late final TranslationsUserRegistrationPageNameEn name = TranslationsUserRegistrationPageNameEn._(_root);
 	late final TranslationsUserRegistrationPageIntroductionEn introduction = TranslationsUserRegistrationPageIntroductionEn._(_root);
 	late final TranslationsUserRegistrationPageMainPhotoEn mainPhoto = TranslationsUserRegistrationPageMainPhotoEn._(_root);
+}
+
+// Path: likePage
+class TranslationsLikePageEn {
+	TranslationsLikePageEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsLikePageSegmentEn segment = TranslationsLikePageSegmentEn._(_root);
 }
 
 // Path: profileDetailPage
@@ -459,6 +470,21 @@ class TranslationsUserRegistrationPageMainPhotoEn {
 	String get question => 'Select your main photo';
 
 	late final TranslationsUserRegistrationPageMainPhotoItemsEn items = TranslationsUserRegistrationPageMainPhotoItemsEn._(_root);
+}
+
+// Path: likePage.segment
+class TranslationsLikePageSegmentEn {
+	TranslationsLikePageSegmentEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'FromUser'
+	String get fromUser => 'FromUser';
+
+	/// en: 'ToUser'
+	String get toUser => 'ToUser';
 }
 
 // Path: profilePage.section
@@ -1997,6 +2023,8 @@ extension on Translations {
 			'userRegistrationPage.mainPhoto.question' => 'Select your main photo',
 			'userRegistrationPage.mainPhoto.items.photoSelectInstructionText' => 'Click to select photo',
 			'userRegistrationPage.mainPhoto.items.photoRecommendationHint' => 'A smiling face photo is recommended',
+			'likePage.segment.fromUser' => 'FromUser',
+			'likePage.segment.toUser' => 'ToUser',
 			'profileDetailPage.title' => 'Profile Details',
 			'profilePage.title' => 'Edit Profile',
 			'profilePage.section.mainPhoto' => 'Main Photo',

--- a/reimi/frontend/reimi_app/lib/i18n/strings_ja.g.dart
+++ b/reimi/frontend/reimi_app/lib/i18n/strings_ja.g.dart
@@ -42,6 +42,7 @@ class TranslationsJa with BaseTranslations<AppLocale, Translations> implements T
 	@override late final _TranslationsSignInPageJa signInPage = _TranslationsSignInPageJa._(_root);
 	@override late final _TranslationsErrorPageJa errorPage = _TranslationsErrorPageJa._(_root);
 	@override late final _TranslationsUserRegistrationPageJa userRegistrationPage = _TranslationsUserRegistrationPageJa._(_root);
+	@override late final _TranslationsLikePageJa likePage = _TranslationsLikePageJa._(_root);
 	@override late final _TranslationsProfileDetailPageJa profileDetailPage = _TranslationsProfileDetailPageJa._(_root);
 	@override late final _TranslationsProfilePageJa profilePage = _TranslationsProfilePageJa._(_root);
 	@override late final _TranslationsSettingPageJa settingPage = _TranslationsSettingPageJa._(_root);
@@ -117,6 +118,16 @@ class _TranslationsUserRegistrationPageJa implements TranslationsUserRegistratio
 	@override late final _TranslationsUserRegistrationPageNameJa name = _TranslationsUserRegistrationPageNameJa._(_root);
 	@override late final _TranslationsUserRegistrationPageIntroductionJa introduction = _TranslationsUserRegistrationPageIntroductionJa._(_root);
 	@override late final _TranslationsUserRegistrationPageMainPhotoJa mainPhoto = _TranslationsUserRegistrationPageMainPhotoJa._(_root);
+}
+
+// Path: likePage
+class _TranslationsLikePageJa implements TranslationsLikePageEn {
+	_TranslationsLikePageJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsLikePageSegmentJa segment = _TranslationsLikePageSegmentJa._(_root);
 }
 
 // Path: profileDetailPage
@@ -359,6 +370,17 @@ class _TranslationsUserRegistrationPageMainPhotoJa implements TranslationsUserRe
 	// Translations
 	@override String get question => 'メイン写真を選んでください';
 	@override late final _TranslationsUserRegistrationPageMainPhotoItemsJa items = _TranslationsUserRegistrationPageMainPhotoItemsJa._(_root);
+}
+
+// Path: likePage.segment
+class _TranslationsLikePageSegmentJa implements TranslationsLikePageSegmentEn {
+	_TranslationsLikePageSegmentJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get fromUser => '相手から';
+	@override String get toUser => '自分から';
 }
 
 // Path: profilePage.section
@@ -1225,6 +1247,8 @@ extension on TranslationsJa {
 			'userRegistrationPage.mainPhoto.question' => 'メイン写真を選んでください',
 			'userRegistrationPage.mainPhoto.items.photoSelectInstructionText' => 'クリックして写真を選択',
 			'userRegistrationPage.mainPhoto.items.photoRecommendationHint' => '笑顔の顔写真がおすすめ',
+			'likePage.segment.fromUser' => '相手から',
+			'likePage.segment.toUser' => '自分から',
 			'profileDetailPage.title' => 'プロフィール詳細',
 			'profilePage.title' => 'プロフィール編集',
 			'profilePage.section.mainPhoto' => 'メイン写真',

--- a/reimi/frontend/reimi_app/lib/presentation/app/router/auth_gate.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/app/router/auth_gate.dart
@@ -28,11 +28,11 @@ class AuthGate extends ConsumerWidget {
         userAsync.when(
           data: (userData) {
             if (userData == null) {
+              // ユーザー情報がDBに保存されていないので、新規ユーザー扱いになりユーザー初期登録画面に遷移する
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 context.go(UserGenderPage.routeLocation);
               });
             } else {
-              // ユーザー情報がDBに保存されていないので、新規ユーザー扱いになりユーザー初期登録画面に遷移する
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 context.go(HomePage.routeLocation);
               });

--- a/reimi/frontend/reimi_app/lib/presentation/features/home/widgets/user_card.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/home/widgets/user_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:reimi_app/core/extensions/datetime_extensions.dart';
 import 'package:reimi_app/core/extensions/image_path_extension.dart';
 import 'package:reimi_app/core/extensions/value_objects/address_extension.dart';
 import 'package:reimi_app/data/models/home_user_model.dart';
@@ -117,7 +118,7 @@ class UserCard extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  ' (${DateTime.now().year - user.birthDate.year})',
+                  ' ${user.birthDate.toAge}',
                   style: theme.textTheme.bodySmall,
                 ),
                 if (true)

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/like_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/like_page.dart
@@ -1,23 +1,62 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:reimi_app/presentation/features/like/notifiers/like_users_notifier.dart';
+import 'package:reimi_app/presentation/features/like/widgets/like_segment_switch.dart';
+import 'package:reimi_app/presentation/features/like/widgets/small_user_card.dart';
+import 'package:reimi_app/presentation/features/profile/pages/profile_detail_page.dart';
 import 'package:reimi_app/presentation/shared/widgets/background_container.dart';
 
-class LikePage extends StatelessWidget {
+class LikePage extends ConsumerWidget {
   const LikePage({super.key});
   static String get routeName => 'like';
   static String get routeLocation => '/$routeName';
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usersAsync = ref.watch(likeUsersNotifierProvider);
     return Scaffold(
       body: BackgroundContainer(
         child: SafeArea(
-          child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 18),
             child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Text(
-                  'いいね画面',
-                  style: Theme.of(context).textTheme.headlineMedium,
+              children: [
+                const SizedBox(height: 16),
+                const LikeSegmentSwitch(),
+                const SizedBox(height: 16),
+                usersAsync.when(
+                  data: (users) {
+                    if (users == null) {
+                      return const Text('現在、表示できるユーザーがいません。');
+                    } else if (users.isEmpty) {
+                      return const Text('新しい出会いをみつけましょう！');
+                    }
+                    return Expanded(
+                      child: GridView.count(
+                        crossAxisCount: 2,
+                        mainAxisSpacing: 16,
+                        crossAxisSpacing: 16,
+                        childAspectRatio: 0.85,
+                        children: [
+                          ...users.map((user) {
+                            return SmallUserCard(
+                              user: user,
+                              onTap: () {
+                                context.push(
+                                  ProfileDetailPage.routeLocation,
+                                  extra: {'userId': user.userId},
+                                );
+                              },
+                            );
+                          }),
+                        ],
+                      ),
+                    );
+                  },
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (e, _) => Center(child: Text('Error: $e')),
                 ),
               ],
             ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_segment_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_segment_notifier.dart
@@ -1,0 +1,16 @@
+import 'package:reimi_app/domain/value_objects/like_segment.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'like_segment_notifier.g.dart';
+
+@riverpod
+class LikeSegmentNotifier extends _$LikeSegmentNotifier {
+  @override
+  LikeSegment build() {
+    return LikeSegment.fromUser;
+  }
+
+  void select(LikeSegment segment) {
+    state = segment;
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_segment_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_segment_notifier.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'like_segment_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$likeSegmentNotifierHash() =>
+    r'a3008a357ae303ff480221c63db5dccfee6431da';
+
+/// See also [LikeSegmentNotifier].
+@ProviderFor(LikeSegmentNotifier)
+final likeSegmentNotifierProvider =
+    AutoDisposeNotifierProvider<LikeSegmentNotifier, LikeSegment>.internal(
+  LikeSegmentNotifier.new,
+  name: r'likeSegmentNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$likeSegmentNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$LikeSegmentNotifier = AutoDisposeNotifier<LikeSegment>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_users_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_users_notifier.dart
@@ -1,0 +1,51 @@
+import 'package:reimi_app/core/di/domain_providers.dart';
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/domain/value_objects/like_segment.dart';
+import 'package:reimi_app/presentation/app/auth/notifiers/current_user_notifier.dart';
+import 'package:reimi_app/presentation/features/like/notifiers/like_segment_notifier.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'like_users_notifier.g.dart';
+
+@riverpod
+class LikeUsersNotifier extends _$LikeUsersNotifier {
+  @override
+  Future<List<LikeUserModel>?> build() async {
+    final segment = ref.watch(likeSegmentNotifierProvider);
+    final userId = ref.watch(currentUserNotifierProvider).value?.id;
+    if (userId == null) {
+      return null;
+    }
+    final users = await fetchLikeUsers(segment: segment, userId: userId);
+    if (users == null) {
+      return null;
+    }
+    return users;
+  }
+
+  Future<List<LikeUserModel>?> fetchLikeUsers({
+    required LikeSegment segment,
+    required String userId,
+  }) async {
+    switch (segment) {
+      case LikeSegment.fromUser:
+        final users =
+            await ref.read(getLikeUsersFromUserUseCaseProvider).call(userId);
+        return users;
+      case LikeSegment.toUser:
+        final users =
+            await ref.read(getLikeUsersToUserUseCaseProvider).call(userId);
+        return users;
+    }
+  }
+
+  Future<void> refresh({
+    required LikeSegment segment,
+    required String userId,
+  }) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(
+      () => fetchLikeUsers(segment: segment, userId: userId),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_users_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_users_notifier.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'like_users_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$likeUsersNotifierHash() => r'fc6b1f7e4cb3e0c8963cd95d878fb75994891af3';
+
+/// See also [LikeUsersNotifier].
+@ProviderFor(LikeUsersNotifier)
+final likeUsersNotifierProvider = AutoDisposeAsyncNotifierProvider<
+    LikeUsersNotifier, List<LikeUserModel>?>.internal(
+  LikeUsersNotifier.new,
+  name: r'likeUsersNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$likeUsersNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$LikeUsersNotifier = AutoDisposeAsyncNotifier<List<LikeUserModel>?>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/like_segment_switch.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/like_segment_switch.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:reimi_app/domain/value_objects/like_segment.dart';
+import 'package:reimi_app/i18n/strings.g.dart';
+import 'package:reimi_app/presentation/features/like/notifiers/like_segment_notifier.dart';
+
+class LikeSegmentSwitch extends HookConsumerWidget {
+  const LikeSegmentSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final segment = ref.watch(likeSegmentNotifierProvider);
+    final notifier = ref.read(likeSegmentNotifierProvider.notifier);
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: const Color(0xFFD7EFF6),
+        borderRadius: BorderRadius.circular(32),
+      ),
+      child: Row(
+        children: [
+          buildItem(
+            label: t.likePage.segment.fromUser,
+            isSelected: segment == LikeSegment.fromUser,
+            onTap: () => notifier.select(LikeSegment.fromUser),
+            theme: theme,
+          ),
+          buildItem(
+            label: t.likePage.segment.toUser,
+            isSelected: segment == LikeSegment.toUser,
+            onTap: () => notifier.select(LikeSegment.toUser),
+            theme: theme,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildItem({
+    required String label,
+    required bool isSelected,
+    required VoidCallback onTap,
+    required ThemeData theme,
+  }) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 300),
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          decoration: BoxDecoration(
+            color: isSelected ? theme.colorScheme.primary : Colors.transparent,
+            borderRadius: BorderRadius.circular(28),
+          ),
+          child: Center(
+            child: Text(
+              label,
+              style: theme.textTheme.labelLarge!.copyWith(
+                fontSize: 13,
+                color: isSelected ? Colors.white : Colors.black54,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/small_user_card.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/small_user_card.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:reimi_app/core/extensions/datetime_extensions.dart';
+import 'package:reimi_app/core/extensions/image_path_extension.dart';
+import 'package:reimi_app/core/extensions/value_objects/address_extension.dart';
+import 'package:reimi_app/data/models/like_user_model.dart';
+import 'package:reimi_app/gen/assets.gen.dart';
+import 'package:reimi_app/presentation/features/home/widgets/circle_badge.dart';
+
+class SmallUserCard extends StatelessWidget {
+  const SmallUserCard({
+    super.key,
+    required this.user,
+    required this.onTap,
+  });
+
+  final LikeUserModel user;
+  final void Function()? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          color: const Color(0xFFDDF5FB),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.9),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Stack(
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: AspectRatio(
+                        aspectRatio: 1,
+                        child: Image(
+                          image: user.mainPhotoUrl.toImageProvider(),
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      top: 5,
+                      right: 5,
+                      child: CircleBadge(
+                        color: Colors.white.withValues(alpha: 0.8),
+                        size: 48,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: Colors.white,
+                              width: 1,
+                            ),
+                          ),
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(30),
+                            child: Image(
+                              image: Assets.images.weatherPersonality
+                                  .nfieSoftOctopusImage.path
+                                  .toImageProvider(),
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      bottom: 7,
+                      right: 7,
+                      child: CircleBadge(
+                        color: theme.colorScheme.secondary,
+                        size: 40,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              '99',
+                              style: theme.textTheme.labelSmall!.copyWith(
+                                fontSize: 13,
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            Text(
+                              '%',
+                              style: theme.textTheme.labelSmall!.copyWith(
+                                fontSize: 10,
+                                color: Colors.white,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Text(
+                  user.address.displayName(context),
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    color: Colors.black87,
+                  ),
+                ),
+                Text(
+                  ' ${user.birthDate.toAge}',
+                  style: theme.textTheme.bodySmall,
+                ),
+                if (true)
+                  const Padding(
+                    padding: EdgeInsets.only(left: 4),
+                    child:
+                        Icon(Icons.check_circle, color: Colors.green, size: 16),
+                  ),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_detail_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:reimi_app/core/extensions/datetime_extensions.dart';
 import 'package:reimi_app/core/extensions/image_path_extension.dart';
 import 'package:reimi_app/core/extensions/value_objects/address_extension.dart';
 import 'package:reimi_app/core/extensions/value_objects/alcohol_extension.dart';
@@ -107,7 +108,7 @@ class ProfileDetailPage extends HookConsumerWidget {
                               ),
                               const SizedBox(width: 4),
                               Text(
-                                '(${DateTime.now().year - data.birthDate.year})',
+                                ' ${data.birthDate.toAge}',
                                 style: theme.textTheme.bodyMedium,
                               ),
                               const SizedBox(width: 8),


### PR DESCRIPTION
## 対応Issue

- #53 

close #53 

## 対応したこと

<!-- このプルリクで何をしたのか記述する -->
- Domain層
  - like関連のdomain層のプロバイダ生成
  - likeリポジトリの抽象クラスを実装
  - 自分がいいねされたユーザー一覧を取得するユースケース作成
  - 自分がいいねしたユーザー一覧を取得するユースケース作成
- Data層
  -  like関連のdata層のプロバイダ生成
  - いいね画面で表示するユーザー一覧のモックデータを作成し、いいねユーザー一覧取得を仮実装
  - いいね画面で表示するユーザーモデル作成
  - likeリポジトリのいいねユーザー一覧取得の処理を仮実装
- Presentation層
  - いいね画面のUI作成
  - いいね画面で使用するユーザーカードウィジェット作成
  - いいね画面でセグメント切り替えするウィジェット作成
  - いいね画面のセグメントの状態管理するプロバイダー作成
  - いいね画面で表示するユーザー一覧を管理するプロバイダ作成

## 参考資料
<!-- 参考にした資料のリンクを貼る -->

## 対応しきれなかったこと

<!-- 修正が必要そうな部分や別チケットで解決したい部分をあげる -->
- いいね画面のロジック
  - #54 

## 画面キャプチャ

<!-- 実装前と実装後でどう変わったかわかるキャプチャを貼る -->

| 相手から | 自分から |
| -- | -- |
| <img width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-12-22 at 23 35 07" src="https://github.com/user-attachments/assets/f7a73b2a-6d3b-49d9-b8e8-40eb9105655d" /> | <img width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-12-22 at 23 35 10" src="https://github.com/user-attachments/assets/348ede72-489f-4c78-999a-e0c9c19c083e" /> |