### PR TITLE
【API設計】マッチング成立したユーザー一覧取得のAPI設計（/matches）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MatchUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MatchUseCase.java
@@ -6,6 +6,6 @@ import com.reimi.reimi_app.domain.model.user.User;
 
 public interface MatchUseCase {
 
-    List<User> getMatchedUsers();
+    List<User> getMatchedUserList();
 
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MatchUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MatchUseCase.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.application.usecase;
+
+import java.util.List;
+
+import com.reimi.reimi_app.domain.model.user.User;
+
+public interface MatchUseCase {
+
+    List<User> getMatchedUsers();
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MatchRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MatchRepository.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.List;
+
 import com.reimi.reimi_app.domain.model.match.Match;
 import com.reimi.reimi_app.domain.model.user.UserId;
 
@@ -8,4 +10,6 @@ public interface MatchRepository {
     boolean exists(UserId userAId, UserId userBId);
 
     void save(Match match);
+
+    List<UserId> findMatchedUserIdsByUserId(UserId userId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/JpaMatchRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/JpaMatchRepository.java
@@ -1,12 +1,26 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.match;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.reimi.reimi_app.infrastructure.persistence.entity.MatchEntity;
 
 public interface JpaMatchRepository extends JpaRepository<MatchEntity, UUID> {
 
     boolean existsByUserAIdAndUserBId(UUID userAId, UUID userBId);
+
+    @Query("""
+        select
+            case
+                when m.userAId = :userId then m.userBId
+                else m.userAId
+            end
+        from MatchEntity m
+        where m.userAId = :userId
+            or m.userBId = :userId
+    """)
+    List<UUID> findMatchedUserIds(UUID userId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/MatchRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/MatchRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.match;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.domain.model.match.Match;
@@ -29,5 +31,13 @@ public class MatchRepositoryImpl implements MatchRepository {
     @Override
     public void save(Match match) {
         jpaMatchRepository.save(MatchMapper.toEntity(match));
+    }
+
+    @Override
+    public List<UserId> findMatchedUserIdsByUserId(UserId userId) {
+        return jpaMatchRepository.findMatchedUserIds(userId.value())
+            .stream()
+            .map(UserId::new)
+            .toList();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MatchUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MatchUseCaseImpl.java
@@ -1,0 +1,46 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.usecase.MatchUseCase;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.repository.MatchRepository;
+import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+@Service
+public class MatchUseCaseImpl implements MatchUseCase {
+
+    private final MatchRepository matchRepository;
+    private final UserRepository userRepository;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+
+    public MatchUseCaseImpl(
+        MatchRepository matchRepository,
+        UserRepository userRepository,
+        AuthenticatedUserProvider authenticatedUserProvider
+    ) {
+        this.matchRepository = matchRepository;
+        this.userRepository = userRepository;
+        this.authenticatedUserProvider = authenticatedUserProvider;
+    }
+
+    @Override
+    public List<User> getMatchedUserList() {
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        User user = userRepository.findMeByFirebaseUid(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        UserId userId = user.getId();
+
+        List<UserId> matchedUserIds = matchRepository.findMatchedUserIdsByUserId(userId);
+
+        return userRepository.findByIds(matchedUserIds);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MatchUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MatchUseCaseImpl.java
@@ -10,6 +10,7 @@ import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.MatchRepository;
 import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.infrastructure.storage.image.ImageStorageComponent;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 @Service
@@ -18,15 +19,18 @@ public class MatchUseCaseImpl implements MatchUseCase {
     private final MatchRepository matchRepository;
     private final UserRepository userRepository;
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final ImageStorageComponent imageStorage;
 
     public MatchUseCaseImpl(
         MatchRepository matchRepository,
         UserRepository userRepository,
-        AuthenticatedUserProvider authenticatedUserProvider
+        AuthenticatedUserProvider authenticatedUserProvider,
+        ImageStorageComponent imageStorage
     ) {
         this.matchRepository = matchRepository;
         this.userRepository = userRepository;
         this.authenticatedUserProvider = authenticatedUserProvider;
+        this.imageStorage = imageStorage;
     }
 
     @Override
@@ -34,13 +38,19 @@ public class MatchUseCaseImpl implements MatchUseCase {
 
         String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
 
-        User user = userRepository.findMeByFirebaseUid(myFirebaseUid)
+        User me = userRepository.findMeByFirebaseUid(myFirebaseUid)
             .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
 
-        UserId userId = user.getId();
+        UserId userId = me.getId();
 
         List<UserId> matchedUserIds = matchRepository.findMatchedUserIdsByUserId(userId);
 
-        return userRepository.findByIds(matchedUserIds);
+        List<User> users = userRepository.findByIds(matchedUserIds);
+
+        for (User user : users) {
+            user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));
+        }
+
+        return users;
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MatchController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MatchController.java
@@ -4,11 +4,15 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.reimi.reimi_app.application.usecase.MatchUseCase;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetMatchedUserListResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.match.GetMatchedUsersApi;
 
+@RestController
+@RequestMapping("/matches")
 public class MatchController {
 
     private final MatchUseCase matchUseCase;
@@ -19,7 +23,7 @@ public class MatchController {
         this.matchUseCase = matchUseCase;
     }
 
-    @GetMapping("/matches")
+    @GetMapping()
     @GetMatchedUsersApi
     public ResponseEntity<List<GetMatchedUserListResponse>> getMatchedUsers() {
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MatchController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MatchController.java
@@ -1,0 +1,36 @@
+package com.reimi.reimi_app.infrastructure.web.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.reimi.reimi_app.application.usecase.MatchUseCase;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetMatchedUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.match.GetMatchedUsersApi;
+
+public class MatchController {
+
+    private final MatchUseCase matchUseCase;
+
+    public MatchController(
+        MatchUseCase matchUseCase
+    ) {
+        this.matchUseCase = matchUseCase;
+    }
+
+    @GetMapping("/matches")
+    @GetMatchedUsersApi
+    public ResponseEntity<List<GetMatchedUserListResponse>> getMatchedUsers() {
+
+        List<GetMatchedUserListResponse> response = matchUseCase.getMatchedUserList()
+                .stream()
+                .map(user -> new GetMatchedUserListResponse(
+                    user.getId().value(),
+                    user.getSignedMainPhotoUrl()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetMatchedUserListResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetMatchedUserListResponse.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "マッチング成立したユーザー一覧取得用レスポンス")
+public record GetMatchedUserListResponse (
+
+        @Schema(description = "ユーザーID", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
+        UUID id,
+
+        @Schema(description = "メイン写真URL")
+        String mainPhotoUrl
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java
@@ -1,0 +1,87 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.match;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetMatchedUserListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "マッチング成立したユーザー一覧取得",
+    description = "マッチングが成立したユーザーの一覧を取得できるAPI",
+    tags = { "Match" }
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "マッチング成立したユーザーの一覧取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            array = @ArraySchema(
+                schema = @Schema(implementation = GetMatchedUserListResponse.class)
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetMatchedUsersApi {
+}


### PR DESCRIPTION
## 概要

API名：マッチング成立したユーザー一覧取得

種別：API開発

関連Issue：

- #102 

close #102 

## API設計

### 【やったこと・開発メモ】

- ドメイン層
  - マッチリポジトリのインターフェイスにメソッド追加
    - ログインユーザーがマッチングしたユーザーIDのリストを取得するメソッド
 
- アプリケーション層
  - マッチングユースケースのインターフェイス作成
    - マッチングユーザー一覧取得の業務操作を定義
 
- インフラストラクチャ層
  - JPQLを用いてマッチングJPA Repositoryメソッド作成
    - MatchエンティティからuserAIdかuserBIdどちらかがログインユーザーのIDで登録されているレコードから、もう一方のユーザーIDをUUIDのリストとして取得
  - マッチングの実装ユースケース作成
    - マッチングユーザー一覧取得のオーバーライドメソッドを定義
      - ログインユーザーのユーザードメインモデルをユーザーリポジトリから取得
      - 自身のユーザーIDでマッチングリポジトリからマッチングしたユーザーIDのリストを取得してくる
      - ↑のIDリストを元に、ユーザーリポジトリからユーザードメインモデルを取得してくる
  - マッチングの実装リポジトリにオーバーライドメソッドを定義
    - UUIDのリストをUserIdに変換する
  - Controllerの作成
    - マッチング成立したユーザー一覧取得APIを定義
    - レスポンスDTOを用いて必要な値をセットする
  - マッチング成立したユーザー一覧取得用レスポンスDTO作成
  - 定義アノテーションを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | マッチング成立したユーザー一覧取得 |
| URL | /matches |
| HTTPメソッド | GET |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
[
  {
    "id": string uuid
    "mainPhotoUrl": string
  }
]
```

### 【追加・変更した設定ファイル】

 - reimi_app/application/usecase/MatchUseCase.java
 - reimi_app/infrastructure/service/MatchUseCaseImpl.java
 - reimi_app/infrastructure/web/controller/MatchController.java
 - reimi_app/infrastructure/web/dto/response/GetMatchedUserListResponse.java
 - reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java

## その他・補足事項

- チャットルームのチャット一覧取得はメッセージ送信APIを作成した後に行う
