### PR TITLE
【API設計】ウェザーパーソナリティ診断結果スコアリングのAPI設計（/diagnoses/score/user-weather-personality-type）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/DiagnoseWeatherPersonalityCommand.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/command/DiagnoseWeatherPersonalityCommand.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.application.command;
+
+import java.util.List;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.model.weatherpersonality.AnswerChoice;
+
+public record DiagnoseWeatherPersonalityCommand(
+    UserId userId,
+    List<AnswerChoice> answers
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/DiagnoseResultAlreadyExistsException.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/exception/client/DiagnoseResultAlreadyExistsException.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.application.exception.client;
+
+import org.springframework.http.HttpStatus;
+
+import com.reimi.reimi_app.application.exception.ClientErrorException;
+
+public class DiagnoseResultAlreadyExistsException  extends ClientErrorException {
+    public DiagnoseResultAlreadyExistsException() {
+        super(
+            "DIAGNOSE_RESUlT_ALREADY_EXISTS",
+            "既に診断済みです",
+            HttpStatus.CONFLICT
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/ImageUrlResolver.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/ImageUrlResolver.java
@@ -1,0 +1,5 @@
+package com.reimi.reimi_app.application.service;
+
+public interface ImageUrlResolver {
+    String resolve(String imagePath);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/WeatherPersonalityUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/WeatherPersonalityUseCase.java
@@ -1,0 +1,9 @@
+package com.reimi.reimi_app.application.usecase;
+
+import com.reimi.reimi_app.application.command.DiagnoseWeatherPersonalityCommand;
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+
+public interface WeatherPersonalityUseCase {
+
+    UserWeatherPersonalityType diagnose(DiagnoseWeatherPersonalityCommand command);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/AnswerChoice.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/AnswerChoice.java
@@ -1,0 +1,27 @@
+package com.reimi.reimi_app.domain.model.weatherpersonality;
+
+public enum AnswerChoice {
+
+    STRONGLY_A(2),
+    SLIGHTLY_A(1),
+    SLIGHTLY_B(-1),
+    STRONGLY_B(-2);
+
+    private final int score;
+
+    AnswerChoice(int score) {
+        this.score = score;
+    }
+
+    public int score() {
+        return score;
+    }
+
+    public static AnswerChoice from(String value) {
+        try {
+            return AnswerChoice.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("選択肢以外の回答が含まれています");
+        }
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
@@ -6,31 +6,31 @@ public class UserWeatherPersonalityType {
 
     private final UserWeatherPersonalityTypeId id;
     private final UserId userId;
-    private final WeatherPersonalityCode code;
+    private final WeatherPersonalityType type;
     private final WeatherPersonalityScore weatherPersonalityScore;
 
     private UserWeatherPersonalityType(
         UserWeatherPersonalityTypeId id,
         UserId userId,
-        WeatherPersonalityCode code,
+        WeatherPersonalityType type,
         WeatherPersonalityScore weatherPersonalityScore
     ) {
         this.id = id;
         this.userId = userId;
-        this.code = code;
+        this.type = type;
         this.weatherPersonalityScore = weatherPersonalityScore;
     }
 
     public static UserWeatherPersonalityType result(
         UserId userId,
-        WeatherPersonalityCode code,
+        WeatherPersonalityType type,
         WeatherPersonalityScore weatherPersonalityScore
     ) {
         UserWeatherPersonalityTypeId userWeatherPersonalityTypeId = UserWeatherPersonalityTypeId.generate();
         return new UserWeatherPersonalityType(
             userWeatherPersonalityTypeId,
             userId,
-            code,
+            type,
             weatherPersonalityScore
         );
 
@@ -38,7 +38,7 @@ public class UserWeatherPersonalityType {
 
     public UserWeatherPersonalityTypeId getId() { return id; }
     public UserId getUserId() { return userId; }
-    public WeatherPersonalityCode getWeatherPersonalityCode() { return code; }
+    public WeatherPersonalityType getWeatherPersonalityType() { return type; }
     public WeatherPersonalityScore getWeatherPersonalityScore() { return weatherPersonalityScore; }
 
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
@@ -1,0 +1,44 @@
+package com.reimi.reimi_app.domain.model.weatherpersonality;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public class UserWeatherPersonalityType {
+
+    private final UserWeatherPersonalityTypeId id;
+    private final UserId userId;
+    private final WeatherPersonalityCode code;
+    private final WeatherPersonalityScore weatherPersonalityScore;
+
+    private UserWeatherPersonalityType(
+        UserWeatherPersonalityTypeId id,
+        UserId userId,
+        WeatherPersonalityCode code,
+        WeatherPersonalityScore weatherPersonalityScore
+    ) {
+        this.id = id;
+        this.userId = userId;
+        this.code = code;
+        this.weatherPersonalityScore = weatherPersonalityScore;
+    }
+
+    public static UserWeatherPersonalityType result(
+        UserId userId,
+        WeatherPersonalityCode code,
+        WeatherPersonalityScore weatherPersonalityScore
+    ) {
+        UserWeatherPersonalityTypeId userWeatherPersonalityTypeId = UserWeatherPersonalityTypeId.generate();
+        return new UserWeatherPersonalityType(
+            userWeatherPersonalityTypeId,
+            userId,
+            code,
+            weatherPersonalityScore
+        );
+
+    }
+
+    public UserWeatherPersonalityTypeId getId() { return id; }
+    public UserId getUserId() { return userId; }
+    public WeatherPersonalityCode getWeatherPersonalityCode() { return code; }
+    public WeatherPersonalityScore getWeatherPersonalityScore() { return weatherPersonalityScore; }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityTypeId.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityTypeId.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.domain.model.weatherpersonality;
+
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.shared.identity.UuidGenerator;
+
+public record UserWeatherPersonalityTypeId(UUID value) {
+    public static UserWeatherPersonalityTypeId generate() {
+        return new UserWeatherPersonalityTypeId(UuidGenerator.generate());
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityDiagnosis.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityDiagnosis.java
@@ -1,0 +1,57 @@
+package com.reimi.reimi_app.domain.model.weatherpersonality;
+
+import java.util.List;
+
+public class WeatherPersonalityDiagnosis {
+
+    public WeatherPersonalityScore diagnoseScore(List<AnswerChoice> answers) {
+
+        if (answers.size() != 16) {
+            throw new IllegalArgumentException("質問に対する回答数は16問である必要があります");
+        }
+
+        WeatherPersonalityScore weatherPersonalityScore = new WeatherPersonalityScore();
+
+        answers.subList(0, 4).forEach(
+            answer -> weatherPersonalityScore.addActivity(answer.score())
+        );
+        answers.subList(4, 8).forEach(
+            answer -> weatherPersonalityScore.addPreparedness(answer.score()));
+        answers.subList(8, 12).forEach(
+            answer -> weatherPersonalityScore.addSensitivity(answer.score())
+        );
+        answers.subList(12, 16).forEach(
+            answer -> weatherPersonalityScore.addMotivation(answer.score())
+        );
+
+        return weatherPersonalityScore;
+    }
+
+    public WeatherPersonalityCode decideType(
+        WeatherPersonalityScore weatherPersonalityScore,
+        List<AnswerChoice> answers
+    ) {
+
+        char a = weatherPersonalityScore.activity() != 0
+            ? (weatherPersonalityScore.activity() > 0 ? 'O' : 'I')
+            : (answers.get(3).score() > 0 ? 'O' : 'I');
+
+        char p = weatherPersonalityScore.preparedness() != 0
+            ? (weatherPersonalityScore.preparedness() > 0 ? 'P' : 'F')
+            : (answers.get(7).score() > 0 ? 'P' : 'F');
+
+        char s = weatherPersonalityScore.sensitivity() != 0
+            ? (weatherPersonalityScore.sensitivity() > 0 ? 'S' : 'N')
+            : (answers.get(11).score() > 0 ? 'S' : 'N');
+
+        char m = weatherPersonalityScore.motivation() != 0
+            ? (weatherPersonalityScore.motivation() > 0 ? 'E' : 'R')
+            : (answers.get(15).score() > 0 ? 'E' : 'R');
+
+        String code = "%c%c%c%c".formatted(s, p, a, m);
+
+        return WeatherPersonalityCode.from(code);
+
+    }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityScore.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityScore.java
@@ -1,0 +1,42 @@
+package com.reimi.reimi_app.domain.model.weatherpersonality;
+
+public class WeatherPersonalityScore {
+
+    private int sensitivity;
+    private int preparedness;
+    private int activity;
+    private int motivation;
+
+    public void addSensitivity(int value) {
+        sensitivity += value;
+    }
+
+    public void addPreparedness(int value) {
+        preparedness += value;
+    }
+
+    public void addActivity(int value) {
+        activity += value;
+    }
+
+    public void addMotivation(int value) {
+        motivation += value;
+    }
+
+
+    public int sensitivity() {
+        return sensitivity;
+    }
+
+    public int preparedness() {
+        return preparedness;
+    }
+
+    public int activity() {
+        return activity;
+    }
+
+    public int motivation() {
+        return motivation;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityType.java
@@ -198,4 +198,10 @@ public class WeatherPersonalityType {
     public String getName() { return name; }
     public String getDescription() { return description; }
     public String getImagePath() { return imagePath; }
+
+    //タイプのイメージ画像をURLとして管理したいためシリアライズ対象外とする
+    private transient String typeImageUrl;
+
+    public String getTypeImageUrl() { return typeImageUrl; }
+    public void setTypeImageUrl(String typeImageUrl) { this.typeImageUrl = typeImageUrl; }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.domain.repository;
+
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+
+public interface UserWeatherPersonalityTypeRepository {
+    void save(UserWeatherPersonalityType userWeatherPersonalityType);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
@@ -1,7 +1,11 @@
 package com.reimi.reimi_app.domain.repository;
 
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 
 public interface UserWeatherPersonalityTypeRepository {
+
+    boolean exists(UserId UserId);
+
     void save(UserWeatherPersonalityType userWeatherPersonalityType);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/Image/ConfigBasedImageUrlResolver.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/Image/ConfigBasedImageUrlResolver.java
@@ -1,0 +1,22 @@
+package com.reimi.reimi_app.infrastructure.Image;
+
+import org.springframework.stereotype.Component;
+
+import com.reimi.reimi_app.application.service.ImageUrlResolver;
+
+@Component
+public class ConfigBasedImageUrlResolver implements ImageUrlResolver {
+
+    private final ImageProperties properties;
+
+    public ConfigBasedImageUrlResolver(
+        ImageProperties properties
+    ) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String resolve(String imagePath) {
+        return properties.getBaseUrl() + imagePath;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/Image/ImageProperties.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/Image/ImageProperties.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.infrastructure.Image;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@ConfigurationProperties(prefix = "app.image")
+@Getter
+@Setter
+public class ImageProperties {
+    private String baseUrl;
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserWeatherPersonalityTypeEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserWeatherPersonalityTypeEntity.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
@@ -39,10 +40,10 @@ public class UserWeatherPersonalityTypeEntity {
     @JoinColumn(name = "user_id", nullable = false, updatable = false, insertable = false)
     private UserEntity user;
 
-    @Column(name = "type_code", nullable = false, unique = true)
+    @Column(name = "type_code", nullable = false, updatable = false, insertable = false)
     private String typeCode;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "type_code", nullable = false)
     private WeatherPersonalityTypeEntity weatherPersonalityType;
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserWeatherPersonalityTypeEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserWeatherPersonalityTypeEntity.java
@@ -1,0 +1,80 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+    name = "user_weather_personality_types",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_weather_personality_types_user_id", columnNames = "user_id")
+    }
+)
+public class UserWeatherPersonalityTypeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private UUID userId;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, updatable = false, insertable = false)
+    private UserEntity user;
+
+    @Column(name = "type_code", nullable = false, unique = true)
+    private String typeCode;
+
+    @OneToOne
+    @JoinColumn(name = "type_code", nullable = false)
+    private WeatherPersonalityTypeEntity weatherPersonalityType;
+
+    @Column(name = "score_sensitivity")
+    private int scoreSensitivity;
+
+    @Column(name = "score_preparedness")
+    private int scorePreparedness;
+
+    @Column(name = "score_activity")
+    private int scoreActivity;
+
+    @Column(name = "score_motivation")
+    private int scoreMotivation;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void prePersist() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void preUpdate() {
+        this.updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    public UserWeatherPersonalityTypeEntity() {}
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
@@ -1,0 +1,28 @@
+package com.reimi.reimi_app.infrastructure.persistence.mapper;
+
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
+import com.reimi.reimi_app.infrastructure.persistence.entity.UserWeatherPersonalityTypeEntity;
+import com.reimi.reimi_app.infrastructure.persistence.entity.WeatherPersonalityTypeEntity;
+
+public class UserWeatherPersonalityTypeMapper {
+
+    public static UserWeatherPersonalityTypeEntity toEntity(
+        UserWeatherPersonalityType userWeatherPersonalityType,
+        UserEntity userEntity,
+        WeatherPersonalityTypeEntity weatherPersonalityTypeEntity
+    ) {
+        UserWeatherPersonalityTypeEntity entity = new UserWeatherPersonalityTypeEntity();
+        entity.setId(userWeatherPersonalityType.getId().value());
+        entity.setUserId(userWeatherPersonalityType.getUserId().value());
+        entity.setUser(userEntity);
+        entity.setTypeCode(userWeatherPersonalityType.getWeatherPersonalityCode().name());
+        entity.setWeatherPersonalityType(weatherPersonalityTypeEntity);
+        entity.setScoreSensitivity(userWeatherPersonalityType.getWeatherPersonalityScore().sensitivity());
+        entity.setScorePreparedness(userWeatherPersonalityType.getWeatherPersonalityScore().preparedness());
+        entity.setScoreActivity(userWeatherPersonalityType.getWeatherPersonalityScore().activity());
+        entity.setScoreMotivation(userWeatherPersonalityType.getWeatherPersonalityScore().motivation());
+
+        return entity;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
@@ -16,7 +16,7 @@ public class UserWeatherPersonalityTypeMapper {
         entity.setId(userWeatherPersonalityType.getId().value());
         entity.setUserId(userWeatherPersonalityType.getUserId().value());
         entity.setUser(userEntity);
-        entity.setTypeCode(userWeatherPersonalityType.getWeatherPersonalityCode().name());
+        entity.setTypeCode(weatherPersonalityTypeEntity.getCode());
         entity.setWeatherPersonalityType(weatherPersonalityTypeEntity);
         entity.setScoreSensitivity(userWeatherPersonalityType.getWeatherPersonalityScore().sensitivity());
         entity.setScorePreparedness(userWeatherPersonalityType.getWeatherPersonalityScore().preparedness());

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserWeatherPersonalityTypeEntity;
 
 public interface JpaUserWeatherPersonalityTypeRepository extends JpaRepository<UserWeatherPersonalityTypeEntity, UUID> {
+    boolean existsByUserId(UUID UserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
@@ -1,0 +1,10 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.userweatherpersonalitytype;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.UserWeatherPersonalityTypeEntity;
+
+public interface JpaUserWeatherPersonalityTypeRepository extends JpaRepository<UserWeatherPersonalityTypeEntity, UUID> {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.userweatherpersonalitytype;
 
+import org.springframework.stereotype.Repository;
+
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
@@ -9,6 +11,7 @@ import com.reimi.reimi_app.infrastructure.persistence.mapper.UserWeatherPersonal
 import com.reimi.reimi_app.infrastructure.persistence.repository.user.JpaUserRepository;
 import com.reimi.reimi_app.infrastructure.persistence.repository.weatherpersonalitytype.JpaWeatherPersonalityTypeRepository;
 
+@Repository
 public class UserWeatherPersonalityTypeRepositoryImpl implements UserWeatherPersonalityTypeRepository {
 
     private final JpaUserWeatherPersonalityTypeRepository jpaUserWeatherPersonalityTypeRepository;
@@ -33,7 +36,7 @@ public class UserWeatherPersonalityTypeRepositoryImpl implements UserWeatherPers
             .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
 
         WeatherPersonalityTypeEntity weatherPersonalityTypEntity = jpaWeatherPersonalityTypeRepository
-            .findByCode(userWeatherPersonalityType.getWeatherPersonalityCode().name())
+            .findByCode(userWeatherPersonalityType.getWeatherPersonalityType().getCode().name())
             .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティタイプ"));
 
         jpaUserWeatherPersonalityTypeRepository

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.reimi.reimi_app.infrastructure.persistence.repository.userweatherper
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
@@ -28,6 +29,11 @@ public class UserWeatherPersonalityTypeRepositoryImpl implements UserWeatherPers
         this.jpaUserRepository = jpaUserRepository;
         this.jpaWeatherPersonalityTypeRepository = jpaWeatherPersonalityTypeRepository;
     }
+
+    @Override
+    public boolean exists(UserId UserId) {
+        return jpaUserWeatherPersonalityTypeRepository.existsByUserId(UserId.value());
+    };
 
     @Override
     public void save(UserWeatherPersonalityType userWeatherPersonalityType) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.userweatherpersonalitytype;
+
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
+import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
+import com.reimi.reimi_app.infrastructure.persistence.entity.WeatherPersonalityTypeEntity;
+import com.reimi.reimi_app.infrastructure.persistence.mapper.UserWeatherPersonalityTypeMapper;
+import com.reimi.reimi_app.infrastructure.persistence.repository.user.JpaUserRepository;
+import com.reimi.reimi_app.infrastructure.persistence.repository.weatherpersonalitytype.JpaWeatherPersonalityTypeRepository;
+
+public class UserWeatherPersonalityTypeRepositoryImpl implements UserWeatherPersonalityTypeRepository {
+
+    private final JpaUserWeatherPersonalityTypeRepository jpaUserWeatherPersonalityTypeRepository;
+    private final JpaUserRepository jpaUserRepository;
+    private final JpaWeatherPersonalityTypeRepository jpaWeatherPersonalityTypeRepository;
+
+
+    public UserWeatherPersonalityTypeRepositoryImpl(
+        JpaUserWeatherPersonalityTypeRepository jpaUserWeatherPersonalityTypeRepository,
+        JpaUserRepository jpaUserRepository,
+        JpaWeatherPersonalityTypeRepository jpaWeatherPersonalityTypeRepository
+    ) {
+        this.jpaUserWeatherPersonalityTypeRepository = jpaUserWeatherPersonalityTypeRepository;
+        this.jpaUserRepository = jpaUserRepository;
+        this.jpaWeatherPersonalityTypeRepository = jpaWeatherPersonalityTypeRepository;
+    }
+
+    @Override
+    public void save(UserWeatherPersonalityType userWeatherPersonalityType) {
+        UserEntity userEntity = jpaUserRepository
+            .findById(userWeatherPersonalityType.getUserId().value())
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        WeatherPersonalityTypeEntity weatherPersonalityTypEntity = jpaWeatherPersonalityTypeRepository
+            .findByCode(userWeatherPersonalityType.getWeatherPersonalityCode().name())
+            .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティタイプ"));
+
+        jpaUserWeatherPersonalityTypeRepository
+            .save(UserWeatherPersonalityTypeMapper
+            .toEntity(
+                userWeatherPersonalityType,
+                userEntity,
+                weatherPersonalityTypEntity
+            ));
+    };
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
@@ -8,6 +8,7 @@ import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalit
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityDiagnosis;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityScore;
+import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityType;
 import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
 
 @Service
@@ -30,9 +31,11 @@ public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase 
 
         WeatherPersonalityCode code = diagnosis.decideType(weatherPersonalityScore, command.answers());
 
+        WeatherPersonalityType type = WeatherPersonalityType.from(code);
+
         UserWeatherPersonalityType result = UserWeatherPersonalityType.result(
             command.userId(),
-            code,
+            type,
             weatherPersonalityScore
         );
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.reimi.reimi_app.application.command.DiagnoseWeatherPersonalityCommand;
 import com.reimi.reimi_app.application.exception.client.DiagnoseResultAlreadyExistsException;
+import com.reimi.reimi_app.application.service.ImageUrlResolver;
 import com.reimi.reimi_app.application.usecase.WeatherPersonalityUseCase;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
@@ -16,11 +17,14 @@ import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepositor
 public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase {
 
     private final UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository;
+    private final ImageUrlResolver imageUrlResolver;
 
     public WeatherPersonalityUseCaseImpl(
-        UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository
+        UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository,
+        ImageUrlResolver imageUrlResolver
     ) {
         this.userWeatherPersonalityTypeRepository = userWeatherPersonalityTypeRepository;
+        this.imageUrlResolver = imageUrlResolver;
     }
 
     @Override
@@ -49,6 +53,12 @@ public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase 
         );
 
         userWeatherPersonalityTypeRepository.save(result);
+
+        String typeImageUrl = imageUrlResolver.resolve(
+            result.getWeatherPersonalityType().getImagePath()
+        );
+
+        result.getWeatherPersonalityType().setTypeImageUrl(typeImageUrl);
 
         return result;
     }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
@@ -3,6 +3,7 @@ package com.reimi.reimi_app.infrastructure.service;
 import org.springframework.stereotype.Service;
 
 import com.reimi.reimi_app.application.command.DiagnoseWeatherPersonalityCommand;
+import com.reimi.reimi_app.application.exception.client.DiagnoseResultAlreadyExistsException;
 import com.reimi.reimi_app.application.usecase.WeatherPersonalityUseCase;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
@@ -25,10 +26,18 @@ public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase 
     @Override
     public UserWeatherPersonalityType diagnose(DiagnoseWeatherPersonalityCommand command) {
 
+        // 既にユーザーが診断済みの場合は重複エラーとする
+        if (userWeatherPersonalityTypeRepository.exists(command.userId())) {
+            throw new DiagnoseResultAlreadyExistsException();
+        }
+
+        // 診断ロジックがあるドメインサービスをインスタンス化して使う
         WeatherPersonalityDiagnosis diagnosis = new WeatherPersonalityDiagnosis();
 
+        // 4つの軸ごとにスコアリングする
         WeatherPersonalityScore weatherPersonalityScore = diagnosis.diagnoseScore(command.answers());
 
+        //スコアリングした結果からタイプコードを決定する
         WeatherPersonalityCode code = diagnosis.decideType(weatherPersonalityScore, command.answers());
 
         WeatherPersonalityType type = WeatherPersonalityType.from(code);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
@@ -1,0 +1,43 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import org.springframework.stereotype.Service;
+
+import com.reimi.reimi_app.application.command.DiagnoseWeatherPersonalityCommand;
+import com.reimi.reimi_app.application.usecase.WeatherPersonalityUseCase;
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
+import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityDiagnosis;
+import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityScore;
+import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
+
+@Service
+public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase {
+
+    private final UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository;
+
+    public WeatherPersonalityUseCaseImpl(
+        UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository
+    ) {
+        this.userWeatherPersonalityTypeRepository = userWeatherPersonalityTypeRepository;
+    }
+
+    @Override
+    public UserWeatherPersonalityType diagnose(DiagnoseWeatherPersonalityCommand command) {
+
+        WeatherPersonalityDiagnosis diagnosis = new WeatherPersonalityDiagnosis();
+
+        WeatherPersonalityScore weatherPersonalityScore = diagnosis.diagnoseScore(command.answers());
+
+        WeatherPersonalityCode code = diagnosis.decideType(weatherPersonalityScore, command.answers());
+
+        UserWeatherPersonalityType result = UserWeatherPersonalityType.result(
+            command.userId(),
+            code,
+            weatherPersonalityScore
+        );
+
+        userWeatherPersonalityTypeRepository.save(result);
+
+        return result;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -82,7 +82,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
                 result.getWeatherPersonalityType().getCode(),
                 result.getWeatherPersonalityType().getName(),
                 result.getWeatherPersonalityType().getDescription(),
-                result.getWeatherPersonalityType().getImagePath()
+                result.getWeatherPersonalityType().getTypeImageUrl()
             );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -1,0 +1,84 @@
+package com.reimi.reimi_app.infrastructure.web.controller.v1;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reimi.reimi_app.application.command.DiagnoseWeatherPersonalityCommand;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.usecase.UserUseCase;
+import com.reimi.reimi_app.application.usecase.WeatherPersonalityUseCase;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.weatherpersonality.AnswerChoice;
+import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+
+@RestController
+public class WeatherPersonalityController extends ApiV1Controller {
+
+    private final WeatherPersonalityUseCase weatherPersonalityUseCase;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final UserUseCase userUseCase;
+
+
+    public WeatherPersonalityController(
+        WeatherPersonalityUseCase weatherPersonalityUseCase,
+        AuthenticatedUserProvider authenticatedUserProvider,
+        UserUseCase userUseCase
+    ) {
+        this.weatherPersonalityUseCase = weatherPersonalityUseCase;
+        this.authenticatedUserProvider = authenticatedUserProvider;
+        this.userUseCase = userUseCase;
+    }
+
+    @PostMapping("/diagnoses/score/user-weather-personality-type")
+    public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> diagnose(
+        @RequestBody DiagnoseWeatherPersonalityRequest request
+    ) {
+        List<AnswerChoice> answers = List.of(
+            request.q1Answer(),
+            request.q2Answer(),
+            request.q3Answer(),
+            request.q4Answer(),
+            request.q5Answer(),
+            request.q6Answer(),
+            request.q7Answer(),
+            request.q8Answer(),
+            request.q9Answer(),
+            request.q10Answer(),
+            request.q11Answer(),
+            request.q12Answer(),
+            request.q13Answer(),
+            request.q14Answer(),
+            request.q15Answer(),
+            request.q16Answer()
+        );
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+        User user = userUseCase.getUser(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        var result = weatherPersonalityUseCase.diagnose(
+            new DiagnoseWeatherPersonalityCommand(
+                user.getId(),
+                answers
+            )
+        );
+
+        DiagnoseResultWeatherPersonalityResponse response =
+            new DiagnoseResultWeatherPersonalityResponse(
+                result.getWeatherPersonalityType().getCode(),
+                result.getWeatherPersonalityType().getName(),
+                result.getWeatherPersonalityType().getDescription(),
+                result.getWeatherPersonalityType().getImagePath()
+            );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -20,6 +20,7 @@ import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.Diagnos
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 
 @RestController
@@ -44,7 +45,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
     @PostMapping("/diagnoses/score/user-weather-personality-type")
     @DiagnoseWeatherPersonalityType
     public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> diagnose(
-        @RequestBody DiagnoseWeatherPersonalityRequest request
+        @Valid @RequestBody DiagnoseWeatherPersonalityRequest request
     ) {
         List<AnswerChoice> answers = List.of(
             request.q1Answer(),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -16,10 +16,14 @@ import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.weatherpersonality.AnswerChoice;
 import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.DiagnoseWeatherPersonalityType;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 @RestController
+@Tag(name = "WeatherPersonality", description = "ウェザーパーソナリティ診断関連のAPI")
 public class WeatherPersonalityController extends ApiV1Controller {
 
     private final WeatherPersonalityUseCase weatherPersonalityUseCase;
@@ -38,6 +42,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
     }
 
     @PostMapping("/diagnoses/score/user-weather-personality-type")
+    @DiagnoseWeatherPersonalityType
     public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> diagnose(
         @RequestBody DiagnoseWeatherPersonalityRequest request
     ) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/DiagnoseWeatherPersonalityRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/DiagnoseWeatherPersonalityRequest.java
@@ -2,21 +2,73 @@ package com.reimi.reimi_app.infrastructure.web.dto.request;
 
 import com.reimi.reimi_app.domain.model.weatherpersonality.AnswerChoice;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "ユーザーのウェザーパーソナリティ診断回答用リクエスト")
 public record DiagnoseWeatherPersonalityRequest(
+
+    @NotNull(message = "Q1の回答は必須です")
+    @Schema(description = "質問１", example = "STRONGLY_A")
     AnswerChoice q1Answer,
+
+    @NotNull(message = "Q2の回答は必須です")
+    @Schema(description = "質問２", example = "STRONGLY_A")
     AnswerChoice q2Answer,
+
+    @NotNull(message = "Q3の回答は必須です")
+    @Schema(description = "質問３", example = "STRONGLY_A")
     AnswerChoice q3Answer,
+
+    @NotNull(message = "Q4の回答は必須です")
+    @Schema(description = "質問４", example = "STRONGLY_A")
     AnswerChoice q4Answer,
+
+    @NotNull(message = "Q5の回答は必須です")
+    @Schema(description = "質問５", example = "STRONGLY_A")
     AnswerChoice q5Answer,
+
+    @NotNull(message = "Q6の回答は必須です")
+    @Schema(description = "質問６", example = "STRONGLY_A")
     AnswerChoice q6Answer,
+
+    @NotNull(message = "Q7の回答は必須です")
+    @Schema(description = "質問７", example = "STRONGLY_A")
     AnswerChoice q7Answer,
+
+    @NotNull(message = "Q8の回答は必須です")
+    @Schema(description = "質問８", example = "STRONGLY_A")
     AnswerChoice q8Answer,
+
+    @NotNull(message = "Q9の回答は必須です")
+    @Schema(description = "質問９", example = "STRONGLY_A")
     AnswerChoice q9Answer,
+
+    @NotNull(message = "Q10の回答は必須です")
+    @Schema(description = "質問１０", example = "STRONGLY_A")
     AnswerChoice q10Answer,
+
+    @NotNull(message = "Q11の回答は必須です")
+    @Schema(description = "質問１１", example = "STRONGLY_A")
     AnswerChoice q11Answer,
+
+    @NotNull(message = "Q12の回答は必須です")
+    @Schema(description = "質問１２", example = "STRONGLY_A")
     AnswerChoice q12Answer,
+
+    @NotNull(message = "Q13の回答は必須です")
+    @Schema(description = "質問１３", example = "STRONGLY_A")
     AnswerChoice q13Answer,
+
+    @NotNull(message = "Q14の回答は必須です")
+    @Schema(description = "質問１４", example = "STRONGLY_A")
     AnswerChoice q14Answer,
+
+    @NotNull(message = "Q15の回答は必須です")
+    @Schema(description = "質問１５", example = "STRONGLY_A")
     AnswerChoice q15Answer,
+
+    @NotNull(message = "Q16の回答は必須です")
+    @Schema(description = "質問１６", example = "STRONGLY_A")
     AnswerChoice q16Answer
 ) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/DiagnoseWeatherPersonalityRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/DiagnoseWeatherPersonalityRequest.java
@@ -1,0 +1,22 @@
+package com.reimi.reimi_app.infrastructure.web.dto.request;
+
+import com.reimi.reimi_app.domain.model.weatherpersonality.AnswerChoice;
+
+public record DiagnoseWeatherPersonalityRequest(
+    AnswerChoice q1Answer,
+    AnswerChoice q2Answer,
+    AnswerChoice q3Answer,
+    AnswerChoice q4Answer,
+    AnswerChoice q5Answer,
+    AnswerChoice q6Answer,
+    AnswerChoice q7Answer,
+    AnswerChoice q8Answer,
+    AnswerChoice q9Answer,
+    AnswerChoice q10Answer,
+    AnswerChoice q11Answer,
+    AnswerChoice q12Answer,
+    AnswerChoice q13Answer,
+    AnswerChoice q14Answer,
+    AnswerChoice q15Answer,
+    AnswerChoice q16Answer
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
@@ -2,9 +2,20 @@ package com.reimi.reimi_app.infrastructure.web.dto.response;
 
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "ユーザーのウェザーパーソナリティ診断結果表示用レスポンス")
 public record DiagnoseResultWeatherPersonalityResponse(
+
+    @Schema(description = "タイプコード", example = "SPOE")
     WeatherPersonalityCode typeCode,
+
+    @Schema(description = "タイプ名", example = "トレーニーラッコ")
     String typeName,
+
+    @Schema(description = "タイプ説明", example = "「共感的ムードメーカー」そのもの")
     String typeDescription,
+
+    @Schema(description = "タイプイメージ画像URL", example = "")
     String typeImageUrl
 ) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
@@ -16,6 +16,6 @@ public record DiagnoseResultWeatherPersonalityResponse(
     @Schema(description = "タイプ説明", example = "「共感的ムードメーカー」そのもの")
     String typeDescription,
 
-    @Schema(description = "タイプイメージ画像URL", example = "")
+    @Schema(description = "タイプイメージ画像URL", example = "http://localhost:8080/images/weather-personalities/トレーニーラッコ_イメージ画像.png")
     String typeImageUrl
 ) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
@@ -1,0 +1,10 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
+
+public record DiagnoseResultWeatherPersonalityResponse(
+    WeatherPersonalityCode typeCode,
+    String typeName,
+    String typeDescription,
+    String typeImageUrl
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
@@ -7,6 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 
 import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -34,7 +35,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         responseCode = "201",
         description = "ユーザーのウェザーパーソナリティ診断が正常に行われました",
         content = @Content(
-            mediaType = "application/json"
+            mediaType = "application/json",
+            schema = @Schema(implementation = DiagnoseResultWeatherPersonalityResponse.class)
         )
     ),
     @ApiResponse(
@@ -62,8 +64,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
                         "code": "INVALID_REQUEST",
                         "message": "入力値が不正です",
                         "details": {
-                            "email": "メールアドレスの形式が不正です",
-                            "introduction": "自己紹介文は20文字以上500文字以下で入力してください"
+                            "q1Answer": "Q1の回答は必須です"
                         }
                     }
                     """

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
@@ -1,0 +1,126 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ウェザーパーソナリティ診断結果スコアリング",
+    description = "ユーザーのウェザーパーソナリティタイプの診断結果をスコアリングしてレスポンスするAPI",
+    requestBody = @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = DiagnoseWeatherPersonalityRequest.class)
+        )
+    )
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "ユーザーのウェザーパーソナリティ診断が正常に行われました",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "無効なリクエスト",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "フォーマット不正",
+                    description = "リクエスト形式が正しくない場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "無効なリクエストです"
+                    }
+                    """
+                ),
+                @ExampleObject(
+                    name = "バリデーションエラー",
+                    description = "入力値のバリデーションに失敗した場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "入力値が不正です",
+                        "details": {
+                            "email": "メールアドレスの形式が不正です",
+                            "introduction": "自己紹介文は20文字以上500文字以下で入力してください"
+                        }
+                    }
+                    """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "409",
+        description = "重複エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    value = """
+                    {
+                        "code": "DIAGNOSE_RESUlT_ALREADY_EXISTS",
+                        "message": "既に診断済みです"
+                    }
+                    """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface DiagnoseWeatherPersonalityType {
+}


### PR DESCRIPTION
## 概要

API名：ウェザーパーソナリティ診断結果スコアリング

種別：API開発

関連Issue：

- #117 

close #117 

## API設計

### 【やったこと・開発メモ】

### ドメイン層

---

- UserWeatherPersonalityTypeドメインモデルの作成
    - 不変オブジェクトとして定義
    - resultメソッドを作成
    - Getterの定義
- 質問の選択肢をenum（列挙型）で定義
- 診断で使う軸ごとのスコア集計用オブジェクトを作成
    - ミュータブルな値オブジェクト
- 診断のドメインロジックを定義するドメインサービスを作成
    - 「回答」→「軸スコア」への変換メソッド
        - 回答数は16問（質問数と同じ）
        - 軸ごとの集計ルール
            - 回答の配列からその軸についての回答スコアだけsubListで切り出してaddする
    - 「スコア」→「16タイプ」への決定をするメソッド
        - 16タイプの決め方
            - スコアが0かどうか
                1. 0以上の場合：左軸の値に決まる
                2. 0以下の場合：右軸の値に決まる
                3. 0だった場合：同点時の決定打ルールとして、それぞれの軸の４問目の回答がプラスよりかマイナスよりかで軸の値を判定する
        - コードの文字列フォーマット
        - ウェザーパーソナリティコードに変換して返す
- ユーザーウェザーパーソナリティタイプIDを不変なUUIDの値として作成される様にする
- ユーザーウェザーパーソナリティタイプリポジトリのインターフェイスを作成
    - ユーザーの診断結果が存在するか確認するメソッド
    - ユーザーウェザーパーソナリティタイプが登録（保存）されるメソッド

### アプリケーション層

---

- ウェザーパーソナリティのユースケースインターフェイスを作成
    - ユーザーウェザーパーソナリティタイプの診断業務操作を定義
- Commandの作成
- すでにユーザーが診断済みの場合のカスタム例外処理を作成
    - 409エラー（重複エラー）
- Seviceフォルダ作成
    - ユースケースで使いたい処理を定義する
    - 画像パスに付与する環境URLを設定するインターフェイスを作成

### インフラストラクチャ層

---

- ウェザーパーソナリティのユースケースを実装
    - 送られてきたUserIdの診断結果が存在するか確認
    - 診断ロジックがあるドメインサービスをインスタンス化する
    - 4つの軸ごとにスコアリングする
    - スコアリングした結果からタイプコードを決定する
    - タイプコードからそのタイプのドメインモデルを取得
    - ユーザーの診断結果を保存
    - タイプイメージ画像のパスに環境URLを付与する
    - 診断結果をスコアリングしたものと一緒に結果として返す
- UserWeatherPersonalityTypeエンティティの作成
    - ユーザーのユニーク制約を貼る
    - 必要なアノテーションとカラム定義
    - Mapperでエンティティに変換するためのコンストラクタを定義
- UserWeatherPersonalityTypeMapperの作成
    - エンティティへの変換メソッド
- JPA Repositoryを使うためのインターフェイス作成
- ユーザーウェザーパーソナリティタイプのリポジトリを実装
    - オーバーライドメソッドを定義
        - 送られたユーザーIDの診断履歴があるかが判定される
        - ドメインモデルからエンティティに変換されて保存される
- リクエストDTOを作成
- Controllerの作成
    - ウェザーパーソナリティ診断結果スコアリングのPOST APIメソッドを定義
        - バリデーション処理追加
        - リクエストDTOからユーザーの回答を受け取る
        - 結果を変数に代入
        - レスポンスDTOを用いて結果を返却
- レスポンスDTOの作成
    - ユーザーのウェザーパーソナリティ診断の結果をレスポンスする
- 定義アノテーションを作成
- Imageフォルダを作成
    - 画像パスに付与する環境URLを設定するコンポーネントクラスの実装
    - 設定ファイルからプロパティを読み込んでくるクラスを作成
        - imageのbase-urlを取得してくる

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ウェザーパーソナリティ診断結果スコアリング |
| URL | api/v1/diagnoses/score/user-weather-personality-type |
| HTTPメソッド | POST |
| ステータスコード | 201 / 400 / 401 / 403 / 409 / 500 |

### 【リクエスト】

```json
{
  "q1Answer": string
  "q2Answer": string
  "q3Answer": string
  "q4Answer": string
  "q5Answer": string
  "q6Answer": string
  "q7Answer": string
  "q8Answer": string
  "q9Answer": string
  "q10Answer": string
  "q11Answer": string
  "q12Answer": string
  "q13Answer": string
  "q14Answer": string
  "q15Answer": string
  "q16Answer": string
}
```

### 【レスポンス】

```json
{
  "typeCode": string
  "typeName": string
  "typeDescription": string
  "typeImageUrl": string
}
```

### 【追加・変更したエンティティ】

- エンティティ名：UserWeatherPersonalityType
  - 役割：ユーザーのウェザーパーソナリティ診断の結果に関する情報を格納する
  - ドメインルール：
    - 診断結果はユーザーと１対１で紐づく

### 【追加・変更した設定ファイル】

 - 追加ファイル
   - reimi_app/application/exception/client/DiagnoseResultAlreadyExistsException.java
   - reimi_app/application/service/ImageUrlResolver.java
   - reimi_app/application/usecase/WeatherPersonalityUseCase.java
   - reimi_app/domain/model/weatherpersonality/AnswerChoice.java
   - reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
   - reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityTypeId.java
   - reimi_app/domain/model/weatherpersonality/WeatherPersonalityDiagnosis.java
   - reimi_app/domain/model/weatherpersonality/WeatherPersonalityScore.java
   - reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
   - reimi_app/infrastructure/Image/ConfigBasedImageUrlResolver.java
   - reimi_app/infrastructure/Image/ImageProperties.java
   - reimi_app/infrastructure/persistence/entity/UserWeatherPersonalityTypeEntity.java
   - reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
   - reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
   - reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
   - reimi_app/infrastructure/web/dto/request/DiagnoseWeatherPersonalityRequest.java
   - reimi_app/infrastructure/web/dto/response/DiagnoseResultWeatherPersonalityResponse.java
   - reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java

 - 変更ファイル
   - reimi_app/domain/model/weatherpersonality/WeatherPersonalityType.java

## 参考資料

- @ConfigurationPropertiesアノテーション
  - https://qiita.com/cfg17771855/items/905da3100ae99c5197f0
 