### PR TITLE
既存のAPIで認証済みユーザー情報を取得できる様にする

### DIFF
--- a/reimi/backend/reimi_app/.gitignore
+++ b/reimi/backend/reimi_app/.gitignore
@@ -7,6 +7,8 @@ src/main/resources/flyway.properties
 !**/src/main/**/target/
 !**/src/test/**/target/
 
+src/main/resources/private-key.json
+
 ### STS ###
 .apt_generated
 .classpath

--- a/reimi/backend/reimi_app/pom.xml
+++ b/reimi/backend/reimi_app/pom.xml
@@ -78,6 +78,12 @@
 			<version>2.8.14</version>
 		</dependency>
 
+		<dependency>
+			<groupId>com.google.firebase</groupId>
+			<artifactId>firebase-admin</artifactId>
+			<version>9.2.0</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/reimi/backend/reimi_app/pom.xml
+++ b/reimi/backend/reimi_app/pom.xml
@@ -84,6 +84,11 @@
 			<version>9.2.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
@@ -3,24 +3,6 @@ package com.reimi.reimi_app;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.servers.Server;
-
-@OpenAPIDefinition(
-	info = @Info(
-		title = "Reimi",
-		version = "1.0",
-		description = "天気で繋がる、出会いのアプリ"
-	),
-	servers = {
-        @Server(
-            description = "ローカルサーバー",
-            url = "http://localhost:8080"
-		)
-	}
-)
-
 @SpringBootApplication
 public class ReimiAppApplication {
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/RegisterUserCommand.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/RegisterUserCommand.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 
 
 public record RegisterUserCommand (
-        String firebaseUid,
         String name,
         Gender gender,
         LocalDate birthDate,

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/AlreadyRegisteredException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/AlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.application.exception;
+
+public class AlreadyRegisteredException  extends RuntimeException {
+    public AlreadyRegisteredException() {
+        super("すでに登録済みのユーザーです");
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/UnauthenticatedException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/UnauthenticatedException.java
@@ -1,0 +1,8 @@
+package com.reimi.reimi_app.application.exception;
+
+public class UnauthenticatedException extends RuntimeException {
+
+    public UnauthenticatedException() {
+        super("ユーザーの認証情報がありません");
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/UserUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/UserUseCase.java
@@ -7,7 +7,7 @@ import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserUseCase {
 
-    List<User> getUsers();
+    List<User> getUsersExcludingMe(String firebaseUid);
 
     void registerUser(RegisterUserCommand command);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
@@ -24,6 +24,10 @@ public class FirebaseConfig {
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
 
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+
         InputStream credentials = privateKey.getInputStream();
 
         FirebaseOptions firebaseOptions = FirebaseOptions.builder()

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
@@ -1,0 +1,40 @@
+package com.reimi.reimi_app.config;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.auth.FirebaseAuth;
+
+import org.springframework.core.io.Resource;
+
+
+@Configuration
+public class FirebaseConfig {
+    @Value("classpath:private-key.json")
+    private Resource privateKey;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+
+        InputStream credentials = privateKey.getInputStream();
+
+        FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.fromStream(credentials))
+            .build();
+
+        return FirebaseApp.initializeApp(firebaseOptions);
+    }
+
+    @Bean
+    public FirebaseAuth firebaseAuth(FirebaseApp firebaseApp) {
+        return FirebaseAuth.getInstance(firebaseApp);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/OpenApiConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/OpenApiConfig.java
@@ -1,7 +1,12 @@
 package com.reimi.reimi_app.config;
 
+import org.springframework.context.annotation.Configuration;
+
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.servers.Server;
 
 @OpenAPIDefinition(
@@ -15,8 +20,16 @@ import io.swagger.v3.oas.annotations.servers.Server;
             description = "ローカルサーバー",
             url = "http://localhost:8080"
 		)
-	}
+	},
+    security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+    name = "bearerAuth",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
 )
 
+@Configuration
 public class OpenApiConfig {
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/OpenApiConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/OpenApiConfig.java
@@ -1,4 +1,22 @@
 package com.reimi.reimi_app.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+
+@OpenAPIDefinition(
+	info = @Info(
+		title = "Reimi",
+		version = "1.0",
+		description = "天気で繋がる、出会いのアプリ"
+	),
+	servers = {
+        @Server(
+            description = "ローカルサーバー",
+            url = "http://localhost:8080"
+		)
+	}
+)
+
 public class OpenApiConfig {
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/OpenApiConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/OpenApiConfig.java
@@ -1,0 +1,4 @@
+package com.reimi.reimi_app.config;
+
+public class OpenApiConfig {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -4,14 +4,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-
+import org.springframework.security.config.http.SessionCreationPolicy;
 
 @Configuration
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(csrf -> csrf.disable());
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(
+                s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            );
         return http.build();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable());
         return http.build();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -4,16 +4,25 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.reimi.reimi_app.security.FirebaseAuthenticationFilter;
+import com.reimi.reimi_app.security.FirebaseTokenVerifier;
+
 import org.springframework.security.config.http.SessionCreationPolicy;
 
 @Configuration
 public class SecurityConfig {
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, FirebaseTokenVerifier verifier) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated());
+            .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+            .addFilterBefore(
+                new FirebaseAuthenticationFilter(verifier),
+                UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -1,9 +1,15 @@
 package com.reimi.reimi_app.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
 
 
 @Configuration
 public class SecurityConfig {
-
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.build();
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -1,0 +1,9 @@
+package com.reimi.reimi_app.config;
+
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class SecurityConfig {
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -12,9 +12,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
-            .sessionManagement(
-                s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            );
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated());
         return http.build();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -18,7 +18,12 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
+                .anyRequest().authenticated())
             .addFilterBefore(
                 new FirebaseAuthenticationFilter(verifier),
                 UsernamePasswordAuthenticationFilter.class);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -6,7 +6,7 @@ import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserRepository {
 
-    List<User> findAll();
+    List<User> findAllExcludingUserFirebaseUid(String firebaseUid);
 
     boolean existsByFirebaseUid(String firebaseUid);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -8,6 +8,8 @@ public interface UserRepository {
 
     List<User> findAll();
 
+    boolean existsByFirebaseUid(String firebaseUid);
+
     boolean existsByEmail(String email);
 
     void save(User user);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserEntity.java
@@ -20,20 +20,26 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "users")
+@Table(name = "users",
+        uniqueConstraints = {
+        @UniqueConstraint(name = "uk_users_firebase_uid", columnNames = "firebase_uid"),
+        @UniqueConstraint(name = "uk_users_email", columnNames = "email")
+    }
+)
 public class UserEntity {
 
     @Id
     @Column(name = "id", nullable = false, updatable = false)
     private UUID id;
 
-    @Column(name = "firebase_uid", nullable = false)
+    @Column(name = "firebase_uid", nullable = false, updatable = false)
     private String firebaseUid;
 
     @Column(name = "name", nullable = false, length = 64)

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, UUID> {
+    boolean existsByFirebaseUid(String firebaseUid);
     boolean existsByEmail(String email);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
@@ -1,5 +1,6 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.user;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, UUID> {
+    List<UserEntity> findByFirebaseUidNot(String firebaseUid);
     boolean existsByFirebaseUid(String firebaseUid);
     boolean existsByEmail(String email);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -18,8 +18,8 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public List<User> findAll() {
-        return jpaUserRepository.findAll()
+    public List<User> findAllExcludingUserFirebaseUid(String firebaseUid) {
+        return jpaUserRepository.findByFirebaseUidNot(firebaseUid)
             .stream()
             .map(UserMapper::toDomain)
             .toList();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -24,6 +24,12 @@ public class UserRepositoryImpl implements UserRepository {
             .map(UserMapper::toDomain)
             .toList();
     }
+
+    @Override
+    public boolean existsByFirebaseUid(String firebaseUid) {
+        return jpaUserRepository.existsByFirebaseUid(firebaseUid);
+    }
+
     @Override
     public boolean existsByEmail(String email) {
         return jpaUserRepository.existsByEmail(email);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -35,7 +35,9 @@ public class UserUseCaseImpl implements UserUseCase {
     @Transactional
     public void registerUser(RegisterUserCommand command) {
 
-        if (userRepository.existsByFirebaseUid(command.firebaseUid())) {
+        String firebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        if (userRepository.existsByFirebaseUid(firebaseUid)) {
             throw new AlreadyRegisteredException();
         }
 
@@ -44,7 +46,7 @@ public class UserUseCaseImpl implements UserUseCase {
         }
 
         User user = User.create(
-                command.firebaseUid(),
+                firebaseUid,
                 command.name(),
                 command.gender(),
                 command.birthDate(),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -1,6 +1,7 @@
 package com.reimi.reimi_app.infrastructure.service;
 
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
+import com.reimi.reimi_app.application.exception.AlreadyRegisteredException;
 import com.reimi.reimi_app.application.exception.EmailAlreadyExistsException;
 import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.User;
@@ -27,6 +28,11 @@ public class UserUseCaseImpl implements UserUseCase {
     @Override
     @Transactional
     public void registerUser(RegisterUserCommand command) {
+
+        if (userRepository.existsByFirebaseUid(command.firebaseUid())) {
+            throw new AlreadyRegisteredException();
+        }
+
         if (userRepository.existsByEmail(command.email())) {
             throw new EmailAlreadyExistsException();
         }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -6,6 +6,7 @@ import com.reimi.reimi_app.application.exception.EmailAlreadyExistsException;
 import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import java.util.List;
 
@@ -15,9 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class UserUseCaseImpl implements UserUseCase {
 
+    private final AuthenticatedUserProvider authenticatedUserProvider;
     private final UserRepository userRepository;
 
-    public UserUseCaseImpl(UserRepository userRepository) {
+    public UserUseCaseImpl(
+        AuthenticatedUserProvider authenticatedUserProvider,
+        UserRepository userRepository
+    ) {
+        this.authenticatedUserProvider = authenticatedUserProvider;
         this.userRepository = userRepository;
     }
     @Override

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -28,8 +28,9 @@ public class UserUseCaseImpl implements UserUseCase {
     }
     @Override
     @Transactional(readOnly = true)
-    public List<User> getUsers() {
-        return userRepository.findAll();
+    public List<User> getUsersExcludingMe(String firebaseUid) {
+
+        return userRepository.findAllExcludingUserFirebaseUid(firebaseUid);
     }
     @Override
     @Transactional

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -68,7 +68,6 @@ public class UserController {
     public ResponseEntity<Void> registerUser(@RequestBody RegisterUserRequest request) {
         userUseCase.registerUser(
             new RegisterUserCommand(
-                request.firebaseUid(),
                 request.name(),
                 Gender.valueOf(request.gender()),
                 request.birthDate(),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -16,6 +16,7 @@ import com.reimi.reimi_app.domain.model.user.Address;
 import com.reimi.reimi_app.domain.model.user.Gender;
 import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterUserRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,9 +26,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 @RequestMapping("/users")
 public class UserController {
 
+    private final AuthenticatedUserProvider authenticatedUserProvider;
     private final UserUseCase userUseCase;
 
-    public UserController(UserUseCase userUseCase) {
+    public UserController(
+        AuthenticatedUserProvider authenticatedUserProvider,
+        UserUseCase userUseCase
+    ) {
+        this.authenticatedUserProvider = authenticatedUserProvider;
         this.userUseCase = userUseCase;
     }
 
@@ -40,7 +46,10 @@ public class UserController {
     })
     @GetMapping
     public ResponseEntity<List<GetUserListResponse>> getUsers() {
-        List<GetUserListResponse> response = userUseCase.getUsers()
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        List<GetUserListResponse> response = userUseCase.getUsersExcludingMe(myFirebaseUid)
                 .stream()
                 .map(user -> new GetUserListResponse(
                     user.getId().value(),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -44,7 +44,6 @@ public class UserController {
                 .stream()
                 .map(user -> new GetUserListResponse(
                     user.getId().value(),
-                    user.getFirebaseUid(),
                     user.getName(),
                     user.getBirthDate(),
                     user.getAddress().getLabel(),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/RegisterUserRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/RegisterUserRequest.java
@@ -7,9 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "ユーザー新規登録用リクエスト")
 public record RegisterUserRequest (
 
-        @Schema(description = "Firebase AuthenticationのUID", type = "string", example = "f7KQ9sLm2A8P0xVZrEwN3HjU1BcD")
-        String firebaseUid,
-
         @Schema(description = "名前", type = "string", example = "山田 太郎")
         String name,
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetUserListResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetUserListResponse.java
@@ -10,8 +10,6 @@ public record GetUserListResponse (
 
         @Schema(description = "ユーザーID", type = "string", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
         UUID id,
-        @Schema(description = "Firebase AuthenticationのUID", type = "string", example = "f7KQ9sLm2A8P0xVZrEwN3HjU1BcD")
-        String firebaseUid,
 
         @Schema(description = "名前", type = "string", example = "山田 太郎")
         String name,

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/AuthenticatedUserProvider.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/AuthenticatedUserProvider.java
@@ -2,6 +2,8 @@ package com.reimi.reimi_app.security;
 
 import org.springframework.stereotype.Component;
 
+import com.reimi.reimi_app.application.exception.UnauthenticatedException;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -9,6 +11,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class AuthenticatedUserProvider {
     public String getFirebaseUid() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnauthenticatedException();
+        }
 
         return authentication.getName();
     }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/AuthenticatedUserProvider.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/AuthenticatedUserProvider.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.security;
+
+import org.springframework.stereotype.Component;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Component
+public class AuthenticatedUserProvider {
+    public String getFirebaseUid() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        return authentication.getName();
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.security;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
@@ -2,7 +2,10 @@ package com.reimi.reimi_app.security;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.google.firebase.auth.FirebaseAuthException;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -11,6 +14,12 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
 
+    private final FirebaseTokenVerifier verifier;
+
+    public FirebaseAuthenticationFilter(FirebaseTokenVerifier verifier) {
+        this.verifier = verifier;
+    }
+
     @Override
     protected void doFilterInternal(
         HttpServletRequest request,
@@ -18,7 +27,19 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain
     ) throws ServletException, IOException {
 
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            try {
+                verifier.verify(token);
+
+            } catch (FirebaseAuthException e) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                return;
+            }
+        }
         filterChain.doFilter(request, response);
     }
-
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
@@ -1,7 +1,24 @@
 package com.reimi.reimi_app.security;
 
+import java.io.IOException;
+
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        filterChain.doFilter(request, response);
+    }
 
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
@@ -1,11 +1,16 @@
 package com.reimi.reimi_app.security;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -33,7 +38,15 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
             String token = header.substring(7);
 
             try {
-                verifier.verify(token);
+                FirebaseToken decoded = verifier.verify(token);
+                Authentication auth =
+                    new UsernamePasswordAuthenticationToken(
+                        decoded.getUid(),
+                        null,
+                        List.of()
+                    );
+
+                SecurityContextHolder.getContext().setAuthentication(auth);
 
             } catch (FirebaseAuthException e) {
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseTokenVerifier.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseTokenVerifier.java
@@ -1,0 +1,21 @@
+package com.reimi.reimi_app.security;
+
+import org.springframework.stereotype.Component;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+
+@Component
+public class FirebaseTokenVerifier {
+
+    private final FirebaseAuth firebaseAuth;
+
+    public FirebaseTokenVerifier(FirebaseAuth firebaseAuth) {
+        this.firebaseAuth = firebaseAuth;
+    }
+
+    public FirebaseToken verify(String idToken) throws FirebaseAuthException {
+        return firebaseAuth.verifyIdToken(idToken);
+    }
+}


### PR DESCRIPTION
## 概要

種別：バックエンド開発

関連Issue：

- #65 

close #65 


## PR内容

### 【やったこと・開発メモ】

- Firebase Admin SDK の導入・設定
  - Firebase Admin SDKの依存関係を追加
  - APIリクエストを認証するために必要な秘密鍵の設定
    - src/main/resources/private-key.jsonファイルを作成
  - Firebaseサービスを使用するために必要な初期化設定を追加
    - FirebaseConfigファイルを作成してBeanを定義
  
- Spring Securityの組み込み
  - Firebase IDToken検証処理の実装
  - Spring Securityの依存関係を追加
  - Spring Securityの設定クラスの実装
    - SecurityConfigファイルを作成してBeanを定義
      - CSRFを無効化
      - セッションレス（STATELESS）設定
      - 全リクエストを認証済必須にする
      - Firebase 認証用のフィルターを通る様にした
    - Firebase 認証用のOncePerRequestFilterを作成
      - Firebase ID Token検証処理を実行
 
- 既存のAPIの修正
  - ユーザー新規登録API
    - firebaseUid関連
      - firebaseUidの重複登録を許可しない
        - UserエンティティでUnique制約を追加
        - Userリポジトリ・Userユースケース諸々修正
      - Command・RequestDTOからfirebaseUidを直接送っているのをやめる
      - AuthenticatedUserProviderクラスからログインユーザー情報を取得し、User作成を行う
    - ログイン中のユーザー情報を取得するためのコンポーネントを作成
      - SecurityContextにセットされたAuthenticationからFirebaseUidを取得するメソッドを追加
      - エラーハンドリング処理
  - ユーザー一覧取得API
    - firebaseUid関連
      - ResponseDTOからfirebaseUidを直接送っているのをやめる
    - ログインユーザーが一覧に含まれないようにした
      - Userリポジトリ・Userユースケース諸々修正
    - UserCotrollerからAuthenticatedUserProviderを注入して、ログインユーザーのFirebaseUidを取得してくる様にした
 
- OpenAPI（springdoc）定義を修正
  - OpenAPIの設定クラスの実装
    - mainクラスに記載していた@OpenAPIDefinition内容をこちらに定義
    - SecuritySchemeを定義する
      - Authorizationヘッダーに自動でIDトークンを含められる様にする
 
 - Firebase Auth REST API を使って動作確認
   - テスト用ユーザーを作成
   - SwaggerUIかPostmanからIDトークンが取得できるAPIを叩く
   - 修正したAPIの動作確認

### 【追加・変更した依存関係】

- ①依存ライブラリ名：firebase-admin
  - 用途：Firebase Admin SDKの導入・設定
  - 追加理由：Flutter 側で Firebase Auth を利用していて、バックエンドでも ID トークンを検証し firebaseUid を安全に取得する必要があるため

- ②依存ライブラリ名：spring-boot-starter-security
  - 用途：Spring Securityでリクエストの認証・認可制御・ログインユーザーの情報取得
  - 追加理由：Firebase ID トークン検証後の認証状態（Authentication / SecurityContext）の管理を行うため。Spring Security の Authenticationとして保持し、Controller / UseCase 層で安全にログインユーザーを取得できるようにするため。

### 【追加・変更した設定ファイル】

```
.
├── application
│   ├── command
│   │   └── RegisterUserCommand.java
│   ├── exception
│   │   ├── AlreadyRegisteredException.java
│   │   ├── EmailAlreadyExistsException.java
│   │   └── UnauthenticatedException.java
│   └── usecase
│       └── UserUseCase.java
├── config
│   ├── FirebaseConfig.java
│   ├── JpaConfig.java
│   ├── OpenApiConfig.java
│   └── SecurityConfig.java
├── domain
│   ├── model
│   │   ├── profile
│   │   │   └── Profile.java
│   │   └── user
│   │       ├── Address.java
│   │       ├── Gender.java
│   │       ├── Status.java
│   │       ├── User.java
│   │       └── UserId.java
│   ├── repository
│   │   └── UserRepository.java
│   └── shared
│       └── identity
│           └── UuidGenerator.java
├── infrastructure
│   ├── persistence
│   │   ├── entity
│   │   │   ├── ProfileEntity.java
│   │   │   └── UserEntity.java
│   │   ├── mapper
│   │   │   ├── ProfileMapper.java
│   │   │   └── UserMapper.java
│   │   └── repository
│   │       └── user
│   │           ├── JpaUserRepository.java
│   │           └── UserRepositoryImpl.java
│   ├── service
│   │   └── UserUseCaseImpl.java
│   └── web
│       ├── controller
│       │   └── UserController.java
│       └── dto
│           ├── request
│           │   └── RegisterUserRequest.java
│           └── response
│               └── GetUserListResponse.java
├── security
│   ├── AuthenticatedUserProvider.java
│   ├── FirebaseAuthenticationFilter.java
│   └── FirebaseTokenVerifier.java
└── ReimiAppApplication.java
```

## 参考資料

- Firebase Admin SDKの追加
  - https://firebase.google.com/docs/admin/setup?hl=ja

- Firebase Authenticationを利用するための初期設定
  - https://www.baeldung.com/spring-security-firebase-authentication

- Firebase サービスアカウントキーファイルを取得する方法
  - https://clemfournier.medium.com/how-to-get-my-firebase-service-account-key-file-f0ec97a21620

- Firebase Admin SDKでIDToken検証
  - https://firebase.google.com/docs/auth/admin/verify-id-tokens

- Spring Securityについて
  - https://qiita.com/suger4/items/39b37af3705f2d0271c7

- OncePerRequestFilterについて
  - https://incompengineer.com/spring-boot/%E3%80%90spring%E3%80%91onceperrequestfilter%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%A6%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E3%81%97%E3%81%A6%E3%81%BF%E3%82%8B/
  - https://www.baeldung.com/spring-onceperrequestfilter

- SecurityContextについて
  - https://qiita.com/shimori/items/5b74fc61bfd7cd57e5a7

- JPA関連
  - https://star-school.jp/spring/230

- Springdoc Openapi関連
  - https://qiita.com/yushi_koga/items/6b6b4aa6fa57f771da6f
  - https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/

## その他・補足事項

- 今後やりたいこと
  - ローカル / 本番でキーを切り替えられるようにする
    - （環境変数 or Secret Manager）
  - IDToken検証のエラーハンドリング
  - 想定ステータスコード整理
