### PR TITLE
エラーハンドリングの共通化

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
@@ -2,8 +2,11 @@ package com.reimi.reimi_app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(
+	exclude = UserDetailsServiceAutoConfiguration.class
+)
 public class ReimiAppApplication {
 
 	public static void main(String[] args) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/AlreadyRegisteredException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/AlreadyRegisteredException.java
@@ -1,7 +1,0 @@
-package com.reimi.reimi_app.application.exception;
-
-public class AlreadyRegisteredException  extends RuntimeException {
-    public AlreadyRegisteredException() {
-        super("すでに登録済みのユーザーです");
-    }
-}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/ApplicationException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/ApplicationException.java
@@ -1,0 +1,27 @@
+package com.reimi.reimi_app.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class ApplicationException extends RuntimeException {
+
+    private final String code;
+    private final HttpStatus status;
+
+    protected ApplicationException(
+        String code,
+        String message,
+        HttpStatus status
+    ) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/ClientErrorException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/ClientErrorException.java
@@ -1,0 +1,20 @@
+package com.reimi.reimi_app.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class ClientErrorException extends ApplicationException {
+
+    protected ClientErrorException(
+        String code,
+        String message,
+        HttpStatus status
+    ) {
+        super(code, message, status);
+
+        if (!status.is4xxClientError()) {
+            throw new IllegalArgumentException(
+                "ClientErrorException must be 4xx status"
+            );
+        }
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/EmailAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/EmailAlreadyExistsException.java
@@ -1,9 +1,14 @@
 package com.reimi.reimi_app.application.exception;
 
-public class EmailAlreadyExistsException extends RuntimeException {
+import org.springframework.http.HttpStatus;
 
-    public EmailAlreadyExistsException() {
-        super("すでに使用されているメールアドレスです");
+public class EmailAlreadyExistsException extends ClientErrorException {
+    public EmailAlreadyExistsException(String email) {
+        super(
+            "EMAIL_ALREADY_EXISTS",
+            "既に使用されているメールアドレスです",
+            HttpStatus.CONFLICT
+        );
     }
 }
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/EmailAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/EmailAlreadyExistsException.java
@@ -3,7 +3,7 @@ package com.reimi.reimi_app.application.exception;
 import org.springframework.http.HttpStatus;
 
 public class EmailAlreadyExistsException extends ClientErrorException {
-    public EmailAlreadyExistsException(String email) {
+    public EmailAlreadyExistsException() {
         super(
             "EMAIL_ALREADY_EXISTS",
             "既に使用されているメールアドレスです",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/InvalidRequestException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/InvalidRequestException.java
@@ -1,0 +1,13 @@
+package com.reimi.reimi_app.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidRequestException extends ClientErrorException {
+    public InvalidRequestException(String message) {
+        super(
+            "INVALID_REQUEST",
+            message,
+            HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/UnauthenticatedException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/UnauthenticatedException.java
@@ -1,8 +1,13 @@
 package com.reimi.reimi_app.application.exception;
 
-public class UnauthenticatedException extends RuntimeException {
+import org.springframework.http.HttpStatus;
 
+public class UnauthenticatedException extends ClientErrorException {
     public UnauthenticatedException() {
-        super("ユーザーの認証情報がありません");
+        super(
+            "UNAUTHENTICATED",
+            "認証されていません",
+            HttpStatus.UNAUTHORIZED
+        );
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/UserAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/UserAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.reimi.reimi_app.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserAlreadyExistsException  extends ClientErrorException {
+    public UserAlreadyExistsException() {
+        super(
+            "USER_ALREADY_EXISTS",
+            "既に登録済みのユーザーです",
+            HttpStatus.CONFLICT
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/AccessDeniedException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/AccessDeniedException.java
@@ -1,0 +1,16 @@
+package com.reimi.reimi_app.application.exception.client;
+
+import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
+
+public class AccessDeniedException extends ClientErrorException {
+
+    public AccessDeniedException() {
+        super(
+            "ACCESS_DENIED",
+            "この操作を行う権限がありません",
+            HttpStatus.FORBIDDEN
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/EmailAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/EmailAlreadyExistsException.java
@@ -1,6 +1,8 @@
-package com.reimi.reimi_app.application.exception;
+package com.reimi.reimi_app.application.exception.client;
 
 import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
 
 public class EmailAlreadyExistsException extends ClientErrorException {
     public EmailAlreadyExistsException() {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/InvalidRequestException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/InvalidRequestException.java
@@ -1,6 +1,8 @@
-package com.reimi.reimi_app.application.exception;
+package com.reimi.reimi_app.application.exception.client;
 
 import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
 
 public class InvalidRequestException extends ClientErrorException {
     public InvalidRequestException(String message) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/ResourceNotFoundException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/ResourceNotFoundException.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.application.exception.client;
+
+import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
+
+public class ResourceNotFoundException extends ClientErrorException {
+    public ResourceNotFoundException(String resourceName) {
+        super(
+            "RESOURCE_NOT_FOUND",
+            resourceName + " が見つかりません",
+            HttpStatus.NOT_FOUND
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/UnauthenticatedException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/UnauthenticatedException.java
@@ -1,6 +1,8 @@
-package com.reimi.reimi_app.application.exception;
+package com.reimi.reimi_app.application.exception.client;
 
 import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
 
 public class UnauthenticatedException extends ClientErrorException {
     public UnauthenticatedException() {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/UserAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/UserAlreadyExistsException.java
@@ -1,6 +1,8 @@
-package com.reimi.reimi_app.application.exception;
+package com.reimi.reimi_app.application.exception.client;
 
 import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
 
 public class UserAlreadyExistsException  extends ClientErrorException {
     public UserAlreadyExistsException() {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/SecurityConfig.java
@@ -17,6 +17,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http, FirebaseTokenVerifier verifier) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
+            .formLogin(form -> form.disable())
+            .httpBasic(basic -> basic.disable())
             .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -1,8 +1,8 @@
 package com.reimi.reimi_app.infrastructure.service;
 
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
-import com.reimi.reimi_app.application.exception.UserAlreadyExistsException;
-import com.reimi.reimi_app.application.exception.EmailAlreadyExistsException;
+import com.reimi.reimi_app.application.exception.client.UserAlreadyExistsException;
+import com.reimi.reimi_app.application.exception.client.EmailAlreadyExistsException;
 import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.repository.UserRepository;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -1,7 +1,7 @@
 package com.reimi.reimi_app.infrastructure.service;
 
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
-import com.reimi.reimi_app.application.exception.AlreadyRegisteredException;
+import com.reimi.reimi_app.application.exception.UserAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.EmailAlreadyExistsException;
 import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.User;
@@ -39,7 +39,7 @@ public class UserUseCaseImpl implements UserUseCase {
         String firebaseUid = authenticatedUserProvider.getFirebaseUid();
 
         if (userRepository.existsByFirebaseUid(firebaseUid)) {
-            throw new AlreadyRegisteredException();
+            throw new UserAlreadyExistsException();
         }
 
         if (userRepository.existsByEmail(command.email())) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/advice/GlobalExceptionHandler.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/advice/GlobalExceptionHandler.java
@@ -1,7 +1,23 @@
 package com.reimi.reimi_app.infrastructure.web.advice;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    // クライアント起因のエラー（400番台のエラー）処理
+    @ExceptionHandler(ClientErrorException.class)
+    public ResponseEntity<ApiErrorResponse> handleClientError(ClientErrorException ex) {
+        return ResponseEntity
+            .status(ex.getStatus())
+            .body(new ApiErrorResponse(
+                ex.getCode(),
+                ex.getMessage(),
+                null
+            ));
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/advice/GlobalExceptionHandler.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/advice/GlobalExceptionHandler.java
@@ -20,4 +20,15 @@ public class GlobalExceptionHandler {
                 null
             ));
     }
+    // 想定外エラー
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiErrorResponse> handleException(Exception ex) {
+        return ResponseEntity
+            .internalServerError()
+            .body(new ApiErrorResponse(
+                "INTERNAL_SERVER_ERROR",
+                "予期しないエラーが発生しました",
+                null
+            ));
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/advice/GlobalExceptionHandler.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/advice/GlobalExceptionHandler.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.infrastructure.web.advice;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -15,15 +15,11 @@ import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.Address;
 import com.reimi.reimi_app.domain.model.user.Gender;
 import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterUserRequest;
-import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.user.GetUsersApi;
+import com.reimi.reimi_app.infrastructure.web.openapi.user.RegisterUserApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 @RestController
 @RequestMapping("/users")
@@ -40,29 +36,8 @@ public class UserController {
         this.userUseCase = userUseCase;
     }
 
-    @Operation(
-        summary = "ユーザー一覧取得",
-        description = "登録されているユーザーの一覧を取得できるAPI"
-    )
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "200",
-            description = "ユーザーの一覧を取得しました",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = GetUserListResponse.class)
-            )
-        ),
-        @ApiResponse(
-            responseCode = "401",
-            description = "認証エラー",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ApiErrorResponse.class)
-            )
-        )
-    })
     @GetMapping
+    @GetUsersApi
     public ResponseEntity<List<GetUserListResponse>> getUsers() {
 
         String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
@@ -82,33 +57,8 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(
-        summary = "ユーザー新規登録",
-        description = "ユーザーの新規登録実行時のAPI"
-    )
-    @ApiResponses({
-        @ApiResponse(
-            responseCode = "201",
-            description = "ユーザーの新規登録が完了しました"
-        ),
-        @ApiResponse(
-            responseCode = "400",
-            description = "無効なリクエストです",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ApiErrorResponse.class)
-            )
-        ),
-        @ApiResponse(
-            responseCode = "401",
-            description = "認証エラー",
-            content = @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ApiErrorResponse.class)
-            )
-        )
-    })
     @PostMapping
+    @RegisterUserApi
     public ResponseEntity<Void> registerUser(@RequestBody RegisterUserRequest request) {
         userUseCase.registerUser(
             new RegisterUserCommand(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -15,10 +15,13 @@ import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.Address;
 import com.reimi.reimi_app.domain.model.user.Gender;
 import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterUserRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -42,7 +45,22 @@ public class UserController {
         description = "登録されているユーザーの一覧を取得できるAPI"
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "ユーザーの一覧を取得しました"),
+        @ApiResponse(
+            responseCode = "200",
+            description = "ユーザーの一覧を取得しました",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = GetUserListResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "認証エラー",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiErrorResponse.class)
+            )
+        )
     })
     @GetMapping
     public ResponseEntity<List<GetUserListResponse>> getUsers() {
@@ -69,8 +87,26 @@ public class UserController {
         description = "ユーザーの新規登録実行時のAPI"
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "201", description = "ユーザーの新規登録が完了しました"),
-        @ApiResponse(responseCode = "400", description = "無効なリクエストです")
+        @ApiResponse(
+            responseCode = "201",
+            description = "ユーザーの新規登録が完了しました"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "無効なリクエストです",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "401",
+            description = "認証エラー",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiErrorResponse.class)
+            )
+        )
     })
     @PostMapping
     public ResponseEntity<Void> registerUser(@RequestBody RegisterUserRequest request) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/ApiErrorResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/ApiErrorResponse.java
@@ -2,8 +2,18 @@ package com.reimi.reimi_app.infrastructure.web.dto.response;
 
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "共通エラーレスポンス")
 public record ApiErrorResponse (
+
+    @Schema(description = "コード", type = "string")
     String code,
+
+    @Schema(description = "エラーメッセージ", type = "string")
     String message,
+
+    @Schema(description = "詳細内容（主にバリデーションエラー）", type = "string")
     Map<String, String> details
+
 ) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/ApiErrorResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/ApiErrorResponse.java
@@ -1,0 +1,9 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.util.Map;
+
+public record ApiErrorResponse (
+    String code,
+    String message,
+    Map<String, String> details
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetUsersApi.java
@@ -1,0 +1,55 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.user;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ユーザー一覧取得",
+    description = "登録されているユーザーの一覧を取得できるAPI",
+    tags = { "User" }
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "ユーザーの一覧取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            array = @ArraySchema(
+                schema = @Schema(implementation = GetUserListResponse.class)
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetUsersApi {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterUserApi.java
@@ -1,0 +1,114 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.user;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ユーザー新規登録",
+    description = "ユーザーの新規登録実行時のAPI",
+    tags = { "User" }
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "ユーザーの新規登録が完了しました",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "無効なリクエスト",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "フォーマット不正",
+                    description = "リクエスト形式が正しくない場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "無効なリクエストです"
+                    }
+                    """
+                ),
+                @ExampleObject(
+                    name = "バリデーションエラー",
+                    description = "入力値のバリデーションに失敗した場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "入力値が不正です",
+                        "details": {
+                            "email": "メールアドレスの形式が正しくありません",
+                            "introduction": "自己紹介文は20〜500文字である必要があります"
+                        }
+                    }
+                    """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "409",
+        description = "重複エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "ユーザー重複",
+                    description = "既に登録されているユーザーで新規登録をした場合",
+                    value = """
+                    {
+                        "code": "USER_ALREADY_EXISTS",
+                        "message": "既に登録済みのユーザーです"
+                    }
+                    """
+                ),
+                @ExampleObject(
+                    name = "メール重複",
+                    description = "既に登録されているメールアドレスで新規登録をした場合",
+                    value = """
+                    {
+                        "code": "EMAIL_ALREADY_EXISTS",
+                        "message": "既に使用されているメールアドレスです"
+                    }
+                    """
+                )
+            }
+        )
+    )
+})
+public @interface RegisterUserApi {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/AuthenticatedUserProvider.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/AuthenticatedUserProvider.java
@@ -2,7 +2,7 @@ package com.reimi.reimi_app.security;
 
 import org.springframework.stereotype.Component;
 
-import com.reimi.reimi_app.application.exception.UnauthenticatedException;
+import com.reimi.reimi_app.application.exception.client.UnauthenticatedException;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/security/FirebaseAuthenticationFilter.java
@@ -49,10 +49,12 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(auth);
 
             } catch (FirebaseAuthException e) {
+                SecurityContextHolder.clearContext();
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());
                 return;
             }
         }
+
         filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
## 概要

種別：バックエンド開発

関連Issue：

- #72 

close #72 


## PR内容

### 【やったこと・開発メモ】

- エラーの共通フォーマットを決める
  - フロントが決まった形でエラーを扱えるようにする
    - HTTPステータス
    - コード
    - メッセージ
    - 詳細（バリデーションエラー時）
 
- アプリケーション全体の共通例外クラスを作成
  - ApplicationExceptionクラス作成

- クライアント起因のエラー（400番台のエラー）で継承に使う共通例外クラスを作成
  - ClientErrorExceptionクラス作成
    - ApplicationExceptionクラスを継承
    - 400番台のエラーのみ対応

- 400番台のエラー例外処理の作成
  - エラーレスポンス一覧（現状）

| ケース | HTTP（ステータス） | エラーコード |
| --- | --- | --- |
| フォーマット不正 | 400 | INVALID_REQUEST |
| バリデーションエラー | 400 | INVALID_REQUEST |
| 未認証 | 401 | UNAUTHENTICATED |
| 権限なし | 403 | ACCESS_DENIED |
| リソース不存在 | 404 | RESOURCE_NOT_FOUND |
| ユーザー重複 | 409 | USER_ALREADY_EXISTS |
| メール重複 | 409 | EMAIL_ALREADY_EXISTS |
| 想定外エラー | 500 | INTERNAL_SERVER_ERROR |

- 発生した全ての例外を一括して処理するクラスを作成
  - GlobalExceptionHandlerクラス作成
    - 作成した共通例外処理クラスをキャッチする
    - クライアント起因のエラー（400番台のエラー）処理
    - 想定外エラー
 
 - ユースケースごとにSwagger定義アノテーションを作成
   - 冗長になっていたControllerを簡潔にした

### 【追加・変更した設定ファイル】

```
.
├── application
│   ├── command
│   │   └── RegisterUserCommand.java
│   ├── exception
│   │   ├── client
│   │   │   ├── AccessDeniedException.java
│   │   │   ├── EmailAlreadyExistsException.java
│   │   │   ├── InvalidRequestException.java
│   │   │   ├── ResourceNotFoundException.java
│   │   │   ├── UnauthenticatedException.java
│   │   │   └── UserAlreadyExistsException.java
│   │   ├── ApplicationException.java
│   │   └── ClientErrorException.java
│   └── usecase
│       └── UserUseCase.java
├── config
│   ├── FirebaseConfig.java
│   ├── JpaConfig.java
│   ├── OpenApiConfig.java
│   └── SecurityConfig.java
├── domain
│   ├── model
│   │   ├── profile
│   │   │   └── Profile.java
│   │   └── user
│   │       ├── Address.java
│   │       ├── Gender.java
│   │       ├── Status.java
│   │       ├── User.java
│   │       └── UserId.java
│   ├── repository
│   │   └── UserRepository.java
│   └── shared
│       └── identity
│           └── UuidGenerator.java
├── infrastructure
│   ├── persistence
│   │   ├── entity
│   │   │   ├── ProfileEntity.java
│   │   │   └── UserEntity.java
│   │   ├── mapper
│   │   │   ├── ProfileMapper.java
│   │   │   └── UserMapper.java
│   │   └── repository
│   │       └── user
│   │           ├── JpaUserRepository.java
│   │           └── UserRepositoryImpl.java
│   ├── service
│   │   └── UserUseCaseImpl.java
│   └── web
│       ├── advice
│       │   └── GlobalExceptionHandler.java
│       ├── controller
│       │   └── UserController.java
│       ├── dto
│       │   ├── request
│       │   │   └── RegisterUserRequest.java
│       │   └── response
│       │       ├── ApiErrorResponse.java
│       │       └── GetUserListResponse.java
│       └── openapi
│           └── user
│               ├── GetUsersApi.java
│               └── RegisterUserApi.java
├── security
│   ├── AuthenticatedUserProvider.java
│   ├── FirebaseAuthenticationFilter.java
│   └── FirebaseTokenVerifier.java
└── ReimiAppApplication.java
```

## 参考資料

- 例外処理の仕組み・基本
  - https://springboot.jp/spring/error-handling/251
  - https://springboot.jp/spring/error-handling/256
  - https://www.ne.jp/asahi/hishidama/home/tech/java/spring/boot/ExceptionHandler.html?utm_source=chatgpt.com
  - https://qiita.com/only/items/de21656f72e2f7259c33

- Swagger定義アノテーション
  - https://qiita.com/crml1206/items/e47ec484af750d301953

## その他・補足事項

- 以下の処理に関しては別のIssuesで回収するものとする
  - バリデーション処理
  - 未認証時のエラーレスポンス内容の修正
    - 401エラーではく403になってしまうのを修正する
