### PR TITLE
【API設計】自分がいいねしたユーザー一覧取得APIの設計（/likes/users/given）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/LikeUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/LikeUseCase.java
@@ -1,6 +1,12 @@
 package com.reimi.reimi_app.application.usecase;
 
+import java.util.List;
+
+import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 public interface LikeUseCase {
+
     void likeUser(UserId toUserId);
+
+    List<User> getLikeGivenUserList();
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/LikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/LikeRepository.java
@@ -1,5 +1,6 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.reimi.reimi_app.domain.model.like.Like;
@@ -13,4 +14,6 @@ public interface LikeRepository {
     boolean exists(UserId fromUserId, UserId toUserId);
 
     void save(Like like);
+
+    List<UserId> findLikeGivenUserIdsByFromUserId(UserId fromUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -4,12 +4,15 @@ import java.util.List;
 import java.util.Optional;
 
 import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
 
 public interface UserRepository {
 
     Optional<User> findMeByFirebaseUid(String firebaseUid);
 
     List<User> findAllUserExcludingMeByFirebaseUid(String firebaseUid);
+
+    List<User> findByIds(List<UserId> userIds);
 
     boolean existsByFirebaseUid(String firebaseUid);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/JpaLikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/JpaLikeRepository.java
@@ -1,11 +1,20 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.like;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.reimi.reimi_app.infrastructure.persistence.entity.LikeEntity;
 
 public interface JpaLikeRepository extends JpaRepository<LikeEntity, UUID> {
     boolean existsByFromUserIdAndToUserId(UUID fromUserId, UUID toUserId);
+
+    @Query("""
+        select l.toUserId
+        from LikeEntity l
+        where l.fromUserId = :fromUserId
+    """)
+    List<UUID> findToUserIdsByFromUserId(UUID fromUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.like;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -44,5 +45,14 @@ public class LikeRepositoryImpl implements LikeRepository {
     @Override
     public void save(Like like) {
         jpaLikeRepository.save(LikeMapper.toEntity(like));
+    }
+
+    @Override
+    public List<UserId> findLikeGivenUserIdsByFromUserId(UserId fromUserId) {
+        return jpaLikeRepository
+            .findToUserIdsByFromUserId(fromUserId.value())
+            .stream()
+            .map(UserId::new)
+            .toList();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/JpaUserRepository.java
@@ -9,8 +9,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, UUID> {
+
     Optional<UserEntity> findByFirebaseUid(String firebaseUid);
+
     List<UserEntity> findByFirebaseUidNot(String firebaseUid);
+
+    List<UserEntity> findByIdIn(List<UUID> ids);
+
     boolean existsByFirebaseUid(String firebaseUid);
+
     boolean existsByEmail(String email);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -2,10 +2,12 @@ package com.reimi.reimi_app.infrastructure.persistence.repository.user;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.UserRepository;
 import com.reimi.reimi_app.infrastructure.persistence.mapper.UserMapper;
 
@@ -27,6 +29,19 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public List<User> findAllUserExcludingMeByFirebaseUid(String firebaseUid) {
         return jpaUserRepository.findByFirebaseUidNot(firebaseUid)
+            .stream()
+            .map(UserMapper::toDomain)
+            .toList();
+    }
+
+    @Override
+    public List<User> findByIds(List<UserId> userIds) {
+
+        List<UUID> uuids = userIds.stream()
+            .map(UserId::value)
+            .toList();
+
+        return jpaUserRepository.findByIdIn(uuids)
             .stream()
             .map(UserMapper::toDomain)
             .toList();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -13,6 +13,7 @@ import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.LikeRepository;
 import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.infrastructure.storage.image.ImageStorageComponent;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 @Service
@@ -21,15 +22,18 @@ public class LikeUseCaseImpl implements LikeUseCase {
 
     private final UserRepository userRepository;
     private final LikeRepository likeRepository;
+    private final ImageStorageComponent imageStorage;
     private final AuthenticatedUserProvider authenticatedUserProvider;
 
     public LikeUseCaseImpl(
         UserRepository userRepository,
         LikeRepository likeRepository,
+        ImageStorageComponent imageStorage,
         AuthenticatedUserProvider authenticatedUserProvider
     ) {
         this.userRepository = userRepository;
         this.likeRepository = likeRepository;
+        this.imageStorage = imageStorage;
         this.authenticatedUserProvider = authenticatedUserProvider;
     }
 
@@ -75,6 +79,12 @@ public class LikeUseCaseImpl implements LikeUseCase {
             return List.of();
         }
 
-        return userRepository.findByIds(likedUserIds);
+        List<User> users = userRepository.findByIds(likedUserIds);
+
+        for (User user : users) {
+            user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));
+        }
+
+        return users;
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,5 +57,24 @@ public class LikeUseCaseImpl implements LikeUseCase {
         );
 
         likeRepository.save(like);
+    }
+
+    @Override
+    public List<User> getLikeGivenUserList() {
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        User fromUser = userRepository.findMeByFirebaseUid(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        UserId fromUserId = fromUser.getId();
+
+        List<UserId> likedUserIds = likeRepository.findLikeGivenUserIdsByFromUserId(fromUserId);
+
+        if (likedUserIds.isEmpty()) {
+            return List.of();
+        }
+
+        return userRepository.findByIds(likedUserIds);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.reimi.reimi_app.application.usecase.LikeUseCase;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetLikedUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.like.GetLikeGivenUsersApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.like.LikeUserApi;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -40,7 +41,8 @@ public class LikeController {
     }
 
     @GetMapping("/users/given")
-    public ResponseEntity<List<GetLikedUserListResponse>> getUsersILiked() {
+    @GetLikeGivenUsersApi
+    public ResponseEntity<List<GetLikedUserListResponse>> getLikeGivenUsers() {
 
         List<GetLikedUserListResponse> response = likeUseCase.getLikeGivenUserList()
                 .stream()

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
@@ -1,7 +1,10 @@
 package com.reimi.reimi_app.infrastructure.web.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,12 +12,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.reimi.reimi_app.application.usecase.LikeUseCase;
 import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetLikedUserListResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.like.LikeUserApi;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 
 @RestController
-@RequestMapping("/likes/{userId}")
+@RequestMapping("/likes")
 public class LikeController {
 
     private final LikeUseCase likeUseCase;
@@ -25,7 +29,7 @@ public class LikeController {
         this.likeUseCase = likeUseCase;
     }
 
-    @PostMapping
+    @PostMapping("/{userId}")
     @LikeUserApi
     public ResponseEntity<Void> like(
         @PathVariable("userId") UserId toUserId,
@@ -34,4 +38,22 @@ public class LikeController {
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @GetMapping("/users/given")
+    public ResponseEntity<List<GetLikedUserListResponse>> getUsersILiked() {
+
+        List<GetLikedUserListResponse> response = likeUseCase.getLikeGivenUserList()
+                .stream()
+                .map(user -> new GetLikedUserListResponse(
+                    user.getId().value(),
+                    user.getName(),
+                    user.getBirthDate(),
+                    user.getAddress(),
+                    user.getSignedMainPhotoUrl()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetLikedUserListResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetLikedUserListResponse.java
@@ -1,0 +1,27 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.model.user.Address;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "自分がいいねした（された）ユーザー一覧取得用レスポンス")
+public record GetLikedUserListResponse (
+
+        @Schema(description = "ユーザーID", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
+        UUID id,
+
+        @Schema(description = "名前", example = "山田 太郎")
+        String name,
+
+        @Schema(description = "生年月日", example = "1996-04-18")
+        LocalDate birthDate,
+
+        @Schema(description = "居住地", example = "TOKYO")
+        Address address,
+
+        @Schema(description = "メイン写真URL")
+        String mainPhotoUrl
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
@@ -1,0 +1,87 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.like;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "自分がいいねしたユーザー一覧取得",
+    description = "自分がいいねしたユーザの一覧を取得できるAPI",
+    tags = { "Like" }
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "自分がいいねしたユーザーの一覧取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            array = @ArraySchema(
+                schema = @Schema(implementation = GetUserListResponse.class)
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetLikeGivenUsersApi {
+}


### PR DESCRIPTION
## 概要

API名：自分がいいねしたユーザー一覧取得

種別：API開発

関連Issue：

- #95 

close #95 

## API設計

### 【やったこと・開発メモ】

- ドメイン層
  - リポジトリインターフェイスにメソッドを追加
    - ライクリポジトリ
      - ログインユーザーがいいねしたユーザーID一覧を取得
    - ユーザーリポジトリ
      - userIdのリストからユーザードメインモデルのリストを取得
  
- アプリケーション層
  - ユースケースのインターフェイスに業務を追加
    - 自分がいいねしたユーザー一覧取得メソッド

- インフラストラクチャ層
  - JPQLを用いてライクJPA Repositoryメソッド作成
    - LikeエンティティからfromUserIdがログインユーザーのIDであるtoUserIdのUUIDリストを取得
  - ユーザーJPA Repositoryメソッドを追加
    - IDリストのUserエンティティを全て取得
  - ライクの実装ユースケースにオーバーライドメソッドを定義
    - 自身のユーザーIDがfromUserIdになっているユーザーIDをリストで取ってきくる
    - ↑のIDリストを元に、ユーザーリポジトリからユーザードメインモデルを取得してくる
  - ライクの実装リポジトリにオーバーライドメソッドを定義
    - UUIDのリストをUserIdに変換
    - ↑ドメイン層ではUUIDに依存しない様にUserIdとして扱う
  - ユーザーの実装リポジトリにオーバーライドメソッドを定義
    - 送られてきたユーザIDたちをユーザードメインモデルのリストに変換する
  - 自分がいいねした（された）ユーザー一覧取得用レスポンスDTO作成
  - Controllerに自分がいいねしたユーザー一覧取得APIを定義
  - 定義アノテーションを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | 自分がいいねしたユーザー一覧取得 |
| URL | /likes/users/given |
| HTTPメソッド | GET |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
[
  {
    "id": string uuid
    "name": string
    "birthDate": string date
    "address": string
    "mainPhotoUrl": string
  }
]
```

### 【追加・変更した設定ファイル】

 - reimi_app/infrastructure/web/dto/response/GetLikedUserListResponse.java
 - reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java

## 参考資料

- JPQL・@Queryアノテーションについて
  - https://qiita.com/opengl-8080/items/e074330b5f4862d9995f
  - https://www.baeldung.com/spring-data-jpa-query
