### PR TITLE
【API設計】チャットルームにメッセージ送信API設計（/chatRooms/{chatRoomId}/messages）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendMessageCommand.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendMessageCommand.java
@@ -1,0 +1,10 @@
+package com.reimi.reimi_app.application.command;
+
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public record SendMessageCommand(
+    ChatRoomId chatRoomId,
+    UserId senderId,
+    String text
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendTextMessageCommand.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendTextMessageCommand.java
@@ -3,7 +3,7 @@ package com.reimi.reimi_app.application.command;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
 import com.reimi.reimi_app.domain.model.user.UserId;
 
-public record SendMessageCommand(
+public record SendTextMessageCommand(
     ChatRoomId chatRoomId,
     UserId senderId,
     String text

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MessageUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MessageUseCase.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.application.usecase;
+
+import com.reimi.reimi_app.application.command.SendTextMessageCommand;
+
+public interface MessageUseCase {
+    void sendText(SendTextMessageCommand command);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/chatroom/ChatRoom.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/chatroom/ChatRoom.java
@@ -35,6 +35,10 @@ public class ChatRoom {
         );
     }
 
+    public boolean canSend(UserId userId, Match match) {
+        return match.isParticipant(userId);
+    }
+
     public ChatRoomId getId() { return id; }
     public MatchId getMatchId() { return matchId; }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/chatroom/ChatRoom.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/chatroom/ChatRoom.java
@@ -1,6 +1,8 @@
 package com.reimi.reimi_app.domain.model.chatroom;
 
+import com.reimi.reimi_app.domain.model.match.Match;
 import com.reimi.reimi_app.domain.model.match.MatchId;
+import com.reimi.reimi_app.domain.model.user.UserId;
 
 public class ChatRoom {
 
@@ -22,6 +24,17 @@ public class ChatRoom {
             matchId
         );
     }
+
+    public static ChatRoom reconstruct(
+        ChatRoomId id,
+        MatchId matchId
+    ) {
+        return new ChatRoom(
+                id,
+                matchId
+        );
+    }
+
     public ChatRoomId getId() { return id; }
     public MatchId getMatchId() { return matchId; }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/match/Match.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/match/Match.java
@@ -53,6 +53,10 @@ public class Match {
         );
     }
 
+    public boolean isParticipant(UserId userId) {
+        return userAId.equals(userId) || userBId.equals(userId);
+    }
+
     public MatchId getId() { return id; }
     public UserId getUserAId() { return userAId; }
     public UserId getUserBId() { return userBId; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/match/Match.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/match/Match.java
@@ -39,6 +39,20 @@ public class Match {
         );
     }
 
+    public static Match reconstruct(
+        MatchId id,
+        UserId userAId,
+        UserId userBId,
+        boolean isActive
+    ) {
+        return new Match(
+                id,
+                userAId,
+                userBId,
+                isActive
+        );
+    }
+
     public MatchId getId() { return id; }
     public UserId getUserAId() { return userAId; }
     public UserId getUserBId() { return userBId; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
@@ -8,18 +8,18 @@ public class Message {
     private final MessageId id;
     private final ChatRoomId chatRoomId;
     private final UserId senderId;
-    private final MessageContent content;
+    private final MessageContent messageContent;
 
     private Message(
         MessageId id,
         ChatRoomId chatRoomId,
         UserId senderId,
-        MessageContent content
+        MessageContent messageContent
     ) {
         this.id = id;
         this.chatRoomId = chatRoomId;
         this.senderId = senderId;
-        this.content = content;
+        this.messageContent = messageContent;
     }
 
     public static Message createText(
@@ -28,18 +28,19 @@ public class Message {
         String text
     ) {
         MessageId messageId = MessageId.generate();
-        MessageText content = MessageText.create(messageId, text);
+        MessageText messageText = MessageText.create(messageId, text);
         return new Message(
             messageId,
             chatRoomId,
             senderId,
-            content
+            messageText
         );
     }
 
     public MessageId getId() { return id; }
     public ChatRoomId getChatRoomId() { return chatRoomId; }
     public UserId getSenderId() { return senderId; }
-    public MessageType getMessageType() { return content.getMessageType(); }
+    public MessageContent getMessageContent() { return messageContent; }
+    public MessageType getMessageType() { return messageContent.getMessageType(); }
 
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
@@ -8,21 +8,18 @@ public class Message {
     private final MessageId id;
     private final ChatRoomId chatRoomId;
     private final UserId senderId;
-    private final MessageType messageType;
-    private final MessageText messageText;
+    private final MessageContent content;
 
     private Message(
         MessageId id,
         ChatRoomId chatRoomId,
         UserId senderId,
-        MessageType messageType,
-        MessageText messageText
+        MessageContent content
     ) {
         this.id = id;
         this.chatRoomId = chatRoomId;
         this.senderId = senderId;
-        this.messageType = messageType;
-        this.messageText = messageText;
+        this.content = content;
     }
 
     public static Message createText(
@@ -31,20 +28,18 @@ public class Message {
         String text
     ) {
         MessageId messageId = MessageId.generate();
-        MessageText messageText = MessageText.create(messageId, text);
+        MessageText content = MessageText.create(messageId, text);
         return new Message(
             messageId,
             chatRoomId,
             senderId,
-            MessageType.TEXT,
-            messageText
+            content
         );
     }
 
     public MessageId getId() { return id; }
     public ChatRoomId getChatRoomId() { return chatRoomId; }
     public UserId getSenderId() { return senderId; }
-    public MessageType getMessageType() { return messageType; }
-    public MessageText getMessageText() { return messageText; }
+    public MessageType getMessageType() { return content.getMessageType(); }
 
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
@@ -1,0 +1,50 @@
+package com.reimi.reimi_app.domain.model.message;
+
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public class Message {
+
+    private final MessageId id;
+    private final ChatRoomId chatRoomId;
+    private final UserId senderId;
+    private final MessageType messageType;
+    private final MessageText messageText;
+
+    private Message(
+        MessageId id,
+        ChatRoomId chatRoomId,
+        UserId senderId,
+        MessageType messageType,
+        MessageText messageText
+    ) {
+        this.id = id;
+        this.chatRoomId = chatRoomId;
+        this.senderId = senderId;
+        this.messageType = messageType;
+        this.messageText = messageText;
+    }
+
+    public static Message createText(
+        ChatRoomId chatRoomId,
+        UserId senderId,
+        String text
+    ) {
+        MessageId messageId = MessageId.generate();
+        MessageText messageText = MessageText.create(messageId, text);
+        return new Message(
+            messageId,
+            chatRoomId,
+            senderId,
+            MessageType.TEXT,
+            messageText
+        );
+    }
+
+    public MessageId getId() { return id; }
+    public ChatRoomId getChatRoomId() { return chatRoomId; }
+    public UserId getSenderId() { return senderId; }
+    public MessageType getMessageType() { return messageType; }
+    public MessageText getMessageText() { return messageText; }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageContent.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageContent.java
@@ -1,0 +1,5 @@
+package com.reimi.reimi_app.domain.model.message;
+
+public interface MessageContent {
+    MessageType getMessageType();
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageId.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageId.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.domain.model.message;
+
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.shared.identity.UuidGenerator;
+
+public record MessageId(UUID value) {
+    public static MessageId generate() {
+        return new MessageId(UuidGenerator.generate());
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageText.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageText.java
@@ -1,6 +1,6 @@
 package com.reimi.reimi_app.domain.model.message;
 
-public class MessageText {
+public class MessageText implements MessageContent {
 
     private final MessageId messageId;
     private final String text;
@@ -21,6 +21,11 @@ public class MessageText {
             messageId,
             text
         );
+    }
+
+    @Override
+    public MessageType getMessageType() {
+        return MessageType.TEXT;
     }
 
     public MessageId getMessageId() { return messageId; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageText.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageText.java
@@ -1,0 +1,28 @@
+package com.reimi.reimi_app.domain.model.message;
+
+public class MessageText {
+
+    private final MessageId messageId;
+    private final String text;
+
+    private MessageText(
+        MessageId messageId,
+        String text
+    ) {
+        this.messageId = messageId;
+        this.text = text;
+    }
+
+    public static MessageText create(
+        MessageId messageId,
+        String text
+    ) {
+        return new MessageText(
+            messageId,
+            text
+        );
+    }
+
+    public MessageId getMessageId() { return messageId; }
+    public String getText() { return text; }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageType.java
@@ -1,0 +1,17 @@
+package com.reimi.reimi_app.domain.model.message;
+
+public enum MessageType {
+    TEXT("テキスト"),
+    IMAGE("イメージ画像"),
+    STAMP("スタンプ");
+
+    private final String label;
+
+    MessageType(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/ChatRoomRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/ChatRoomRepository.java
@@ -1,8 +1,13 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.Optional;
+
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
 
 public interface ChatRoomRepository {
+
+    Optional<ChatRoom> findByChatRoomId(ChatRoomId chatRoomId);
 
     void save(ChatRoom chatRoom);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MatchRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MatchRepository.java
@@ -1,8 +1,10 @@
 package com.reimi.reimi_app.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.reimi.reimi_app.domain.model.match.Match;
+import com.reimi.reimi_app.domain.model.match.MatchId;
 import com.reimi.reimi_app.domain.model.user.UserId;
 
 public interface MatchRepository {
@@ -12,4 +14,6 @@ public interface MatchRepository {
     void save(Match match);
 
     List<UserId> findMatchedUserIdsByUserId(UserId userId);
+
+    Optional<Match> findByMatchId(MatchId matchId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MessageRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MessageRepository.java
@@ -1,0 +1,8 @@
+package com.reimi.reimi_app.domain.repository;
+
+import com.reimi.reimi_app.domain.model.message.Message;
+import com.reimi.reimi_app.domain.model.message.MessageText;
+
+public interface MessageRepository {
+    void save(Message message, MessageText messageText);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MessageRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MessageRepository.java
@@ -1,8 +1,7 @@
 package com.reimi.reimi_app.domain.repository;
 
 import com.reimi.reimi_app.domain.model.message.Message;
-import com.reimi.reimi_app.domain.model.message.MessageText;
 
 public interface MessageRepository {
-    void save(Message message, MessageText messageText);
+    void save(Message message);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageContentEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageContentEntity.java
@@ -1,0 +1,30 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "message_contents")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "message_type")
+public abstract class MessageContentEntity {
+
+    @Id
+    @Column(name = "message_id", nullable = false, unique = true)
+    private UUID messageId;
+
+    @MapsId
+    @OneToOne(optional = false)
+    @JoinColumn(name = "message_id", nullable = false, updatable = false, insertable = false)
+    protected MessageEntity message;
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageEntity.java
@@ -1,0 +1,49 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.model.message.MessageType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "messages")
+public class MessageEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "chat_room_id", nullable = false)
+    private UUID chatRoomId;
+
+    @Column(name = "sender_id", nullable = false)
+    private UUID senderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", nullable = false)
+    private MessageType messageType;
+
+    @Column(name = "sent_at", nullable = false, updatable = false)
+    private OffsetDateTime sentAt;
+
+    @PrePersist
+    protected void prePersist() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        this.sentAt = now;
+    }
+
+    public MessageEntity() {}
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageEntity.java
@@ -4,13 +4,11 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
-import com.reimi.reimi_app.domain.model.message.MessageType;
-
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -32,10 +30,6 @@ public class MessageEntity {
     @Column(name = "sender_id", nullable = false)
     private UUID senderId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "message_type", nullable = false)
-    private MessageType messageType;
-
     @Column(name = "sent_at", nullable = false, updatable = false)
     private OffsetDateTime sentAt;
 
@@ -44,6 +38,14 @@ public class MessageEntity {
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         this.sentAt = now;
     }
+
+    @OneToOne(
+        mappedBy = "message",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        optional = false
+    )
+    private MessageContentEntity messageContent;
 
     public MessageEntity() {}
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageTextEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageTextEntity.java
@@ -1,13 +1,8 @@
 package com.reimi.reimi_app.infrastructure.persistence.entity;
 
-import java.util.UUID;
-
 import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,17 +11,16 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "message_texts")
-public class MessageTextEntity {
+@DiscriminatorValue("TEXT")
+public class MessageTextEntity extends MessageContentEntity {
 
-    @Id
-    @Column(name = "message_id", nullable = false, updatable = false)
-    private UUID messageId;
-
-    @MapsId
-    @OneToOne
-    @JoinColumn(name = "message_id", nullable = false, updatable = false, insertable = false)
-    private MessageEntity message;
-
-    @Column(name = "text", nullable = false)
+    @Column(name = "text", nullable = false, updatable = false)
     private String text;
+
+    protected MessageTextEntity() {}
+
+    public MessageTextEntity(MessageEntity message, String text) {
+        this.message = message;
+        this.text = text;
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageTextEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageTextEntity.java
@@ -1,0 +1,32 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "message_texts")
+public class MessageTextEntity {
+
+    @Id
+    @Column(name = "message_id", nullable = false, updatable = false)
+    private UUID messageId;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "message_id", nullable = false, updatable = false, insertable = false)
+    private MessageEntity message;
+
+    @Column(name = "text", nullable = false)
+    private String text;
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ChatRoomMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ChatRoomMapper.java
@@ -1,10 +1,19 @@
 package com.reimi.reimi_app.infrastructure.persistence.mapper;
 
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
+import com.reimi.reimi_app.domain.model.match.MatchId;
 import com.reimi.reimi_app.infrastructure.persistence.entity.ChatRoomEntity;
 import com.reimi.reimi_app.infrastructure.persistence.entity.MatchEntity;
 
 public class ChatRoomMapper {
+
+    public static ChatRoom toDomain(ChatRoomEntity entity) {
+        return ChatRoom.reconstruct(
+                new ChatRoomId(entity.getId()),
+                new MatchId(entity.getMatchId())
+        );
+    }
 
     public static ChatRoomEntity toEntity(ChatRoom chatRoom, MatchEntity matchEntity) {
         ChatRoomEntity entity = new ChatRoomEntity();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/MatchMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/MatchMapper.java
@@ -1,9 +1,20 @@
 package com.reimi.reimi_app.infrastructure.persistence.mapper;
 
 import com.reimi.reimi_app.domain.model.match.Match;
+import com.reimi.reimi_app.domain.model.match.MatchId;
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.persistence.entity.MatchEntity;
 
 public class MatchMapper {
+
+    public static Match toDomain(MatchEntity entity) {
+        return Match.reconstruct(
+                new MatchId(entity.getId()),
+                new UserId(entity.getUserAId()),
+                new UserId(entity.getUserBId()),
+                entity.isActive()
+        );
+    }
 
     public static MatchEntity toEntity(Match match) {
         MatchEntity entity = new MatchEntity();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/MessageMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/MessageMapper.java
@@ -1,0 +1,23 @@
+package com.reimi.reimi_app.infrastructure.persistence.mapper;
+
+import com.reimi.reimi_app.domain.model.message.Message;
+import com.reimi.reimi_app.domain.model.message.MessageText;
+import com.reimi.reimi_app.infrastructure.persistence.entity.MessageEntity;
+import com.reimi.reimi_app.infrastructure.persistence.entity.MessageTextEntity;
+
+public class MessageMapper {
+
+    public static MessageEntity toTextEntity(Message message) {
+        MessageEntity entity = new MessageEntity();
+        entity.setId(message.getId().value());
+        entity.setChatRoomId(message.getChatRoomId().value());
+        entity.setSenderId(message.getSenderId().value());
+
+        MessageText messageText = (MessageText) message.getMessageContent();
+        MessageTextEntity messageTextEntity = new MessageTextEntity(entity, messageText.getText());
+
+        entity.setMessageContent(messageTextEntity);
+
+        return entity;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/chatroom/ChatRoomRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/chatroom/ChatRoomRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.chatroom;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
 import com.reimi.reimi_app.domain.repository.ChatRoomRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.MatchEntity;
 import com.reimi.reimi_app.infrastructure.persistence.mapper.ChatRoomMapper;
@@ -21,6 +24,12 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     ) {
         this.jpaChatRoomRepository = jpaChatRoomRepository;
         this.jpaMatchRepository = jpaMatchRepository;
+    }
+    @Override
+    public Optional<ChatRoom> findByChatRoomId(ChatRoomId chatRoomId) {
+        return jpaChatRoomRepository
+            .findById(chatRoomId.value())
+            .map(ChatRoomMapper::toDomain);
     }
 
     @Override

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/MatchRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/MatchRepositoryImpl.java
@@ -1,10 +1,12 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.match;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.domain.model.match.Match;
+import com.reimi.reimi_app.domain.model.match.MatchId;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.MatchRepository;
 import com.reimi.reimi_app.infrastructure.persistence.mapper.MatchMapper;
@@ -40,4 +42,12 @@ public class MatchRepositoryImpl implements MatchRepository {
             .map(UserId::new)
             .toList();
     }
+
+    @Override
+    public Optional<Match> findByMatchId(MatchId matchId) {
+        return jpaMatchRepository
+            .findById(matchId.value())
+            .map(MatchMapper::toDomain);
+    }
+
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/JpaMessageRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/JpaMessageRepository.java
@@ -1,0 +1,10 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.message;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.MessageEntity;
+
+public interface JpaMessageRepository extends JpaRepository<MessageEntity, UUID> {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/MessageRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/MessageRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.message;
+
+import org.springframework.stereotype.Repository;
+
+import com.reimi.reimi_app.domain.model.message.Message;
+import com.reimi.reimi_app.domain.repository.MessageRepository;
+import com.reimi.reimi_app.infrastructure.persistence.entity.MessageEntity;
+import com.reimi.reimi_app.infrastructure.persistence.mapper.MessageMapper;
+
+@Repository
+public class MessageRepositoryImpl implements MessageRepository {
+
+    private final JpaMessageRepository jpaMessageRepository;
+
+    private MessageRepositoryImpl(
+        JpaMessageRepository jpaMessageRepository
+    ) {
+        this.jpaMessageRepository = jpaMessageRepository;
+    }
+
+    @Override
+    public void save(Message message) {
+        MessageEntity messageEntity = MessageMapper.toTextEntity(message);
+        jpaMessageRepository.save(messageEntity);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/MessageRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/MessageRepositoryImpl.java
@@ -12,7 +12,7 @@ public class MessageRepositoryImpl implements MessageRepository {
 
     private final JpaMessageRepository jpaMessageRepository;
 
-    private MessageRepositoryImpl(
+    public MessageRepositoryImpl(
         JpaMessageRepository jpaMessageRepository
     ) {
         this.jpaMessageRepository = jpaMessageRepository;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MessageUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MessageUseCaseImpl.java
@@ -24,7 +24,7 @@ public class MessageUseCaseImpl implements MessageUseCase {
     private final ChatRoomRepository chatRoomRepository;
     private final MatchRepository matchRepository;
 
-    private MessageUseCaseImpl(
+    public MessageUseCaseImpl(
         MessageRepository messageRepository,
         ChatRoomRepository chatRoomRepository,
         MatchRepository matchRepository

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MessageUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MessageUseCaseImpl.java
@@ -1,0 +1,62 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import org.springframework.stereotype.Service;
+
+import com.reimi.reimi_app.application.command.SendTextMessageCommand;
+import com.reimi.reimi_app.application.exception.client.AccessDeniedException;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.usecase.MessageUseCase;
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
+import com.reimi.reimi_app.domain.model.match.Match;
+import com.reimi.reimi_app.domain.model.message.Message;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.repository.ChatRoomRepository;
+import com.reimi.reimi_app.domain.repository.MatchRepository;
+import com.reimi.reimi_app.domain.repository.MessageRepository;
+
+import jakarta.transaction.Transactional;
+
+@Service
+@Transactional
+public class MessageUseCaseImpl implements MessageUseCase {
+
+    private final MessageRepository messageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MatchRepository matchRepository;
+
+    private MessageUseCaseImpl(
+        MessageRepository messageRepository,
+        ChatRoomRepository chatRoomRepository,
+        MatchRepository matchRepository
+    ) {
+        this.messageRepository = messageRepository;
+        this.chatRoomRepository = chatRoomRepository;
+        this.matchRepository = matchRepository;
+
+    }
+
+    @Override
+    public void sendText(SendTextMessageCommand command) {
+
+        ChatRoom chatRoom = chatRoomRepository.findByChatRoomId(command.chatRoomId())
+            .orElseThrow(() -> new ResourceNotFoundException("チャットルーム"));
+
+        Match match = matchRepository.findByMatchId(chatRoom.getMatchId())
+            .orElseThrow(() -> new ResourceNotFoundException("マッチング"));
+
+        UserId senderId = command.senderId();
+
+        // マッチング成立した同士のユーザーか検証
+        if (!chatRoom.canSend(senderId, match)) {
+            throw new AccessDeniedException();
+        }
+
+        Message message = Message.createText(
+            chatRoom.getId(),
+            senderId,
+            command.text()
+        );
+
+        messageRepository.save(message);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
@@ -1,0 +1,58 @@
+package com.reimi.reimi_app.infrastructure.web.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reimi.reimi_app.application.command.SendTextMessageCommand;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.usecase.MessageUseCase;
+import com.reimi.reimi_app.application.usecase.UserUseCase;
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.infrastructure.web.dto.request.SendMessageRequest;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+
+@RestController
+@RequestMapping("/chatRooms")
+public class MessageController {
+
+    private final MessageUseCase messageUseCase;
+    private final UserUseCase userUseCase;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+
+    public MessageController(
+        MessageUseCase messageUseCase,
+        UserUseCase userUseCase,
+        AuthenticatedUserProvider authenticatedUserProvider
+    ) {
+        this.messageUseCase = messageUseCase;
+        this.userUseCase = userUseCase;
+        this.authenticatedUserProvider = authenticatedUserProvider;
+    }
+
+    @PostMapping("/{chatRoomId}/messages")
+    public ResponseEntity<Void> sendTextMessage(
+        @PathVariable("chatRoomId") ChatRoomId chatRoomId,
+        @RequestBody SendMessageRequest request
+    ) {
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+        User user = userUseCase.getUser(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        messageUseCase.sendText(
+            new SendTextMessageCommand(
+                chatRoomId,
+                user.getId(),
+                request.text()
+            )
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
@@ -17,7 +17,8 @@ import com.reimi.reimi_app.infrastructure.web.dto.request.SendMessageRequest;
 import com.reimi.reimi_app.infrastructure.web.openapi.message.SendTextMessageApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.web.bind.annotation.RequestBody;
+
 
 @RestController
 @RequestMapping("/chatRooms")

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
@@ -14,6 +14,7 @@ import com.reimi.reimi_app.application.usecase.UserUseCase;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.infrastructure.web.dto.request.SendMessageRequest;
+import com.reimi.reimi_app.infrastructure.web.openapi.message.SendTextMessageApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -37,6 +38,7 @@ public class MessageController {
     }
 
     @PostMapping("/{chatRoomId}/messages")
+    @SendTextMessageApi
     public ResponseEntity<Void> sendTextMessage(
         @PathVariable("chatRoomId") ChatRoomId chatRoomId,
         @RequestBody SendMessageRequest request

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/converter/StringToChatRoomIdConverter.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/converter/StringToChatRoomIdConverter.java
@@ -1,0 +1,16 @@
+package com.reimi.reimi_app.infrastructure.web.converter;
+
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoomId;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class StringToChatRoomIdConverter implements Converter<String, ChatRoomId> {
+
+    @Override
+    public ChatRoomId convert(String source) {
+        return new ChatRoomId(UUID.fromString(source));
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
@@ -1,5 +1,12 @@
 package com.reimi.reimi_app.infrastructure.web.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
 public record SendMessageRequest(
+
+    @NotBlank(message = "メッセージは必須です")
+    @Schema(description = "テキストメッセージ", example = "よろしくお願いします！")
     String text
+
 ) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
@@ -3,6 +3,7 @@ package com.reimi.reimi_app.infrastructure.web.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "メッセージ送信用リクエスト")
 public record SendMessageRequest(
 
     @NotBlank(message = "メッセージは必須です")

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
@@ -1,0 +1,5 @@
+package com.reimi.reimi_app.infrastructure.web.dto.request;
+
+public record SendMessageRequest(
+    String text
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java
@@ -1,0 +1,121 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.message;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "チャットルームにメッセージ送信",
+    description = "マッチング成立後に作成されるチャットルームにメッセージを送信できるAPI",
+    tags = { "ChatRoom" },
+    requestBody = @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = "application/json"
+        )
+    )
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "メッセージ送信が成功",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "無効なリクエスト",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INVALID_REQUEST",
+                    "message": "メッセージは必須です"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "403",
+        description = "権限エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "ACCESS_DENIED",
+                    "message": "この操作を行う権限がありません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "チャットルームが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface SendTextMessageApi {
+}


### PR DESCRIPTION
## 概要

API名：チャットルームにメッセージ送信

種別：API開発

関連Issue：

- #104 

close #104 

## API設計

### 【やったこと・開発メモ】

- ドメイン層
  - Messageドメインモデルを作成
    - 不変オブジェクトとして定義
    - createTextメソッドを作成
    - Getterを定義
  - MatchとChatRoomドメインモデルにメソッド追加
    - DBから取得してきたエンティティをドメインモデルに復元する
  - メッセージタイプをenum（列挙型）で定義
  - メッセージIDを不変なUUIDの値として作成される様にする
  - MessageTextドメインモデルを作成
    - Messageドメインモデルと同じ
  - Messageが１つのMessageContentを持つ形にする
    - メッセージタイプを分けれる様に抽象クラスを作成
    - MessageTextを実装クラスとして定義
  - メッセージリポジトリのインターフェイスを作成
    - メッセージが登録（保存）されるメソッド
  - マッチングリポジトリとチャットルームリポジトリのインターフェイスにメソッド追加
    - IDからドメインモデルを取得してくるメソッド
  
- アプリケーション層
  - Commandの作成
  - メッセージのユースケースインターフェイスを作成
    - テキストメッセージ送信の業務操作を定義
 
- インフラストラクチャ層
  - Messageエンティティの作成
    - 送信日時のカラムは自動生成される
    - その他必要なアノテーションとカラム定義
    - 必ずMessageContentエンティティ（抽象クラス）と１対１で紐づく
  - MessageTextエンティティの作成
    - Messageと１対１で紐づく
    - `@DiscriminatorValue`アノテーションによって、message_typeを擬似的に表現
      - テキストメッセージの場合：`@DiscriminatorValue("TEXT")`
    - その他必要なアノテーションとカラム定義
  - MessageContentエンティティの作成
    - Messageと１対１で結びつくコンテンツ（タイプ）は複数存在するので、共通概念として抽象クラスを定義
    - 親のMessageIDをそのまま主キーとして使うため`@MapsId`を付与
    - `＠DiscriminatorColumn`アノテーションを付与することで、識別子（TEXT / IMAGE / FILE）を表現できる
  - MessageMapperの作成
    - エンティティへの変換
      - MessageとMessageText両方
  - ChatRoomMapperとMatchMapperにメソッド追加
    - ドメインモデルへの変換
  - メッセージJPA Repositoryを使うためのインターフェイス作成
  - メッセージリポジトリの実装クラスを作成
    - オーバーライドメソッドを定義
      - エンティティに変換して保存
  - マッチングとチャットルームのリポジトリ実装クラスにオーバーライドメソッドを定義
    - IDをUUIDに変換してエンティティを取得してくる
    - ドメインモデルに変換
  - メッセージユースケースの実装クラスを作成
    - CommandからIDよりチャットルームとマッチングのドメインモデルを取得
    - マッチング成立した同士のユーザーか検証
      - ドメインモデルに検証ロジックを作成
    - Matchに保存されているUserIdであった場合にメッセージ作成
  - リクエストDTO作成
  - Controllerの作成
    - パスパラメーターでチャットルームIDを受け取る
    - リクエストボディでメッセージのテキストを取得
  - 定義アノテーションを作成
  - String型のチャットルームIDをChatRoomId型に変換するConverterを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | チャットルームにメッセージ送信 |
| URL | /chatRooms/{chatRoomId}/messages |
| HTTPメソッド | POST |
| ステータスコード | 201 / 400 / 401 / 403 / 404 / 500 |

### 【リクエスト】

```json
{
  "text": string
}
```

### 【レスポンス】

特になし

### 【追加・変更したエンティティ】

- エンティティ名①：Message
  - 役割：チャット時のメッセージに関する情報を格納する
  - ドメインルール：
    - １つのコンテンツ（メッセージ）と紐づく
    - チャットルーム/マッチングに紐づている人しかメッセージが送信できない
 
 - エンティティ名②：MessageContent
  - 役割：メッセージに紐づくコンテンツの抽象エンティティクラス
  - ドメインルール：
    - メッセージと１対１で紐づく
    - メッセージ種別の必須項目

- エンティティ名③：MessageText
  - 役割：message_typeがTEXTの情報を格納する
  - ドメインルール：文字列が必須

### 【追加・変更した設定ファイル】

- reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendTextMessageCommand.java
- reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/MessageUseCase.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/chatroom/ChatRoom.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/match/Match.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/Message.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageContent.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageId.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageText.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/model/message/MessageType.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/ChatRoomRepository.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MatchRepository.java
- reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/MessageRepository.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageContentEntity.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageEntity.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/MessageTextEntity.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ChatRoomMapper.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/MatchMapper.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/MessageMapper.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/chatroom/ChatRoomRepositoryImpl.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/match/MatchRepositoryImpl.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/JpaMessageRepository.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/message/MessageRepositoryImpl.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/MessageUseCaseImpl.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/converter/StringToChatRoomIdConverter.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendMessageRequest.java
- reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java

## 参考資料

- JPAの継承戦略（JOINED）
  - https://stackoverflow.com/questions/16772370/when-to-use-discriminatorvalue-annotation-in-hibernate

## その他・補足事項

- メッセージのリアルタイム通信は別タスクとして行う
