### PR TITLE
【API設計】ユーザーレインボーいいねAPIの設計（/rainbowLikes/{userId}）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendRainbowLikeCommand.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/SendRainbowLikeCommand.java
@@ -1,0 +1,8 @@
+package com.reimi.reimi_app.application.command;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public record SendRainbowLikeCommand(
+    UserId toUserId,
+    String message
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/LikeAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/LikeAlreadyExistsException.java
@@ -8,7 +8,7 @@ public class LikeAlreadyExistsException extends ClientErrorException {
     public LikeAlreadyExistsException() {
         super(
             "LIKE_ALREADY_SENT",
-            "既にいいねが送られています",
+            "既にいいねを送信しています",
             HttpStatus.CONFLICT
         );
     }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/RainbowLikeAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/RainbowLikeAlreadyExistsException.java
@@ -8,7 +8,7 @@ public class RainbowLikeAlreadyExistsException extends ClientErrorException {
     public RainbowLikeAlreadyExistsException() {
         super(
             "RAINBOW_LIKE_ALREADY_SENT",
-            "既にレインボーいいねが送られています",
+            "既にレインボーいいねを送信しています",
             HttpStatus.CONFLICT
         );
     }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/RainbowLikeAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/RainbowLikeAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.application.exception.client;
+
+import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
+
+public class RainbowLikeAlreadyExistsException extends ClientErrorException {
+    public RainbowLikeAlreadyExistsException() {
+        super(
+            "RAINBOW_LIKE_ALREADY_SENT",
+            "既にレインボーいいねが送られています",
+            HttpStatus.CONFLICT
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/RainbowLikeUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/RainbowLikeUseCase.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.application.usecase;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public interface RainbowLikeUseCase {
+    void rainbowLikeUser(UserId toUserId, String message);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/RainbowLikeUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/RainbowLikeUseCase.java
@@ -1,7 +1,7 @@
 package com.reimi.reimi_app.application.usecase;
 
-import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.application.command.SendRainbowLikeCommand;
 
 public interface RainbowLikeUseCase {
-    void rainbowLikeUser(UserId toUserId, String message);
+    void rainbowLikeUser(SendRainbowLikeCommand command);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/rainbowlike/RainbowLike.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/rainbowlike/RainbowLike.java
@@ -1,0 +1,46 @@
+package com.reimi.reimi_app.domain.model.rainbowlike;
+
+import com.reimi.reimi_app.application.exception.client.InvalidRequestException;
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public class RainbowLike {
+
+    private final RainbowLikeId id;
+    private final UserId fromUserId;
+    private final UserId toUserId;
+    private final String message;
+
+    private RainbowLike(
+        RainbowLikeId id,
+        UserId fromUserId,
+        UserId toUserId,
+        String message
+    ) {
+        if (fromUserId.equals(toUserId)) {
+            throw new InvalidRequestException("ユーザー自身にはレインボーいいねできません");
+        }
+        this.id = id;
+        this.fromUserId = fromUserId;
+        this.toUserId = toUserId;
+        this.message = message;
+    }
+
+    public static RainbowLike create(
+        UserId fromUserId,
+        UserId toUserId,
+        String message
+    ) {
+        RainbowLikeId rainbowLikeId = RainbowLikeId.generate();
+        return new RainbowLike(
+            rainbowLikeId,
+            fromUserId,
+            toUserId,
+            message
+        );
+    }
+
+    public RainbowLikeId getId() { return id; }
+    public UserId getFromUserId() { return fromUserId; }
+    public UserId getToUserId() { return toUserId; }
+    public String getMessage() { return message; }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/rainbowlike/RainbowLikeId.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/rainbowlike/RainbowLikeId.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.domain.model.rainbowlike;
+
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.shared.identity.UuidGenerator;
+
+public record RainbowLikeId(UUID value) {
+    public static RainbowLikeId generate() {
+        return new RainbowLikeId(UuidGenerator.generate());
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/LikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/LikeRepository.java
@@ -1,15 +1,11 @@
 package com.reimi.reimi_app.domain.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.reimi.reimi_app.domain.model.like.Like;
-import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 
 public interface LikeRepository {
-
-    Optional<User> findUserByUserId(UserId userId);
 
     boolean exists(UserId fromUserId, UserId toUserId);
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/RainbowLikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/RainbowLikeRepository.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.domain.repository;
+
+import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public interface RainbowLikeRepository {
+
+    boolean exists(UserId fromUserId, UserId toUserId);
+
+    void save(RainbowLike rainbowLike);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository {
     boolean existsByEmail(String email);
 
     void save(User user);
+
+    Optional<User> findUserByUserId(UserId userId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/RainbowLikeEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/RainbowLikeEntity.java
@@ -1,0 +1,53 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+    name = "rainbow_likes",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_rainbow_likes_from_to",
+            columnNames = { "from_user_id", "to_user_id" }
+        )
+    }
+)
+public class RainbowLikeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "from_user_id", nullable = false)
+    private UUID fromUserId;
+
+    @Column(name = "to_user_id", nullable = false)
+    private UUID toUserId;
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        this.createdAt = now;
+    }
+
+    public RainbowLikeEntity() {}
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/RainbowLikeMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/RainbowLikeMapper.java
@@ -1,0 +1,17 @@
+package com.reimi.reimi_app.infrastructure.persistence.mapper;
+
+import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
+import com.reimi.reimi_app.infrastructure.persistence.entity.RainbowLikeEntity;
+
+public class RainbowLikeMapper {
+
+        public static RainbowLikeEntity toEntity(RainbowLike rainbowLike) {
+        RainbowLikeEntity entity = new RainbowLikeEntity();
+        entity.setId(rainbowLike.getId().value());
+        entity.setFromUserId(rainbowLike.getFromUserId().value());
+        entity.setToUserId(rainbowLike.getToUserId().value());
+        entity.setMessage(rainbowLike.getMessage());
+
+        return entity;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
@@ -1,37 +1,23 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.like;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.domain.model.like.Like;
-import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.LikeRepository;
 import com.reimi.reimi_app.infrastructure.persistence.mapper.LikeMapper;
-import com.reimi.reimi_app.infrastructure.persistence.mapper.UserMapper;
-import com.reimi.reimi_app.infrastructure.persistence.repository.user.JpaUserRepository;
 
 @Repository
 public class LikeRepositoryImpl implements LikeRepository {
 
     private final JpaLikeRepository jpaLikeRepository;
-    private final JpaUserRepository jpaUserRepository;
 
     public LikeRepositoryImpl(
-        JpaLikeRepository jpaLikeRepository,
-        JpaUserRepository jpaUserRepository
+        JpaLikeRepository jpaLikeRepository
     ) {
         this.jpaLikeRepository = jpaLikeRepository;
-        this.jpaUserRepository = jpaUserRepository;
-    }
-
-    @Override
-    public Optional<User> findUserByUserId(UserId userId) {
-        return jpaUserRepository
-            .findById(userId.value())
-            .map(UserMapper::toDomain);
     }
 
     @Override

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/JpaRainbowLikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/JpaRainbowLikeRepository.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.rainbowlike;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.RainbowLikeEntity;
+
+public interface JpaRainbowLikeRepository extends JpaRepository<RainbowLikeEntity, UUID> {
+    boolean existsByFromUserIdAndToUserId(UUID fromUserId, UUID toUserId);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/RainbowLikeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/RainbowLikeRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.rainbowlike;
+
+import org.springframework.stereotype.Repository;
+
+import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.repository.RainbowLikeRepository;
+import com.reimi.reimi_app.infrastructure.persistence.mapper.RainbowLikeMapper;
+
+@Repository
+public class RainbowLikeRepositoryImpl implements RainbowLikeRepository {
+
+    private final JpaRainbowLikeRepository jpaRainbowLikeRepository;
+
+    public RainbowLikeRepositoryImpl(
+        JpaRainbowLikeRepository jpaRainbowLikeRepository
+    ) {
+        this.jpaRainbowLikeRepository = jpaRainbowLikeRepository;
+    }
+
+    @Override
+    public boolean exists(UserId fromUserId, UserId toUserId) {
+        return jpaRainbowLikeRepository.existsByFromUserIdAndToUserId(
+            fromUserId.value(),
+            toUserId.value()
+        );
+    }
+
+    @Override
+    public void save(RainbowLike rainbowLike) {
+        jpaRainbowLikeRepository.save(RainbowLikeMapper.toEntity(rainbowLike));
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
@@ -61,4 +61,11 @@ public class UserRepositoryImpl implements UserRepository {
     public void save(User user) {
         jpaUserRepository.save(UserMapper.toEntity(user));
     }
+
+    @Override
+    public Optional<User> findUserByUserId(UserId userId) {
+        return jpaUserRepository
+            .findById(userId.value())
+            .map(UserMapper::toDomain);
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -70,7 +70,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
 
         // いいねとレインボーいいねを両方送ることはできない
         // 既にレインボーいいねが送信されている場合は重複エラーとする
-        if (rainbowLikeRepository.exists(toUserId, fromUserId)) {
+        if (rainbowLikeRepository.exists(fromUserId, toUserId)) {
             throw new RainbowLikeAlreadyExistsException();
         }
         // 既にレインボーいいねを受信している場合は無効なリクエストとする

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.reimi.reimi_app.application.exception.client.InvalidRequestException;
 import com.reimi.reimi_app.application.exception.client.LikeAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.MatchAlreadyExistsException;
+import com.reimi.reimi_app.application.exception.client.RainbowLikeAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.application.usecase.LikeUseCase;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
@@ -16,6 +18,7 @@ import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.ChatRoomRepository;
 import com.reimi.reimi_app.domain.repository.LikeRepository;
+import com.reimi.reimi_app.domain.repository.RainbowLikeRepository;
 import com.reimi.reimi_app.domain.repository.MatchRepository;
 import com.reimi.reimi_app.domain.repository.UserRepository;
 import com.reimi.reimi_app.infrastructure.storage.image.ImageStorageComponent;
@@ -27,6 +30,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
 
     private final UserRepository userRepository;
     private final LikeRepository likeRepository;
+    private final RainbowLikeRepository rainbowLikeRepository;
     private final MatchRepository matchRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ImageStorageComponent imageStorage;
@@ -35,6 +39,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
     public LikeUseCaseImpl(
         UserRepository userRepository,
         LikeRepository likeRepository,
+        RainbowLikeRepository rainbowLikeRepository,
         MatchRepository matchRepository,
         ChatRoomRepository chatRoomRepository,
         ImageStorageComponent imageStorage,
@@ -42,6 +47,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
     ) {
         this.userRepository = userRepository;
         this.likeRepository = likeRepository;
+        this.rainbowLikeRepository = rainbowLikeRepository;
         this.matchRepository = matchRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.imageStorage = imageStorage;
@@ -62,6 +68,17 @@ public class LikeUseCaseImpl implements LikeUseCase {
 
         UserId fromUserId = fromUser.getId();
 
+        // いいねとレインボーいいねを両方送ることはできない
+        // 既にレインボーいいねが送信されている場合は重複エラーとする
+        if (rainbowLikeRepository.exists(toUserId, fromUserId)) {
+            throw new RainbowLikeAlreadyExistsException();
+        }
+        // 既にレインボーいいねを受信している場合は無効なリクエストとする
+        if (rainbowLikeRepository.exists(toUserId, fromUserId)) {
+            throw new InvalidRequestException("既にレインボーいいねを受信しています");
+        }
+
+        //二重送信の防止
         if (likeRepository.exists(fromUserId, toUserId)) {
             throw new LikeAlreadyExistsException();
         }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -51,7 +51,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
     @Override
     public void likeUser(UserId UserId) {
 
-        User toUser = likeRepository.findUserByUserId(UserId)
+        User toUser = userRepository.findUserByUserId(UserId)
             .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
         UserId toUserId = toUser.getId();
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -71,7 +71,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
 
         // いいねとレインボーいいねを両方送ることはできない
         // 既にいいねが送信されている場合は重複エラーとする
-        if (likeRepository.exists(toUserId, fromUserId)) {
+        if (likeRepository.exists(fromUserId, toUserId)) {
             throw new LikeAlreadyExistsException();
         }
         // 既にいいねを受信している場合は無効なリクエストとする

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.reimi.reimi_app.application.command.SendRainbowLikeCommand;
 import com.reimi.reimi_app.application.exception.client.InvalidRequestException;
+import com.reimi.reimi_app.application.exception.client.LikeAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.MatchAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.RainbowLikeAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
@@ -15,6 +16,7 @@ import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.ChatRoomRepository;
+import com.reimi.reimi_app.domain.repository.LikeRepository;
 import com.reimi.reimi_app.domain.repository.MatchRepository;
 import com.reimi.reimi_app.domain.repository.RainbowLikeRepository;
 import com.reimi.reimi_app.domain.repository.UserRepository;
@@ -27,6 +29,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
 
     private final UserRepository userRepository;
     private final RainbowLikeRepository rainbowLikeRepository;
+    private final LikeRepository likeRepository;
     private final MatchRepository matchRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final AuthenticatedUserProvider authenticatedUserProvider;
@@ -34,6 +37,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
     public RainbowLikeUseCaseImpl(
         UserRepository userRepository,
         RainbowLikeRepository rainbowLikeRepository,
+        LikeRepository likeRepository,
         MatchRepository matchRepository,
         ChatRoomRepository chatRoomRepository,
         ImageStorageComponent imageStorage,
@@ -41,6 +45,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
     ) {
         this.userRepository = userRepository;
         this.rainbowLikeRepository = rainbowLikeRepository;
+        this.likeRepository = likeRepository;
         this.matchRepository = matchRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.authenticatedUserProvider = authenticatedUserProvider;
@@ -64,6 +69,17 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
 
         UserId fromUserId = fromUser.getId();
 
+        // いいねとレインボーいいねを両方送ることはできない
+        // 既にいいねが送信されている場合は重複エラーとする
+        if (likeRepository.exists(toUserId, fromUserId)) {
+            throw new LikeAlreadyExistsException();
+        }
+        // 既にいいねを受信している場合は無効なリクエストとする
+        if (likeRepository.exists(toUserId, fromUserId)) {
+            throw new InvalidRequestException("既にいいねを受信しています");
+        }
+
+        //二重送信の防止
         if (rainbowLikeRepository.exists(fromUserId, toUserId)) {
             throw new RainbowLikeAlreadyExistsException();
         }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -12,12 +12,14 @@ import com.reimi.reimi_app.application.exception.client.ResourceNotFoundExceptio
 import com.reimi.reimi_app.application.usecase.RainbowLikeUseCase;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
 import com.reimi.reimi_app.domain.model.match.Match;
+import com.reimi.reimi_app.domain.model.message.Message;
 import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.repository.ChatRoomRepository;
 import com.reimi.reimi_app.domain.repository.LikeRepository;
 import com.reimi.reimi_app.domain.repository.MatchRepository;
+import com.reimi.reimi_app.domain.repository.MessageRepository;
 import com.reimi.reimi_app.domain.repository.RainbowLikeRepository;
 import com.reimi.reimi_app.domain.repository.UserRepository;
 import com.reimi.reimi_app.infrastructure.storage.image.ImageStorageComponent;
@@ -32,6 +34,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
     private final LikeRepository likeRepository;
     private final MatchRepository matchRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final MessageRepository messageRepository;
     private final AuthenticatedUserProvider authenticatedUserProvider;
 
     public RainbowLikeUseCaseImpl(
@@ -40,6 +43,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         LikeRepository likeRepository,
         MatchRepository matchRepository,
         ChatRoomRepository chatRoomRepository,
+        MessageRepository messageRepository,
         ImageStorageComponent imageStorage,
         AuthenticatedUserProvider authenticatedUserProvider
     ) {
@@ -48,6 +52,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         this.likeRepository = likeRepository;
         this.matchRepository = matchRepository;
         this.chatRoomRepository = chatRoomRepository;
+        this.messageRepository = messageRepository;
         this.authenticatedUserProvider = authenticatedUserProvider;
     }
 
@@ -57,6 +62,8 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         if (command.message() == null || command.message().isBlank()) {
             throw new InvalidRequestException("メッセージは必須です");
         }
+
+        String textMessage = command.message();
 
         User toUser = userRepository.findUserByUserId(command.toUserId())
             .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
@@ -87,15 +94,15 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         RainbowLike rainbowLike = RainbowLike.create(
             fromUserId,
             toUserId,
-            command.message()
+            textMessage
         );
 
         rainbowLikeRepository.save(rainbowLike);
 
-        handleMatching(fromUserId, toUserId);
+        handleMatching(fromUserId, toUserId, textMessage);
     }
 
-    private void handleMatching(UserId fromUserId, UserId toUserId) {
+    private void handleMatching(UserId fromUserId, UserId toUserId, String textMessage) {
 
         // 逆方向レインボーいいね確認
         // 存在していた場合、マッチングが成立する
@@ -114,5 +121,14 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
 
         ChatRoom chatRoom = ChatRoom.create(match.getId());
         chatRoomRepository.save(chatRoom);
+
+        // レインボーいいねを返した時に送ったメッセージは、そのままチャットルームに表示される
+        Message message = Message.createText(
+            chatRoom.getId(),
+            fromUserId,
+            textMessage
+        );
+
+        messageRepository.save(message);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -1,0 +1,102 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reimi.reimi_app.application.command.SendRainbowLikeCommand;
+import com.reimi.reimi_app.application.exception.client.InvalidRequestException;
+import com.reimi.reimi_app.application.exception.client.MatchAlreadyExistsException;
+import com.reimi.reimi_app.application.exception.client.RainbowLikeAlreadyExistsException;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.usecase.RainbowLikeUseCase;
+import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
+import com.reimi.reimi_app.domain.model.match.Match;
+import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.repository.ChatRoomRepository;
+import com.reimi.reimi_app.domain.repository.MatchRepository;
+import com.reimi.reimi_app.domain.repository.RainbowLikeRepository;
+import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.infrastructure.storage.image.ImageStorageComponent;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+@Service
+@Transactional
+public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
+
+    private final UserRepository userRepository;
+    private final RainbowLikeRepository rainbowLikeRepository;
+    private final MatchRepository matchRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+
+    public RainbowLikeUseCaseImpl(
+        UserRepository userRepository,
+        RainbowLikeRepository rainbowLikeRepository,
+        MatchRepository matchRepository,
+        ChatRoomRepository chatRoomRepository,
+        ImageStorageComponent imageStorage,
+        AuthenticatedUserProvider authenticatedUserProvider
+    ) {
+        this.userRepository = userRepository;
+        this.rainbowLikeRepository = rainbowLikeRepository;
+        this.matchRepository = matchRepository;
+        this.chatRoomRepository = chatRoomRepository;
+        this.authenticatedUserProvider = authenticatedUserProvider;
+    }
+
+    @Override
+    public void rainbowLikeUser(SendRainbowLikeCommand command) {
+
+        if (command.message() == null || command.message().isBlank()) {
+            throw new InvalidRequestException("メッセージは必須です");
+        }
+
+        User toUser = userRepository.findUserByUserId(command.toUserId())
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+        UserId toUserId = toUser.getId();
+
+        String firebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        User fromUser = userRepository.findMeByFirebaseUid(firebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        UserId fromUserId = fromUser.getId();
+
+        if (rainbowLikeRepository.exists(fromUserId, toUserId)) {
+            throw new RainbowLikeAlreadyExistsException();
+        }
+
+        RainbowLike rainbowLike = RainbowLike.create(
+            fromUserId,
+            toUserId,
+            command.message()
+        );
+
+        rainbowLikeRepository.save(rainbowLike);
+
+        handleMatching(fromUserId, toUserId);
+    }
+
+    private void handleMatching(UserId fromUserId, UserId toUserId) {
+
+        // 逆方向レインボーいいね確認
+        // 存在していた場合、マッチングが成立する
+        if (!rainbowLikeRepository.exists(toUserId, fromUserId)) { return; }
+
+        // 正規化（必ずUUIDの値が小さい方からA・Bになる）
+        UserId userAId = fromUserId.value().compareTo(toUserId.value()) < 0 ? fromUserId : toUserId;
+        UserId userBId = fromUserId.value().compareTo(toUserId.value()) < 0 ? toUserId : fromUserId;
+
+        if (matchRepository.exists(userAId, userBId)) {
+            throw new MatchAlreadyExistsException();
+        }
+
+        Match match = Match.create(userAId, userBId);
+        matchRepository.save(match);
+
+        ChatRoom chatRoom = ChatRoom.create(match.getId());
+        chatRoomRepository.save(chatRoom);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
@@ -1,0 +1,44 @@
+package com.reimi.reimi_app.infrastructure.web.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reimi.reimi_app.application.command.SendRainbowLikeCommand;
+import com.reimi.reimi_app.application.usecase.RainbowLikeUseCase;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.infrastructure.web.dto.request.SendRainbowLikeRequest;
+import com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike.RainbowLikeUserApi;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+
+@RestController
+@RequestMapping("/rainbowLikes")
+public class RainbowLikeController {
+
+    private final RainbowLikeUseCase rainbowLikeUseCase;
+
+    public RainbowLikeController(
+        RainbowLikeUseCase rainbowLikeUseCase
+    ) {
+        this.rainbowLikeUseCase = rainbowLikeUseCase;
+    }
+
+    @PostMapping("/{userId}")
+    @RainbowLikeUserApi
+    public ResponseEntity<Void> RainbowLike(
+        @PathVariable("userId") UserId toUserId,
+        @RequestBody SendRainbowLikeRequest request) {
+        rainbowLikeUseCase.rainbowLikeUser(
+            new SendRainbowLikeCommand(
+                toUserId,
+                request.message()
+            )
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
@@ -13,7 +13,9 @@ import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.web.dto.request.SendRainbowLikeRequest;
 import com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike.RainbowLikeUserApi;
 
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/rainbowLikes")
@@ -31,7 +33,8 @@ public class RainbowLikeController {
     @RainbowLikeUserApi
     public ResponseEntity<Void> RainbowLike(
         @PathVariable("userId") UserId toUserId,
-        @RequestBody SendRainbowLikeRequest request) {
+        @Valid @RequestBody SendRainbowLikeRequest request
+    ) {
         rainbowLikeUseCase.rainbowLikeUser(
             new SendRainbowLikeCommand(
                 toUserId,

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendRainbowLikeRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/SendRainbowLikeRequest.java
@@ -1,0 +1,13 @@
+package com.reimi.reimi_app.infrastructure.web.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "メッセージ送信用リクエスト")
+public record SendRainbowLikeRequest(
+
+    @NotBlank(message = "メッセージは必須です")
+    @Schema(description = "特別なメッセージ", example = "プロフィール見て気になって、特別ないいねしました！！")
+    String message
+
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
@@ -93,11 +93,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
             examples = {
                 @ExampleObject(
                     name = "いいね重複",
-                    description = "既にいいねが送られてる場合",
+                    description = "既にいいねを送信している場合",
                     value = """
                     {
                         "code": "LIKE_ALREADY_SENT",
-                        "message": "既にいいねが送られています"
+                        "message": "既にいいねを送信しています"
                     }
                     """
                 ),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
@@ -1,0 +1,135 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ユーザーレインボーいいね",
+    description = "ユーザーにレインボーいいねを送れるAPI。ユーザー双方がレインボーいいねを送信した場合のみマッチングが成立する。",
+    tags = { "RainbowLike" },
+    requestBody = @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = "application/json"
+        )
+    )
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "レインボーいいね送信が成功",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "無効なリクエスト",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INVALID_REQUEST",
+                    "message": "ユーザー自身にはレインボーいいねできません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "409",
+        description = "重複エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "レインボーいいね重複",
+                    description = "既にレインボーいいねが送られてる場合",
+                    value = """
+                    {
+                        "code": "LIKE_ALREADY_SENT",
+                        "message": "既にレインボーいいねが送られています"
+                    }
+                    """
+                ),
+                @ExampleObject(
+                    name = "マッチング重複",
+                    description = "既にマッチングが成立している場合",
+                    value = """
+                    {
+                        "code": "MATCH_ALREADY_EXISTS",
+                        "message": "既にマッチングが成立しています"
+                    }
+                    """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface RainbowLikeUserApi {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
@@ -93,11 +93,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
             examples = {
                 @ExampleObject(
                     name = "レインボーいいね重複",
-                    description = "既にレインボーいいねが送られてる場合",
+                    description = "既にレインボーいいねを送信している場合",
                     value = """
                     {
-                        "code": "LIKE_ALREADY_SENT",
-                        "message": "既にレインボーいいねが送られています"
+                        "code": "RAINBOW_LIKE_ALREADY_SENT",
+                        "message": "既にレインボーいいねを送信しています"
                     }
                     """
                 ),


### PR DESCRIPTION
## 概要

API名：ユーザーレインボーいいね

種別：API開発

関連Issue：

- #116 

close #116 

## API設計

### 【やったこと・開発メモ】

### ドメイン層

---

- RainbowLikeドメインモデルの作成
    - 不変オブジェクトとして定義
    - createメソッドを作成
    - ユーザー自身にはレインボーいいねできない仕様にする
    - Getterの定義
- レインボーライクIDを不変なUUIDの値として作成される様にする
- レインボーライクリポジトリのインターフェイスを作成
    - そのいいねが存在するか確認するメソッド
    - レインボーいいねが登録（保存）されるメソッド

### アプリケーション層

---

- レインボーライクユースケースインターフェイスを作成
    - ユーザーレインボーいいねの業務操作を定義
- Commandの作成
- すでにレインボーいいねが送られていた場合のカスタム例外処理を作成
    - 409エラー（重複エラー）

### インフラストラクチャ層

---

- レインボーライクのユースケースを実装
    - メッセージが含まれているか確認
    - 既にいいねを送受信していないか確認
    - 既に存在しているレインボーいいねじゃないか確認
    - マッチングが成立した場合、レインボーいいねを返したユーザー側のメッセージは、そのままチャットルームに表示される
- ライクのユースケースに処理を追加
    - 既にレインボーいいねを送受信していないか確認
- RainbowLikeエンティティの作成
    - 作成日時のみカラムを用意する
    - `from_user_id` と `to_user_id` の複合ユニーク制約を貼る
    - その他必要なアノテーションとカラム定義
- RainbowLikeMapperの作成
    - エンティティへの変換
- JPA Repositoryを使うためのインターフェイス作成
- リクエストDTOを作成
- レインボーライクのリポジトリを実装
    - オーバーライドメソッドを定義
    - fromUser（自分）とtoUser（相手）のレインボーいいね履歴があるかが判定されるメソッド
    - ドメインモデルからエンティティに変換されて保存されるメソッド
- Controllerの作成
    - ユーザーにレインボーいいねが送信できるPOST APIメソッドを定義
        - パスパラメーターでユーザーIDを受け取る
        - RequestBodyでmessageを取得
- 定義アノテーションを作成

### その他

---

- ライクリポジトリにユーザー取得のメソッドを定義していたのを削除
    - 代わりにユーザーリポジトリに定義（債務的に）
    - 以下変更内容
        - ユーザーリポジトリ
            - インターフェイスにユーザーIDからユーザーを取得するメソッドを追加
        - ユーザー実装リポジトリ
            - 送られてきたUserIdからユーザードメインモデルを取得するオーバーライドメソッドを定義
        - ライクリポジトリとライク実装リポジトリ
            - メソッド削除
        - ライク実装ユースケース
            - ユーザーリポジトリからメソッドを使う

- いいねとレインボーいいねについてまとめる

| 相手 → 自分の状態 | 自分が 👍 Like | 自分が 🌈 RainbowLike | 補足 |
|---|---|---|---|
| 👍 Like が来ている | ✅ 可能（マッチ成立） | ❌ 不可 | 同種リアクションのみ許可 |
| 🌈 RainbowLike が来ている | ❌ 不可 | ✅ 可能（マッチ成立） | 同種リアクションのみ許可 |
| 何も来ていない | ✅ 可能（新規送信） | ✅ 可能（新規送信） | どちらか一方のみ送信可 |

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ユーザーレインボーいいね |
| URL | /rainbowLikes/{userId} |
| HTTPメソッド | POST |
| ステータスコード | 201 / 400 / 401 / 404 / 409 / 500 |

### 【リクエスト】

```json
{
  "message": string
}
```

### 【レスポンス】

特になし

### 【追加・変更したエンティティ】

- エンティティ名：RainbowLike
  - 役割：ユーザーのレインボーいいねに関する情報を格納する
  - ドメインルール：
    - ユーザーに一度だけレインボーいいねできる（重複なし）
    - 自分自身にはレインボーいいねが送れない
    - レインボーいいね情報は作成以外の操作ができない
      - 更新・削除など
    - いいねを送った（受け取った）ユーザーにはレインボーいいねはできない（リアクションのみ）

### 【追加・変更した設定ファイル】

- reimi_app/application/command/SendRainbowLikeCommand.java
- reimi_app/application/exception/client/LikeAlreadyExistsException.java
- reimi_app/application/exception/client/RainbowLikeAlreadyExistsException.java
- reimi_app/application/usecase/RainbowLikeUseCase.java
- reimi_app/domain/model/rainbowlike/RainbowLike.java
- reimi_app/domain/model/rainbowlike/RainbowLikeId.java
- reimi_app/domain/repository/LikeRepository.java
- reimi_app/domain/repository/RainbowLikeRepository.java
- reimi_app/domain/repository/UserRepository.java
- reimi_app/infrastructure/persistence/entity/RainbowLikeEntity.java
- reimi_app/infrastructure/persistence/mapper/RainbowLikeMapper.java
- reimi_app/infrastructure/persistence/repository/like/LikeRepositoryImpl.java
- reimi_app/infrastructure/persistence/repository/rainbowlike/JpaRainbowLikeRepository.java
- reimi_app/infrastructure/persistence/repository/rainbowlike/RainbowLikeRepositoryImpl.java
- reimi_app/infrastructure/persistence/repository/user/UserRepositoryImpl.java
- reimi_app/infrastructure/service/LikeUseCaseImpl.java
- reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
- reimi_app/infrastructure/web/controller/RainbowLikeController.java
- reimi_app/infrastructure/web/dto/request/SendRainbowLikeRequest.java
- reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
- reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
