### PR TITLE
URL命名規則の統一

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/LikeController.java
@@ -18,9 +18,11 @@ import com.reimi.reimi_app.infrastructure.web.openapi.like.GetLikeReceivedUsersA
 import com.reimi.reimi_app.infrastructure.web.openapi.like.LikeUserApi;
 
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/likes")
+@Tag(name = "Like", description = "いいね関連のAPI")
 public class LikeController {
 
     private final LikeUseCase likeUseCase;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MatchController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MatchController.java
@@ -11,8 +11,11 @@ import com.reimi.reimi_app.application.usecase.MatchUseCase;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetMatchedUserListResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.match.GetMatchedUsersApi;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @RestController
 @RequestMapping("/matches")
+@Tag(name = "Match", description = "マッチング関連のAPI")
 public class MatchController {
 
     private final MatchUseCase matchUseCase;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
@@ -22,11 +22,14 @@ import com.reimi.reimi_app.infrastructure.web.openapi.message.GetChatRoomMessage
 import com.reimi.reimi_app.infrastructure.web.openapi.message.SendTextMessageApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.web.bind.annotation.RequestBody;
 
 
 @RestController
 @RequestMapping("/chat-rooms")
+@Tag(name = "ChatRoom", description = "チャットルーム関連のAPI")
 public class MessageController {
 
     private final MessageUseCase messageUseCase;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/MessageController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 
 @RestController
-@RequestMapping("/chatRooms")
+@RequestMapping("/chat-rooms")
 public class MessageController {
 
     private final MessageUseCase messageUseCase;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
@@ -13,12 +13,15 @@ import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.web.dto.request.SendRainbowLikeRequest;
 import com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike.RainbowLikeUserApi;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.web.bind.annotation.RequestBody;
 
 import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/rainbow-likes")
+@Tag(name = "RainbowLike", description = "レインボーいいね関連のAPI")
 public class RainbowLikeController {
 
     private final RainbowLikeUseCase rainbowLikeUseCase;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/RainbowLikeController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping("/rainbowLikes")
+@RequestMapping("/rainbow-likes")
 public class RainbowLikeController {
 
     private final RainbowLikeUseCase rainbowLikeUseCase;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserController.java
@@ -22,11 +22,13 @@ import com.reimi.reimi_app.infrastructure.web.openapi.user.GetUsersApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.user.RegisterUserApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 
 @RestController
 @RequestMapping("/users")
+@Tag(name = "User", description = "ユーザー関連のAPI")
 public class UserController {
 
     private final AuthenticatedUserProvider authenticatedUserProvider;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserProfileController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/UserProfileController.java
@@ -18,10 +18,12 @@ import com.reimi.reimi_app.infrastructure.web.dto.response.UserWithProfileRespon
 import com.reimi.reimi_app.infrastructure.web.openapi.profile.GetUserProfileApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.profile.UpdateUserProfileApi;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/users/{userId}/profile")
+@Tag(name = "UserProfile", description = "プロフィール関連のAPI")
 public class UserProfileController {
     private final UserProfileUseCase userProfileUseCase;
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
@@ -15,14 +15,15 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "自分がいいねしたユーザー一覧取得",
-    description = "自分がいいねしたユーザの一覧を取得できるAPI",
-    tags = { "Like" }
+    description = "自分がいいねしたユーザの一覧を取得できるAPI"
 )
+@Tag(name = "Like", description = "いいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -23,7 +22,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
     summary = "自分がいいねしたユーザー一覧取得",
     description = "自分がいいねしたユーザの一覧を取得できるAPI"
 )
-@Tag(name = "Like", description = "いいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -23,7 +22,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
     summary = "自分がいいねされたユーザー一覧取得",
     description = "自分がいいねされたユーザの一覧を取得できるAPI"
 )
-@Tag(name = "Like", description = "いいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
@@ -15,14 +15,15 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "自分がいいねされたユーザー一覧取得",
-    description = "自分がいいねされたユーザの一覧を取得できるAPI",
-    tags = { "Like" }
+    description = "自分がいいねされたユーザの一覧を取得できるAPI"
 )
+@Tag(name = "Like", description = "いいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
@@ -14,13 +14,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザーいいね",
     description = "ユーザーにいいねを送れるAPI。ユーザー双方がいいねを送信した場合のみマッチングが成立する。",
-    tags = { "Like" },
     requestBody = @RequestBody(
         required = true,
         content = @Content(
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     )
 )
+@Tag(name = "Like", description = "いいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/LikeUserApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -28,7 +27,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         )
     )
 )
-@Tag(name = "Like", description = "いいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -23,7 +22,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
     summary = "マッチング成立したユーザー一覧取得",
     description = "マッチングが成立したユーザーの一覧を取得できるAPI"
 )
-@Tag(name = "Match", description = "マッチング関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/match/GetMatchedUsersApi.java
@@ -15,14 +15,15 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "マッチング成立したユーザー一覧取得",
-    description = "マッチングが成立したユーザーの一覧を取得できるAPI",
-    tags = { "Match" }
+    description = "マッチングが成立したユーザーの一覧を取得できるAPI"
 )
+@Tag(name = "Match", description = "マッチング関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/GetChatRoomMessagesApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/GetChatRoomMessagesApi.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -23,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
     summary = "チャットルームのメッセージ一覧取得",
     description = "チャットルームに送信されたメッセージの一覧を取得できるAPI"
 )
-@Tag(name = "ChatRoom", description = "チャットルーム関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/GetChatRoomMessagesApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/GetChatRoomMessagesApi.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
@@ -20,9 +21,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "チャットルームのメッセージ一覧取得",
-    description = "チャットルームに送信されたメッセージの一覧を取得できるAPI",
-    tags = { "ChatRoom" }
+    description = "チャットルームに送信されたメッセージの一覧を取得できるAPI"
 )
+@Tag(name = "ChatRoom", description = "チャットルーム関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -28,7 +27,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         )
     )
 )
-@Tag(name = "ChatRoom", description = "チャットルーム関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/message/SendTextMessageApi.java
@@ -14,13 +14,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "チャットルームにメッセージ送信",
     description = "マッチング成立後に作成されるチャットルームにメッセージを送信できるAPI",
-    tags = { "ChatRoom" },
     requestBody = @RequestBody(
         required = true,
         content = @Content(
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     )
 )
+@Tag(name = "ChatRoom", description = "チャットルーム関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/GetUserProfileApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/GetUserProfileApi.java
@@ -14,14 +14,15 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザープロフィール取得",
-    description = "ユーザーのプロフィール詳細を取得できるAPI",
-    tags = { "UserProfile" }
+    description = "ユーザーのプロフィール詳細を取得できるAPI"
 )
+@Tag(name = "UserProfile", description = "プロフィール関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/GetUserProfileApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/GetUserProfileApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -22,7 +21,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
     summary = "ユーザープロフィール取得",
     description = "ユーザーのプロフィール詳細を取得できるAPI"
 )
-@Tag(name = "UserProfile", description = "プロフィール関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/UpdateUserProfileApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/UpdateUserProfileApi.java
@@ -15,13 +15,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザープロフィール編集",
     description = "ユーザーのプロフィール編集API",
-    tags = { "UserProfile" },
     requestBody = @RequestBody(
         required = true,
         content = @Content(
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     )
 )
+@Tag(name = "UserProfile", description = "プロフィール関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "204",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/UpdateUserProfileApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/profile/UpdateUserProfileApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -30,7 +29,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         )
     )
 )
-@Tag(name = "UserProfile", description = "プロフィール関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "204",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -28,7 +27,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         )
     )
 )
-@Tag(name = "RainbowLike", description = "レインボーいいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/RainbowLikeUserApi.java
@@ -14,13 +14,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザーレインボーいいね",
     description = "ユーザーにレインボーいいねを送れるAPI。ユーザー双方がレインボーいいねを送信した場合のみマッチングが成立する。",
-    tags = { "RainbowLike" },
     requestBody = @RequestBody(
         required = true,
         content = @Content(
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     )
 )
+@Tag(name = "RainbowLike", description = "レインボーいいね関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
@@ -14,14 +14,15 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザー取得",
-    description = "ログインしているユーザー情報を取得できるAPI",
-    tags = { "User" }
+    description = "ログインしているユーザー情報を取得できるAPI"
 )
+@Tag(name = "User", description = "ユーザー関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetMeApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -22,7 +21,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
     summary = "ユーザー取得",
     description = "ログインしているユーザー情報を取得できるAPI"
 )
-@Tag(name = "User", description = "ユーザー関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetUsersApi.java
@@ -15,14 +15,15 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザー一覧取得",
-    description = "登録されているユーザーの一覧を取得できるAPI",
-    tags = { "User" }
+    description = "登録されているユーザーの一覧を取得できるAPI"
 )
+@Tag(name = "User", description = "ユーザー関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/GetUsersApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -23,7 +22,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
     summary = "ユーザー一覧取得",
     description = "登録されているユーザーの一覧を取得できるAPI"
 )
-@Tag(name = "User", description = "ユーザー関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "200",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterUserApi.java
@@ -15,13 +15,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ユーザー新規登録",
     description = "ユーザーの新規登録実行時のAPI",
-    tags = { "User" },
     requestBody = @RequestBody(
         required = true,
         content = @Content(
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     )
 )
+@Tag(name = "User", description = "ユーザー関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterUserApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterUserApi.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -30,7 +29,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
         )
     )
 )
-@Tag(name = "User", description = "ユーザー関連のAPI")
 @ApiResponses({
     @ApiResponse(
         responseCode = "201",


### PR DESCRIPTION
## 概要

種別：バックエンド開発

関連Issue：

- #118 

close #118 


## PR内容

### 【やったこと・開発メモ】

- 決定した命名規則
  - 命名規則の種類：ケバブケース
  - 文字を小文字に統一
  - パスパラメーターはそのままキャメルケース（javaの変数定義などと同じ）
- URLの命名規則を決めて統一させる

- その他
  - 全てのControllerにswaggerの@Tagアノテーションを付与して、APIの説明を追加

## 参考資料

- URL命名規則
  - https://techtarget.itmedia.co.jp/tt/news/2003/22/news01.html
  - https://qiita.com/uechi-shingo/items/d8f02ecdd8a535d6868e
  - https://qiita.com/deerboy/items/f035b9044edf9a51aff7
