### PR TITLE
【API設計】自分がいいねされたユーザー一覧取得APIの設計（/likes/users/received）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/LikeUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/LikeUseCase.java
@@ -9,4 +9,6 @@ public interface LikeUseCase {
     void likeUser(UserId toUserId);
 
     List<User> getLikeGivenUserList();
+
+    List<User> getLikeReceivedUserList();
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/LikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/LikeRepository.java
@@ -16,4 +16,6 @@ public interface LikeRepository {
     void save(Like like);
 
     List<UserId> findLikeGivenUserIdsByFromUserId(UserId fromUserId);
+
+    List<UserId> findLikeReceivedUserIdsByToUserId(UserId toUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/JpaLikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/JpaLikeRepository.java
@@ -17,4 +17,11 @@ public interface JpaLikeRepository extends JpaRepository<LikeEntity, UUID> {
         where l.fromUserId = :fromUserId
     """)
     List<UUID> findToUserIdsByFromUserId(UUID fromUserId);
+
+    @Query("""
+        select l.fromUserId
+        from LikeEntity l
+        where l.toUserId = :toUserId
+    """)
+    List<UUID> findFromUserIdsByToUserId(UUID toUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
@@ -55,4 +55,13 @@ public class LikeRepositoryImpl implements LikeRepository {
             .map(UserId::new)
             .toList();
     }
+
+    @Override
+    public List<UserId> findLikeReceivedUserIdsByToUserId(UserId toUserId) {
+        return jpaLikeRepository
+            .findFromUserIdsByToUserId(toUserId.value())
+            .stream()
+            .map(UserId::new)
+            .toList();
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -87,4 +87,29 @@ public class LikeUseCaseImpl implements LikeUseCase {
 
         return users;
     }
+
+    @Override
+    public List<User> getLikeReceivedUserList() {
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        User toUser = userRepository.findMeByFirebaseUid(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        UserId toUserId = toUser.getId();
+
+        List<UserId> likedUserIds = likeRepository.findLikeReceivedUserIdsByToUserId(toUserId);
+
+        if (likedUserIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<User> users = userRepository.findByIds(likedUserIds);
+
+        for (User user : users) {
+            user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));
+        }
+
+        return users;
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
@@ -14,6 +14,7 @@ import com.reimi.reimi_app.application.usecase.LikeUseCase;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetLikedUserListResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.like.GetLikeGivenUsersApi;
+import com.reimi.reimi_app.infrastructure.web.openapi.like.GetLikeReceivedUsersApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.like.LikeUserApi;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -45,6 +46,24 @@ public class LikeController {
     public ResponseEntity<List<GetLikedUserListResponse>> getLikeGivenUsers() {
 
         List<GetLikedUserListResponse> response = likeUseCase.getLikeGivenUserList()
+                .stream()
+                .map(user -> new GetLikedUserListResponse(
+                    user.getId().value(),
+                    user.getName(),
+                    user.getBirthDate(),
+                    user.getAddress(),
+                    user.getSignedMainPhotoUrl()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/users/received")
+    @GetLikeReceivedUsersApi
+    public ResponseEntity<List<GetLikedUserListResponse>> getLikeReceivedUsers() {
+
+        List<GetLikedUserListResponse> response = likeUseCase.getLikeReceivedUserList()
                 .stream()
                 .map(user -> new GetLikedUserListResponse(
                     user.getId().value(),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
@@ -1,0 +1,87 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.like;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "自分がいいねされたユーザー一覧取得",
+    description = "自分がいいねされたユーザの一覧を取得できるAPI",
+    tags = { "Like" }
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "自分がいいねされたユーザーの一覧取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            array = @ArraySchema(
+                schema = @Schema(implementation = GetUserListResponse.class)
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetLikeReceivedUsersApi {
+}


### PR DESCRIPTION
## 概要

API名：自分がいいねされたユーザー一覧取得

種別：API開発

関連Issue：

- #96 

close #96 

## API設計

### 【やったこと・開発メモ】

- ドメイン層
  - ライクリポジトリインターフェイスにメソッドを追加
    - ログインユーザーがいいねされたユーザーID一覧を取得

- アプリケーション層
  - ユースケースのインターフェイスに業務を追加
    - 自分がいいねされたユーザー一覧取得メソッド

- インフラストラクチャ層
  - JPQLを用いてライクJPA Repositoryメソッド作成
    - LikeエンティティからtoUserIdがログインユーザーのIDであるfromUserIdのUUIDリストを取得
  - ライクの実装ユースケースにオーバーライドメソッドを定義
    - 自身のユーザーIDがtoUserIdになっているユーザーIDをリストで取ってきくる
    - ↑のIDリストを元に、ユーザーリポジトリからユーザードメインモデルを取得してくる
  - ライクの実装リポジトリにオーバーライドメソッドを定義
    - UUIDのリストをUserIdに変換する
    - ↑ドメイン層ではUUIDに依存しない様にUserIdとして扱う
  - Controllerに自分がいいねされたユーザー一覧取得APIを定義
  - 定義アノテーションを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | 自分がいいねされたユーザー一覧取得 |
| URL | /likes/users/received |
| HTTPメソッド | GET |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
[
  {
    "id": string uuid
    "name": string
    "birthDate": string date
    "address": string
    "mainPhotoUrl": string
  }
]
```

### 【追加・変更した設定ファイル】

- reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
