### PR TITLE
【API設計】ユーザー取得APIの設計（/users/me）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/UserUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/UserUseCase.java
@@ -1,11 +1,14 @@
 package com.reimi.reimi_app.application.usecase;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
 import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserUseCase {
+
+    Optional<User> getUser(String firebaseUid);
 
     List<User> getUsersExcludingMe(String firebaseUid);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.reimi.reimi_app.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserRepository {
+
+    Optional<User> findMeByFirebaseUid(String firebaseUid);
 
     List<User> findAllUserExcludingMeByFirebaseUid(String firebaseUid);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -6,7 +6,7 @@ import com.reimi.reimi_app.domain.model.user.User;
 
 public interface UserRepository {
 
-    List<User> findAllExcludingUserFirebaseUid(String firebaseUid);
+    List<User> findAllUserExcludingMeByFirebaseUid(String firebaseUid);
 
     boolean existsByFirebaseUid(String firebaseUid);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
@@ -1,6 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.user;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, UUID> {
+    Optional<UserEntity> findByFirebaseUid(String firebaseUid);
     List<UserEntity> findByFirebaseUidNot(String firebaseUid);
     boolean existsByFirebaseUid(String firebaseUid);
     boolean existsByEmail(String email);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -18,7 +18,7 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public List<User> findAllExcludingUserFirebaseUid(String firebaseUid) {
+    public List<User> findAllUserExcludingMeByFirebaseUid(String firebaseUid) {
         return jpaUserRepository.findByFirebaseUidNot(firebaseUid)
             .stream()
             .map(UserMapper::toDomain)

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.user;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -15,6 +16,12 @@ public class UserRepositoryImpl implements UserRepository {
 
     public UserRepositoryImpl(JpaUserRepository jpaUserRepository) {
         this.jpaUserRepository = jpaUserRepository;
+    }
+
+    @Override
+    public Optional<User> findMeByFirebaseUid(String firebaseUid) {
+        return jpaUserRepository.findByFirebaseUid(firebaseUid)
+            .map(UserMapper::toDomain);
     }
 
     @Override

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserUseCaseImpl.java
@@ -3,6 +3,7 @@ package com.reimi.reimi_app.infrastructure.service;
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
 import com.reimi.reimi_app.application.exception.client.UserAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.InvalidRequestException;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.application.exception.client.EmailAlreadyExistsException;
 import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.User;
@@ -12,6 +13,7 @@ import com.reimi.reimi_app.infrastructure.storage.image.ImageStoragePath;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,11 +37,25 @@ public class UserUseCaseImpl implements UserUseCase {
         this.imageStorage = imageStorage;
         this.imageStoragePath = imageStoragePath;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> getUser(String firebaseUid) {
+
+        Optional<User> me = userRepository.findMeByFirebaseUid(firebaseUid);
+
+        if (me.isEmpty()) {
+            throw new ResourceNotFoundException("ユーザー");
+        }
+
+        return me;
+    }
+
     @Override
     @Transactional(readOnly = true)
     public List<User> getUsersExcludingMe(String firebaseUid) {
 
-        List<User> users = userRepository.findAllExcludingUserFirebaseUid(firebaseUid);
+        List<User> users = userRepository.findAllUserExcludingMeByFirebaseUid(firebaseUid);
 
         for (User user : users) {
             user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -12,10 +12,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.reimi.reimi_app.application.command.RegisterUserCommand;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.user.Address;
 import com.reimi.reimi_app.domain.model.user.Gender;
 import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterUserRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetMeResponse;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.user.GetUsersApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.user.RegisterUserApi;
@@ -39,6 +41,24 @@ public class UserController {
         this.userUseCase = userUseCase;
     }
 
+    @GetMapping("/me")
+    public ResponseEntity<GetMeResponse> getMe() {
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+        GetMeResponse getMeResponse = userUseCase.getUser(myFirebaseUid)
+            .map(user -> new GetMeResponse(
+                user.getId().value(),
+                user.getName(),
+                user.getGender().getLabel(),
+                user.getBirthDate(),
+                user.getAddress().getLabel(),
+                user.getEmail(),
+                user.getStatus().getLabel()
+            ))
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        return ResponseEntity.ok(getMeResponse);
+    }
     @GetMapping
     @GetUsersApi
     public ResponseEntity<List<GetUserListResponse>> getUsers() {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -19,6 +19,7 @@ import com.reimi.reimi_app.domain.model.user.Gender;
 import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterUserRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetMeResponse;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.user.GetMeApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.user.GetUsersApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.user.RegisterUserApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
@@ -42,6 +43,7 @@ public class UserController {
     }
 
     @GetMapping("/me")
+    @GetMeApi
     public ResponseEntity<GetMeResponse> getMe() {
 
         String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetMeResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetMeResponse.java
@@ -1,0 +1,31 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "ユーザー取得用レスポンス")
+public record GetMeResponse (
+
+        @Schema(description = "ユーザーID", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
+        UUID id,
+
+        @Schema(description = "名前", example = "山田 太郎")
+        String name,
+
+        @Schema(description = "性別", example = "男性")
+        String gender,
+
+        @Schema(description = "生年月日", example = "1996-04-18")
+        LocalDate birthDate,
+
+        @Schema(description = "居住地", example = "東京都")
+        String address,
+
+        @Schema(description = "メールアドレス", example = "taro.yamada@example.com")
+        String email,
+
+        @Schema(description = "アカウントの状態", example = "通常利用中")
+        String status
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
@@ -51,6 +51,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     ),
     @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
         responseCode = "500",
         description = "サーバーエラー",
         content = @Content(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
@@ -1,0 +1,71 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.user;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetMeResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ユーザー取得",
+    description = "ログインしているユーザー情報を取得できるAPI",
+    tags = { "User" }
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "ユーザーの取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            array = @ArraySchema(
+                schema = @Schema(implementation = GetMeResponse.class)
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetMeApi {
+}


### PR DESCRIPTION
## 概要

API名：ユーザー取得

種別：API開発

関連Issue：

- #82 

close #82 

## API設計

### 【やったこと・開発メモ】

- ドメイン層
  - リポジトリのインターフェイスにユーザー取得の操作を追加
 
- アプリケーション層
  - ユースケースのインターフェイスにユーザー取得の業務操作を追加

- インフラストラクチャ層
  - ユースケースの実装部分にユーザー取得操作を追加
  - ユーザー取得用レスポンスのDTOを作成
  - コントローラーで作成したレスポンスDTOで返却される様にした
  - リポジトリの実装
  - Swagger定義アノテーションを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ユーザー取得 |
| URL | /users/me |
| HTTPメソッド | GET |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
  {
        "id": string uuid
        "name": string
        "gender": string
        "birthDate": string date
        "address": string
        "email": string
        "status": string
  }
```

### 【追加・変更した設定ファイル】

- GetMeResponse.java
- GetMeApi.java
