### PR TITLE
【API修正】ユーザープロフィール編集APIの修正（/users/{userId}/profile）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/UpdateUserProfileCommand.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/UpdateUserProfileCommand.java
@@ -35,5 +35,5 @@ public record UpdateUserProfileCommand (
     Holiday holiday,
     List<String> sunnyDayHobbies,
     List<String> rainyDayHobbies,
-    List<MultipartFile> subPhotos
+    MultipartFile subPhoto
 ) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/SubPhotoUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/SubPhotoUseCase.java
@@ -1,6 +1,5 @@
 package com.reimi.reimi_app.application.usecase;
 
-import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -8,5 +7,5 @@ import com.reimi.reimi_app.domain.model.profile.Profile;
 
 public interface SubPhotoUseCase {
 
-    void registerSubPhoto(Profile profile, List<MultipartFile> subPhotoFiles);
+    void registerSubPhoto(Profile profile, MultipartFile subPhotoFile);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/profile/Profile.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/profile/Profile.java
@@ -151,11 +151,12 @@ public class Profile {
         List<String> sunnyDayHobbies,
         List<String> rainyDayHobbies
     ) {
-        if (introduction == null || introduction.isBlank() || introduction.length() < 20 || introduction.length() > 500) {
+        if (introduction != null && !introduction.isBlank()) {
+            if (introduction.length() < 20 || introduction.length() > 500) {
             throw new IllegalArgumentException("自己紹介文は20〜500文字である必要があります");
+            }
+            this.introduction = introduction;
         }
-        this.introduction = introduction;
-        if (introduction != null) this.introduction = introduction;
         if (height != null) this.height = height;
         if (bodyShape != null) this.bodyShape = bodyShape;
         if (annualIncome != null) this.annualIncome = annualIncome;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
@@ -98,18 +98,15 @@ public class User {
         Address address,
         String mainPhotoUrl
     ) {
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("名前は必須です");
+        if (name != null) {
+            this.name = name;
         }
-        if (address == null) {
-            throw new IllegalArgumentException("居住地は必須です");
+        if (address != null) {
+            this.address = address;
         }
-        if (mainPhotoUrl == null || mainPhotoUrl.isBlank()) {
-            throw new IllegalArgumentException("メイン写真は必須です");
+        if (mainPhotoUrl != null) {
+            this.mainPhotoUrl = mainPhotoUrl;
         }
-        this.name = name;
-        this.address = address;
-        this.mainPhotoUrl = mainPhotoUrl;
     }
 
     public UserId getId() { return id; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
@@ -98,13 +98,13 @@ public class User {
         Address address,
         String mainPhotoUrl
     ) {
-        if (name != null) {
+        if (name != null && !name.isBlank()) {
             this.name = name;
         }
         if (address != null) {
             this.address = address;
         }
-        if (mainPhotoUrl != null) {
+        if (mainPhotoUrl != null && !mainPhotoUrl.isBlank()) {
             this.mainPhotoUrl = mainPhotoUrl;
         }
     }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/SubPhotoUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/SubPhotoUseCaseImpl.java
@@ -33,7 +33,7 @@ public class SubPhotoUseCaseImpl implements SubPhotoUseCase {
     }
     @Override
     @Transactional
-    public void registerSubPhoto(Profile profile, List<MultipartFile> subPhotoFiles) {
+    public void registerSubPhoto(Profile profile, MultipartFile subPhotoFile) {
 
         // 最大6枚までサブ写真を登録できる
         int limit = 6;
@@ -45,24 +45,16 @@ public class SubPhotoUseCaseImpl implements SubPhotoUseCase {
             throw new InvalidRequestException("サブ写真は最大6枚までです");
         }
 
-        if (subPhotoFiles.size() > remaining) {
-            throw new InvalidRequestException(
-                "追加できるのは残り " + remaining + " 枚までです"
-            );
-        }
-
         // サブ写真のベースパスを取得
         String subPhotoBasePath = imageStoragePath.userProfileSubPhotoPath(profile.getId().value());
         int sortOrder = existing.isEmpty() ? 1 : existing.get(existing.size() - 1).getSortOrder() + 1;
 
-        for (MultipartFile file : subPhotoFiles) {
-            String photoUrl = imageStorage.imageUpload(file, subPhotoBasePath);
-            SubPhoto subPhoto = SubPhoto.create(
-                profile.getId(),
-                photoUrl,
-                sortOrder++
-            );
-            subPhotoRepository.save(subPhoto);
-        }
+        String photoUrl = imageStorage.imageUpload(subPhotoFile, subPhotoBasePath);
+        SubPhoto subPhoto = SubPhoto.create(
+            profile.getId(),
+            photoUrl,
+            sortOrder++
+        );
+        subPhotoRepository.save(subPhoto);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserProfileUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/UserProfileUseCaseImpl.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.reimi.reimi_app.application.command.UpdateUserProfileCommand;
 import com.reimi.reimi_app.application.exception.client.AccessDeniedException;
-import com.reimi.reimi_app.application.exception.client.InvalidRequestException;
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.application.usecase.SubPhotoUseCase;
 import com.reimi.reimi_app.application.usecase.UserProfileUseCase;
@@ -91,10 +90,6 @@ public class UserProfileUseCaseImpl implements UserProfileUseCase {
     @Transactional
     public void updateUserProfile(UserId userId, UpdateUserProfileCommand command) {
 
-        if (command.mainPhoto() == null || command.mainPhoto().isEmpty()) {
-            throw new InvalidRequestException("メイン写真は必須です");
-        }
-
         User user = userProfileRepository.findUserByUserId(userId)
             .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
 
@@ -105,19 +100,25 @@ public class UserProfileUseCaseImpl implements UserProfileUseCase {
             throw new AccessDeniedException();
         }
 
-        String currentFilePath = user.getMainPhotoUrl();
-        String currentFileName = imageStorage.removeUuidPrefix(imageStorage.extractFileName(currentFilePath));
-        String uploadedFileName = command.mainPhoto().getOriginalFilename();
+        // 初期値ではnull
+        String mainPhotoPath = null;
 
-        String mainPhotoPath = currentFilePath;
-        if (!uploadedFileName.equals(currentFileName)) {
-            // メイン写真のベースパスを取得
-            String basePath = imageStoragePath.userMainPhotoPath();
-            // メイン写真の画像アップロード
-            mainPhotoPath = imageStorage.imageUpload(command.mainPhoto(), basePath);
-            //古いファイルは削除
-            if (currentFilePath != null) {
-                imageStorage.deleteImage(currentFilePath);
+        if (command.mainPhoto() != null && !command.mainPhoto().isEmpty()) {
+            // 画像アップロード処理
+            String currentFilePath = user.getMainPhotoUrl();
+            String currentFileName = imageStorage.removeUuidPrefix(imageStorage.extractFileName(currentFilePath));
+            String uploadedFileName = command.mainPhoto().getOriginalFilename();
+
+            mainPhotoPath = currentFilePath;
+            if (!uploadedFileName.equals(currentFileName)) {
+                // メイン写真のベースパスを取得
+                String basePath = imageStoragePath.userMainPhotoPath();
+                // メイン写真の画像アップロード
+                mainPhotoPath = imageStorage.imageUpload(command.mainPhoto(), basePath);
+                //古いファイルは削除
+                if (currentFilePath != null) {
+                    imageStorage.deleteImage(currentFilePath);
+                }
             }
         }
 
@@ -125,8 +126,8 @@ public class UserProfileUseCaseImpl implements UserProfileUseCase {
             .orElseThrow(() -> new ResourceNotFoundException("ユーザーのプロフィール"));
 
         // nullでない場合、サブ写真の登録処理（アップロード）
-        if (command.subPhotos() != null || !command.subPhotos().isEmpty()) {
-            subPhotoUseCase.registerSubPhoto(profile, command.subPhotos());
+        if (command.subPhoto() != null && !command.subPhoto().isEmpty()) {
+            subPhotoUseCase.registerSubPhoto(profile, command.subPhoto());
         }
 
         user.update(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserProfileController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserProfileController.java
@@ -65,7 +65,7 @@ public class UserProfileController {
                 request.holiday(),
                 request.sunnyDayHobbies(),
                 request.rainyDayHobbies(),
-                request.subPhotos()
+                request.subPhoto()
             )
         );
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/UpdateUserProfileRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/UpdateUserProfileRequest.java
@@ -2,6 +2,7 @@ package com.reimi.reimi_app.infrastructure.web.dto.request;
 
 import java.util.List;
 
+import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.reimi.reimi_app.domain.model.profile.Alcohol;
@@ -19,27 +20,21 @@ import com.reimi.reimi_app.domain.model.user.Address;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "ユーザープロフィール編集用リクエスト")
 public record UpdateUserProfileRequest (
 
-    @NotBlank(message = "名前は必須です")
     @Size(max = 16, message = "名前は16文字以内で入力してください")
     @Schema(description = "名前", example = "山田 太郎")
     String name,
 
-    @NotNull(message = "居住地は必須です")
     @Schema(description = "居住地", example = "TOKYO")
     Address address,
 
-    @NotNull(message = "メイン写真URLは必須です")
     @Schema(description = "メイン写真", format = "binary")
-    MultipartFile mainPhoto,
+    @Nullable MultipartFile mainPhoto,
 
-    @NotNull(message = "自己紹介文は必須です")
     @Size(min = 20, max = 500, message = "自己紹介文は20文字以上500文字以下で入力してください")
     @Schema(description = "自己紹介文", example = "都内でエンジニアをしています。休日はカフェ巡りやランニングを楽しんでいます。")
     String introduction,
@@ -91,10 +86,6 @@ public record UpdateUserProfileRequest (
     )
     List<String> rainyDayHobbies,
 
-    @Schema(
-        description = "ユーザープロフィールのサブ写真（6枚までファイルアップロード可能）",
-        type = "array",
-        format = "binary"
-    )
-    List<MultipartFile> subPhotos
+    @Schema(description = "ユーザープロフィールのサブ写真（6枚までファイルアップロード可能）", format = "binary")
+    @Nullable MultipartFile subPhoto
 ) {}


### PR DESCRIPTION
## 概要

修正するAPI名：ユーザープロフィール編集

種別：API修正

関連Issue：

- #105 

close #105 


## 修正内容

### 【修正理由】

- ファイルアップロード関連で入力エラーがあったため

### 【やったこと・開発メモ】

- ユーザー情報の送信を必須じゃなくした
  - 名前・居住地・メイン写真
  - nullだった（空文字も）場合、値の更新処理が行われない
- サブ写真をListで送れなくした
  - 一つずつ追加処理をしてもらう
- 画像のアップロード処理は、リクエストがnullでない場合のみ行う

### 【追加・変更した設定ファイル】

- 変更したファイル
  - /reimi_app/application/command/UpdateUserProfileCommand.java
  - reimi_app/application/usecase/SubPhotoUseCase.java
  - reimi_app/domain/model/profile/Profile.java
  - reimi_app/domain/model/user/User.java
  - reimi_app/infrastructure/service/SubPhotoUseCaseImpl.java
  - reimi_app/infrastructure/service/UserProfileUseCaseImpl.java
  - reimi_app/infrastructure/web/controller/UserProfileController.java
  - reimi_app/infrastructure/web/dto/request/UpdateUserProfileRequest.java
