### PR TITLE
【API設計】ユーザー一覧取得APIの設計（/users）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/UserUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/UserUseCase.java
@@ -1,7 +1,13 @@
 package com.reimi.reimi_app.application.usecase;
 
+import java.util.List;
+
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
+import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserUseCase {
+
+    List<User> getUsers();
+
     void registerUser(RegisterUserCommand command);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/profile/Profile.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/profile/Profile.java
@@ -15,8 +15,24 @@ public class Profile {
         this.userId = userId;
         this.introduction = introduction;
     }
-    public static Profile create(UserId userId, String introduction) {
-        return new Profile(userId, introduction);
+    public static Profile create(
+        UserId userId,
+        String introduction
+    ) {
+        return new Profile(
+            userId,
+            introduction
+        );
+    }
+
+    public static Profile reconstruct(
+        UserId userId,
+        String introduction
+    ) {
+        return new Profile(
+                userId,
+                introduction
+        );
     }
 
     public UserId getUserId() { return userId; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
@@ -67,6 +67,33 @@ public class User {
         );
     }
 
+    public static User reconstruct(
+        UserId id,
+        String firebaseUid,
+        String name,
+        Gender gender,
+        LocalDate birthDate,
+        Address address,
+        String mainPhotoUrl,
+        String email,
+        Status status,
+        Profile profile
+    ) {
+        return new User(
+                id,
+                firebaseUid,
+                name,
+                gender,
+                birthDate,
+                address,
+                mainPhotoUrl,
+                email,
+                status,
+                profile
+        );
+    }
+
+
     public UserId getId() { return id; }
     public String getFirebaseUid() { return firebaseUid; }
     public String getName() { return name; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -1,8 +1,12 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.List;
+
 import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserRepository {
+
+    List<User> findAll();
 
     boolean existsByEmail(String email);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ProfileMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ProfileMapper.java
@@ -1,10 +1,18 @@
 package com.reimi.reimi_app.infrastructure.persistence.mapper;
 
 import com.reimi.reimi_app.domain.model.profile.Profile;
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.persistence.entity.ProfileEntity;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 
 public class ProfileMapper {
+
+    public static Profile toDomain(ProfileEntity entity) {
+        return Profile.reconstruct(
+                new UserId(entity.getUserId()),
+                entity.getIntroduction()
+        );
+    }
     public static ProfileEntity toEntity(Profile profile, UserEntity userEntity) {
         ProfileEntity entity = new ProfileEntity();
         entity.setUser(userEntity);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserMapper.java
@@ -1,9 +1,25 @@
 package com.reimi.reimi_app.infrastructure.persistence.mapper;
 
 import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 
 public class UserMapper {
+
+    public static User toDomain(UserEntity entity) {
+        return User.reconstruct(
+                new UserId(entity.getId()),
+                entity.getFirebaseUid(),
+                entity.getName(),
+                entity.getGender(),
+                entity.getBirthDate(),
+                entity.getAddress(),
+                entity.getMainPhotoUrl(),
+                entity.getEmail(),
+                entity.getStatus(),
+                ProfileMapper.toDomain(entity.getProfile())
+        );
+    }
 
     public static UserEntity toEntity(User user) {
         UserEntity entity = new UserEntity();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.user;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.domain.model.user.User;
@@ -15,6 +17,13 @@ public class UserRepositoryImpl implements UserRepository {
         this.jpaUserRepository = jpaUserRepository;
     }
 
+    @Override
+    public List<User> findAll() {
+        return jpaUserRepository.findAll()
+            .stream()
+            .map(UserMapper::toDomain)
+            .toList();
+    }
     @Override
     public boolean existsByEmail(String email) {
         return jpaUserRepository.existsByEmail(email);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -6,6 +6,7 @@ import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.repository.UserRepository;
 
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,11 @@ public class UserUseCaseImpl implements UserUseCase {
 
     public UserUseCaseImpl(UserRepository userRepository) {
         this.userRepository = userRepository;
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsers() {
+        return userRepository.findAll();
     }
     @Override
     @Transactional

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -31,6 +31,13 @@ public class UserController {
         this.userUseCase = userUseCase;
     }
 
+    @Operation(
+        summary = "ユーザー一覧取得",
+        description = "登録されているユーザーの一覧を取得できるAPI"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "ユーザーの一覧を取得しました"),
+    })
     @GetMapping
     public ResponseEntity<List<GetUserListResponse>> getUsers() {
         List<GetUserListResponse> response = userUseCase.getUsers()

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -1,7 +1,10 @@
 package com.reimi.reimi_app.infrastructure.web.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +15,7 @@ import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.Address;
 import com.reimi.reimi_app.domain.model.user.Gender;
 import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterUserRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,6 +29,24 @@ public class UserController {
 
     public UserController(UserUseCase userUseCase) {
         this.userUseCase = userUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GetUserListResponse>> getUsers() {
+        List<GetUserListResponse> response = userUseCase.getUsers()
+                .stream()
+                .map(user -> new GetUserListResponse(
+                    user.getId().value(),
+                    user.getFirebaseUid(),
+                    user.getName(),
+                    user.getBirthDate(),
+                    user.getAddress().getLabel(),
+                    user.getMainPhotoUrl(),
+                    user.getProfile().getIntroduction()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(response);
     }
 
     @Operation(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetUserListResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetUserListResponse.java
@@ -1,0 +1,14 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record GetUserListResponse (
+        UUID id,
+        String firebaseUid,
+        String name,
+        LocalDate birthDate,
+        String address,
+        String mainPhotoUrl,
+        String introduction
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetUserListResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetUserListResponse.java
@@ -3,12 +3,28 @@ package com.reimi.reimi_app.infrastructure.web.dto.response;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "ユーザー一覧取得用レスポンス")
 public record GetUserListResponse (
+
+        @Schema(description = "ユーザーID", type = "string", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
         UUID id,
+        @Schema(description = "Firebase AuthenticationのUID", type = "string", example = "f7KQ9sLm2A8P0xVZrEwN3HjU1BcD")
         String firebaseUid,
+
+        @Schema(description = "名前", type = "string", example = "山田 太郎")
         String name,
+
+        @Schema(description = "生年月日", type = "LocalDate", example = "1996-04-18")
         LocalDate birthDate,
+
+        @Schema(description = "居住地", type = "string", example = "東京都")
         String address,
+
+        @Schema(description = "メイン写真の保存URL", type = "string", example = "images/users/main_12345.jpg")
         String mainPhotoUrl,
+
+        @Schema(description = "自己紹介文", type = "string", example = "都内でエンジニアをしています。休日はカフェ巡りやランニングを楽しんでいます。")
         String introduction
 ) {}


### PR DESCRIPTION
## 概要

API名：ユーザー一覧取得

種別：API開発

関連Issue：

- #60 

close #60 

## API設計

### 【やったこと・開発メモ】

- ドメイン層
  - リポジトリのインターフェイスにユーザー一覧取得の操作を追加
  - ドメインモデルにDBから取得してきたエンティティをドメインモデルに復元するメソッドを追加する
    - User
    - Profile
- アプリケーション層
  - ユースケースのインターフェイスにユーザー一覧取得の業務操作を追加
- インフラストラクチャ層
  - ユースケースの実装部分にユーザー一覧取得操作を追加
  - ユーザー一覧取得レスポンス用のDTOを作成
  - リポジトリの実装
  - UserとProfileのMapperでエンティティからドメインモデルに変換するメソッドを定義

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ユーザー一覧取得 |
| URL | /users |
| HTTPメソッド | GET |
| ステータスコード | 200 |

### 【リクエスト】
特になし

### 【レスポンス】

```json
  {
        "id": string uuid
        "firebaseUid": string
        "name": string
        "birthDate": string date
        "address": string
        "mainPhotoUrl": string
        "introduction": string
  }
```

### 【追加・変更した設定ファイル】
 - GetUserListResponse.java

## その他・補足事項

- 必要なレスポンス内容な追々変更していく想定で考えている
- 最終ログイン日時に関してはログイン機能を作成してから追加する予定
