### PR TITLE
【UI】プロフィール欄のウェザーパーソナリティ項目のUI実装

### DIFF
--- a/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_detail_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_detail_usecase.dart
@@ -5,7 +5,7 @@ class GetWeatherPersonalityDetailUseCase {
   const GetWeatherPersonalityDetailUseCase(this._repository);
   final WeatherPersonalityRepository _repository;
 
-  Future<WeatherPersonalityDetailReadModel> call() {
-    return _repository.fetchWeatherPersonalityDetail();
+  Future<WeatherPersonalityDetailReadModel> call(String userId) {
+    return _repository.fetchWeatherPersonalityDetail(userId);
   }
 }

--- a/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_detail_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_detail_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
+import 'package:reimi_app/domain/repositories/weather_personality_repository.dart';
+
+class GetWeatherPersonalityDetailUseCase {
+  const GetWeatherPersonalityDetailUseCase(this._repository);
+  final WeatherPersonalityRepository _repository;
+
+  Future<WeatherPersonalityDetailReadModel> call() {
+    return _repository.fetchWeatherPersonalityDetail();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/core/di/usecase_providers.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/usecase_providers.dart
@@ -4,6 +4,7 @@ import 'package:reimi_app/application/usecases/profile/update_user_profile_useca
 import 'package:reimi_app/application/usecases/rainbow_like/rainbow_like_user_usecase.dart';
 import 'package:reimi_app/application/usecases/session/get_current_user_state_usecase.dart';
 import 'package:reimi_app/application/usecases/like/get_like_users_to_user_usecase.dart';
+import 'package:reimi_app/application/usecases/weather_personality/get_weather_personality_detail_usecase.dart';
 import 'package:reimi_app/application/usecases/weather_personality/get_weather_personality_result_usecase.dart';
 import 'package:reimi_app/application/usecases/weather_personality/test_weather_personality_usecase.dart';
 import 'package:reimi_app/application/usecases/weather_report/get_my_weather_reports_usecase.dart';
@@ -146,5 +147,11 @@ TestWeatherPersonalityUseCase testWeatherPersonalityUseCase(Ref ref) {
 @riverpod
 GetWeatherPersonalityResultUseCase getWeatherPersonalityResultUseCase(Ref ref) {
   return GetWeatherPersonalityResultUseCase(
+      ref.watch(weatherPersonalityRepositoryProvider));
+}
+
+@riverpod
+GetWeatherPersonalityDetailUseCase getWeatherPersonalityDetailUseCase(Ref ref) {
+  return GetWeatherPersonalityDetailUseCase(
       ref.watch(weatherPersonalityRepositoryProvider));
 }

--- a/reimi/frontend/reimi_app/lib/core/di/usecase_providers.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/usecase_providers.g.dart
@@ -438,5 +438,25 @@ final getWeatherPersonalityResultUseCaseProvider =
 // ignore: unused_element
 typedef GetWeatherPersonalityResultUseCaseRef
     = AutoDisposeProviderRef<GetWeatherPersonalityResultUseCase>;
+String _$getWeatherPersonalityDetailUseCaseHash() =>
+    r'f83366acf9b8191122b6288a2d2ce32d449f5e4b';
+
+/// See also [getWeatherPersonalityDetailUseCase].
+@ProviderFor(getWeatherPersonalityDetailUseCase)
+final getWeatherPersonalityDetailUseCaseProvider =
+    AutoDisposeProvider<GetWeatherPersonalityDetailUseCase>.internal(
+  getWeatherPersonalityDetailUseCase,
+  name: r'getWeatherPersonalityDetailUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getWeatherPersonalityDetailUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetWeatherPersonalityDetailUseCaseRef
+    = AutoDisposeProviderRef<GetWeatherPersonalityDetailUseCase>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/core/i18n/en.i18n.json
+++ b/reimi/frontend/reimi_app/lib/core/i18n/en.i18n.json
@@ -167,6 +167,7 @@
   },
   "profilePage": {
     "title": "Edit Profile",
+    "nullCase": "Profile information could not be retrieved.",
     "section": {
       "mainPhoto": "Main Photo",
       "subPhoto": "Sub Photos",
@@ -249,6 +250,55 @@
       "contentText4": "and classify you into one of 16 character types\n\n",
       "contentText5": "",
       "contentText6": "Answer 16 questions to discover\nyour Weather Personality type"
+    }
+  },
+  "weatherPersonalityDetailPage": {
+    "title": "Test Result",
+    "nullCase": "Failed to get test results.",
+    "section": {
+      "mainResult": {
+        "typeCode": "Assessment Type Code",
+        "you": "You are"
+      },
+      "godsRuling": {
+        "title": "The Gods' Ruling Statement"
+      },
+      "behaviorTendency": {
+        "title": "Behavioral Tendencies"
+      },
+      "axisFeature":{
+        "title": "4-Axis Characteristics"
+      },
+      "axisScore":{
+        "title": "4-Axis Score",
+        "axis": {
+          "sensitivity": {
+            "sensitive": "S (High Sensitivity)",
+            "neutral": "N (Low Sensitivity)"
+          },
+          "preparedness": {
+            "planned": "P (Planned)",
+            "flexible": "F (Flexible)"
+          },
+          "activity": {
+            "outdoor": "O (Outdoor)",
+            "indoor": "I (Indoor)"
+          },
+          "motivation": {
+            "emotional": "E (Emotional)",
+            "rational": "R (Rational)"
+          }
+        }
+      },
+      "compatibleType": {
+        "title": "Compatible Type"
+      },
+      "incompatibleType": {
+        "title": "Incompatible Type"
+      },
+      "godsMessage": {
+        "title": "A Word from the Gods"
+      }
     }
   },
   "weatherPersonalityTestJudgingPage": {
@@ -502,6 +552,10 @@
     "completeTest":{
       "title": "Confirmation of completion of Test",
       "contentText": "Would you like to submit your answers and complete the test?"
+    },
+    "reTest":{
+      "title": "Confirmation of Re-Test",
+      "contentText": "If you run the test again, the current test results will be deleted. \nDo you really want to run the test again?"
     }
   },
   "modalSheet": {
@@ -567,7 +621,8 @@
     "completion": "Complete",
     "weatherPersonalityTest": "Weather Personality Test",
     "goTochatPage": "Go To Chat Screen",
-    "rainbowLike": "Rainbow Like!"
+    "rainbowLike": "Rainbow Like!",
+    "retest": "Re-test"
   },
   "segmentedSwitch": {
     "like": {

--- a/reimi/frontend/reimi_app/lib/core/i18n/ja.i18n.json
+++ b/reimi/frontend/reimi_app/lib/core/i18n/ja.i18n.json
@@ -167,6 +167,7 @@
   },
   "profilePage": {
     "title": "プロフィール編集",
+    "nullCase": "プロフィール情報が取得できませんでした。",
     "section": {
       "mainPhoto": "メイン写真",
       "subPhoto": "サブ写真",
@@ -249,6 +250,55 @@
       "contentText4": "16タイプのキャラ",
       "contentText5": "に分類されます\n\n",
       "contentText6": "16の質問に答えて、\nあなたのウェザーパーソナルタイプを\n診断しましょう"
+    }
+  },
+  "weatherPersonalityDetailPage": {
+    "title": "診断結果",
+    "nullCase": "診断結果の取得に失敗しました。",
+    "section": {
+      "mainResult": {
+        "typeCode": " 診断タイプコード",
+        "you": "あなたは"
+      },
+      "godsRuling": {
+        "title": "神様の裁定文"
+      },
+      "behaviorTendency": {
+        "title": "行動傾向"
+      },
+      "axisFeature":{
+        "title": "4軸の特徴"
+      },
+      "axisScore":{
+        "title": "4軸スコア",
+        "axis": {
+          "sensitivity": {
+            "sensitive": "S（高感受）",
+            "neutral": "N（低感受）"
+          },
+          "preparedness": {
+            "planned": "P（計画）",
+            "flexible": "F（柔軟）"
+          },
+          "activity": {
+            "outdoor": "O（外向）",
+            "indoor": "I（内向）"
+          },
+          "motivation": {
+            "emotional": "E（情緒）",
+            "rational": "R（実用）"
+          }
+        }
+      },
+      "compatibleType": {
+        "title": "あなたと相性の良いタイプ"
+      },
+      "incompatibleType": {
+        "title": "注意が必要なタイプ"
+      },
+      "godsMessage": {
+        "title": "神様からの一言"
+      }
     }
   },
   "weatherPersonalityTestJudgingPage": {
@@ -502,6 +552,10 @@
     "completeTest":{
       "title": "診断完了の確認",
       "contentText": "回答した内容を送信し、診断を完了しますか？"
+    },
+    "reTest":{
+      "title": "再診断の確認",
+      "contentText": "診断をやり直すと、現在の診断結果は削除されます。\n本当に再診断しますか？"
     }
   },
   "modalSheet": {
@@ -567,7 +621,8 @@
     "completion": "完了",
     "weatherPersonalityTest": "ウェザーパーソナリティ診断",
     "goTochatPage": "チャット画面へ",
-    "rainbowLike": "レインボーいいね！"
+    "rainbowLike": "レインボーいいね！",
+    "retest": "再診断"
   },
   "segmentedSwitch": {
     "like": {

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1154 (577 per locale)
+/// Strings: 1200 (600 per locale)
 ///
-/// Built on 2026-01-22 at 15:26 UTC
+/// Built on 2026-01-24 at 14:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings_en.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings_en.g.dart
@@ -65,6 +65,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsProfilePageEn profilePage = TranslationsProfilePageEn._(_root);
 	late final TranslationsProfileDetailPageEn profileDetailPage = TranslationsProfileDetailPageEn._(_root);
 	late final TranslationsWeatherPersonalityConceptPageEn weatherPersonalityConceptPage = TranslationsWeatherPersonalityConceptPageEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageEn weatherPersonalityDetailPage = TranslationsWeatherPersonalityDetailPageEn._(_root);
 	late final TranslationsWeatherPersonalityTestJudgingPageEn weatherPersonalityTestJudgingPage = TranslationsWeatherPersonalityTestJudgingPageEn._(_root);
 	late final TranslationsWeatherPersonalityTestPageEn weatherPersonalityTestPage = TranslationsWeatherPersonalityTestPageEn._(_root);
 	late final TranslationsWeatherPersonalityTestResultPageEn weatherPersonalityTestResultPage = TranslationsWeatherPersonalityTestResultPageEn._(_root);
@@ -376,6 +377,9 @@ class TranslationsProfilePageEn {
 	/// en: 'Edit Profile'
 	String get title => 'Edit Profile';
 
+	/// en: 'Profile information could not be retrieved.'
+	String get nullCase => 'Profile information could not be retrieved.';
+
 	late final TranslationsProfilePageSectionEn section = TranslationsProfilePageSectionEn._(_root);
 	late final TranslationsProfilePageEditEn edit = TranslationsProfilePageEditEn._(_root);
 	late final TranslationsProfilePagePlaceholderEn placeholder = TranslationsProfilePagePlaceholderEn._(_root);
@@ -408,6 +412,23 @@ class TranslationsWeatherPersonalityConceptPageEn {
 	String get title => 'Weather Personality Assessment';
 
 	late final TranslationsWeatherPersonalityConceptPageContentTextEn contentText = TranslationsWeatherPersonalityConceptPageContentTextEn._(_root);
+}
+
+// Path: weatherPersonalityDetailPage
+class TranslationsWeatherPersonalityDetailPageEn {
+	TranslationsWeatherPersonalityDetailPageEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Test Result'
+	String get title => 'Test Result';
+
+	/// en: 'Failed to get test results.'
+	String get nullCase => 'Failed to get test results.';
+
+	late final TranslationsWeatherPersonalityDetailPageSectionEn section = TranslationsWeatherPersonalityDetailPageSectionEn._(_root);
 }
 
 // Path: weatherPersonalityTestJudgingPage
@@ -511,6 +532,7 @@ class TranslationsDialogEn {
 	late final TranslationsDialogDestructionChangesEn destructionChanges = TranslationsDialogDestructionChangesEn._(_root);
 	late final TranslationsDialogInterruptTestEn interruptTest = TranslationsDialogInterruptTestEn._(_root);
 	late final TranslationsDialogCompleteTestEn completeTest = TranslationsDialogCompleteTestEn._(_root);
+	late final TranslationsDialogReTestEn reTest = TranslationsDialogReTestEn._(_root);
 }
 
 // Path: modalSheet
@@ -603,6 +625,9 @@ class TranslationsButtonEn {
 
 	/// en: 'Rainbow Like!'
 	String get rainbowLike => 'Rainbow Like!';
+
+	/// en: 'Re-test'
+	String get retest => 'Re-test';
 }
 
 // Path: segmentedSwitch
@@ -1014,6 +1039,23 @@ class TranslationsWeatherPersonalityConceptPageContentTextEn {
 
 	/// en: 'Answer 16 questions to discover your Weather Personality type'
 	String get contentText6 => 'Answer 16 questions to discover\nyour Weather Personality type';
+}
+
+// Path: weatherPersonalityDetailPage.section
+class TranslationsWeatherPersonalityDetailPageSectionEn {
+	TranslationsWeatherPersonalityDetailPageSectionEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWeatherPersonalityDetailPageSectionMainResultEn mainResult = TranslationsWeatherPersonalityDetailPageSectionMainResultEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionGodsRulingEn godsRuling = TranslationsWeatherPersonalityDetailPageSectionGodsRulingEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyEn behaviorTendency = TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisFeatureEn axisFeature = TranslationsWeatherPersonalityDetailPageSectionAxisFeatureEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisScoreEn axisScore = TranslationsWeatherPersonalityDetailPageSectionAxisScoreEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeEn compatibleType = TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeEn incompatibleType = TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionGodsMessageEn godsMessage = TranslationsWeatherPersonalityDetailPageSectionGodsMessageEn._(_root);
 }
 
 // Path: weatherPersonalityTestJudgingPage.contentText
@@ -1667,6 +1709,21 @@ class TranslationsDialogCompleteTestEn {
 
 	/// en: 'Would you like to submit your answers and complete the test?'
 	String get contentText => 'Would you like to submit your answers and complete the test?';
+}
+
+// Path: dialog.reTest
+class TranslationsDialogReTestEn {
+	TranslationsDialogReTestEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Confirmation of Re-Test'
+	String get title => 'Confirmation of Re-Test';
+
+	/// en: 'If you run the test again, the current test results will be deleted. Do you really want to run the test again?'
+	String get contentText => 'If you run the test again, the current test results will be deleted. \nDo you really want to run the test again?';
 }
 
 // Path: modalSheet.sortUser
@@ -2745,6 +2802,107 @@ class TranslationsProfilePagePlaceholderBasicInformationEn {
 	String get toolTip => 'This field cannot be changed.';
 }
 
+// Path: weatherPersonalityDetailPage.section.mainResult
+class TranslationsWeatherPersonalityDetailPageSectionMainResultEn {
+	TranslationsWeatherPersonalityDetailPageSectionMainResultEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Assessment Type Code'
+	String get typeCode => 'Assessment Type Code';
+
+	/// en: 'You are'
+	String get you => 'You are';
+}
+
+// Path: weatherPersonalityDetailPage.section.godsRuling
+class TranslationsWeatherPersonalityDetailPageSectionGodsRulingEn {
+	TranslationsWeatherPersonalityDetailPageSectionGodsRulingEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'The Gods' Ruling Statement'
+	String get title => 'The Gods\' Ruling Statement';
+}
+
+// Path: weatherPersonalityDetailPage.section.behaviorTendency
+class TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyEn {
+	TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Behavioral Tendencies'
+	String get title => 'Behavioral Tendencies';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisFeature
+class TranslationsWeatherPersonalityDetailPageSectionAxisFeatureEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisFeatureEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '4-Axis Characteristics'
+	String get title => '4-Axis Characteristics';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore
+class TranslationsWeatherPersonalityDetailPageSectionAxisScoreEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisScoreEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: '4-Axis Score'
+	String get title => '4-Axis Score';
+
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisEn axis = TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisEn._(_root);
+}
+
+// Path: weatherPersonalityDetailPage.section.compatibleType
+class TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeEn {
+	TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Compatible Type'
+	String get title => 'Compatible Type';
+}
+
+// Path: weatherPersonalityDetailPage.section.incompatibleType
+class TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeEn {
+	TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Incompatible Type'
+	String get title => 'Incompatible Type';
+}
+
+// Path: weatherPersonalityDetailPage.section.godsMessage
+class TranslationsWeatherPersonalityDetailPageSectionGodsMessageEn {
+	TranslationsWeatherPersonalityDetailPageSectionGodsMessageEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'A Word from the Gods'
+	String get title => 'A Word from the Gods';
+}
+
 // Path: weatherPersonalityTestResultPage.section.mainResult
 class TranslationsWeatherPersonalityTestResultPageSectionMainResultEn {
 	TranslationsWeatherPersonalityTestResultPageSectionMainResultEn._(this._root);
@@ -3221,6 +3379,19 @@ class TranslationsProfilePagePlaceholderSubPhotoLabelsEn {
 	String get holiday => 'Day Off';
 }
 
+// Path: weatherPersonalityDetailPage.section.axisScore.axis
+class TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityEn sensitivity = TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessEn preparedness = TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityEn activity = TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityEn._(_root);
+	late final TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationEn motivation = TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationEn._(_root);
+}
+
 // Path: weatherPersonalityTestResultPage.section.axisScore.axis
 class TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisEn {
 	TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisEn._(this._root);
@@ -3232,6 +3403,66 @@ class TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisEn {
 	late final TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisPreparednessEn preparedness = TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisPreparednessEn._(_root);
 	late final TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisActivityEn activity = TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisActivityEn._(_root);
 	late final TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisMotivationEn motivation = TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisMotivationEn._(_root);
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.sensitivity
+class TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'S (High Sensitivity)'
+	String get sensitive => 'S (High Sensitivity)';
+
+	/// en: 'N (Low Sensitivity)'
+	String get neutral => 'N (Low Sensitivity)';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.preparedness
+class TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'P (Planned)'
+	String get planned => 'P (Planned)';
+
+	/// en: 'F (Flexible)'
+	String get flexible => 'F (Flexible)';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.activity
+class TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'O (Outdoor)'
+	String get outdoor => 'O (Outdoor)';
+
+	/// en: 'I (Indoor)'
+	String get indoor => 'I (Indoor)';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.motivation
+class TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationEn {
+	TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'E (Emotional)'
+	String get emotional => 'E (Emotional)';
+
+	/// en: 'R (Rational)'
+	String get rational => 'R (Rational)';
 }
 
 // Path: weatherPersonalityTestResultPage.section.axisScore.axis.sensitivity
@@ -3387,6 +3618,7 @@ extension on Translations {
 			'weatherReportDetailPage.label.forecast' => 'Sensory Forecast',
 			'accountPage.nullCase' => 'User information could not be obtained.',
 			'profilePage.title' => 'Edit Profile',
+			'profilePage.nullCase' => 'Profile information could not be retrieved.',
 			'profilePage.section.mainPhoto' => 'Main Photo',
 			'profilePage.section.subPhoto' => 'Sub Photos',
 			'profilePage.section.weatherPersonality' => 'Weather Personality',
@@ -3440,6 +3672,25 @@ extension on Translations {
 			'weatherPersonalityConceptPage.contentText.contentText4' => 'and classify you into one of 16 character types\n\n',
 			'weatherPersonalityConceptPage.contentText.contentText5' => '',
 			'weatherPersonalityConceptPage.contentText.contentText6' => 'Answer 16 questions to discover\nyour Weather Personality type',
+			'weatherPersonalityDetailPage.title' => 'Test Result',
+			'weatherPersonalityDetailPage.nullCase' => 'Failed to get test results.',
+			'weatherPersonalityDetailPage.section.mainResult.typeCode' => 'Assessment Type Code',
+			'weatherPersonalityDetailPage.section.mainResult.you' => 'You are',
+			'weatherPersonalityDetailPage.section.godsRuling.title' => 'The Gods\' Ruling Statement',
+			'weatherPersonalityDetailPage.section.behaviorTendency.title' => 'Behavioral Tendencies',
+			'weatherPersonalityDetailPage.section.axisFeature.title' => '4-Axis Characteristics',
+			'weatherPersonalityDetailPage.section.axisScore.title' => '4-Axis Score',
+			'weatherPersonalityDetailPage.section.axisScore.axis.sensitivity.sensitive' => 'S (High Sensitivity)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.sensitivity.neutral' => 'N (Low Sensitivity)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.preparedness.planned' => 'P (Planned)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.preparedness.flexible' => 'F (Flexible)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.activity.outdoor' => 'O (Outdoor)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.activity.indoor' => 'I (Indoor)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.motivation.emotional' => 'E (Emotional)',
+			'weatherPersonalityDetailPage.section.axisScore.axis.motivation.rational' => 'R (Rational)',
+			'weatherPersonalityDetailPage.section.compatibleType.title' => 'Compatible Type',
+			'weatherPersonalityDetailPage.section.incompatibleType.title' => 'Incompatible Type',
+			'weatherPersonalityDetailPage.section.godsMessage.title' => 'A Word from the Gods',
 			'weatherPersonalityTestJudgingPage.loading' => 'Assessing',
 			'weatherPersonalityTestJudgingPage.contentText.contentTitle' => 'Assessment Complete',
 			'weatherPersonalityTestJudgingPage.contentText.contentText1' => 'The gods have finished reviewing\nall records of your past life\'s actions.',
@@ -3577,6 +3828,8 @@ extension on Translations {
 			'dialog.interruptTest.contentText' => 'Your answers will not be saved.\nDo you really want to stop the test?',
 			'dialog.completeTest.title' => 'Confirmation of completion of Test',
 			'dialog.completeTest.contentText' => 'Would you like to submit your answers and complete the test?',
+			'dialog.reTest.title' => 'Confirmation of Re-Test',
+			'dialog.reTest.contentText' => 'If you run the test again, the current test results will be deleted. \nDo you really want to run the test again?',
 			'modalSheet.sortUser.title' => 'Sort',
 			'modalSheet.refineSearchUser.title' => 'Filter',
 			'modalSheet.refineSearchUser.section.age' => 'Age',
@@ -3618,6 +3871,7 @@ extension on Translations {
 			'button.weatherPersonalityTest' => 'Weather Personality Test',
 			'button.goTochatPage' => 'Go To Chat Screen',
 			'button.rainbowLike' => 'Rainbow Like!',
+			'button.retest' => 'Re-test',
 			'segmentedSwitch.like.fromUser' => 'From Them',
 			'segmentedSwitch.like.toUser' => 'From Me',
 			'segmentedSwitch.chat.message' => 'Message',
@@ -3791,6 +4045,8 @@ extension on Translations {
 			'kEnum.holiday.irregular' => 'Irregular',
 			'kEnum.occupation.universityStudent' => 'University Student',
 			'kEnum.occupation.graduateStudent' => 'Graduate Student',
+			_ => null,
+		} ?? switch (path) {
 			'kEnum.occupation.vocationalStudent' => 'Vocational Student',
 			'kEnum.occupation.juniorCollegeStudent' => 'Junior College Student',
 			'kEnum.occupation.technicalCollegeStudent' => 'Technical College Student',
@@ -3814,8 +4070,6 @@ extension on Translations {
 			'kEnum.occupation.consulting' => 'Consulting',
 			'kEnum.occupation.massMedia' => 'Media',
 			'kEnum.occupation.advertising' => 'Advertising',
-			_ => null,
-		} ?? switch (path) {
 			'kEnum.occupation.publishing' => 'Publishing',
 			'kEnum.occupation.education' => 'Education',
 			'kEnum.occupation.retail' => 'Retail',

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings_ja.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings_ja.g.dart
@@ -62,6 +62,7 @@ class TranslationsJa with BaseTranslations<AppLocale, Translations> implements T
 	@override late final _TranslationsProfilePageJa profilePage = _TranslationsProfilePageJa._(_root);
 	@override late final _TranslationsProfileDetailPageJa profileDetailPage = _TranslationsProfileDetailPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityConceptPageJa weatherPersonalityConceptPage = _TranslationsWeatherPersonalityConceptPageJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageJa weatherPersonalityDetailPage = _TranslationsWeatherPersonalityDetailPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityTestJudgingPageJa weatherPersonalityTestJudgingPage = _TranslationsWeatherPersonalityTestJudgingPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityTestPageJa weatherPersonalityTestPage = _TranslationsWeatherPersonalityTestPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityTestResultPageJa weatherPersonalityTestResultPage = _TranslationsWeatherPersonalityTestResultPageJa._(_root);
@@ -296,6 +297,7 @@ class _TranslationsProfilePageJa implements TranslationsProfilePageEn {
 
 	// Translations
 	@override String get title => 'プロフィール編集';
+	@override String get nullCase => 'プロフィール情報が取得できませんでした。';
 	@override late final _TranslationsProfilePageSectionJa section = _TranslationsProfilePageSectionJa._(_root);
 	@override late final _TranslationsProfilePageEditJa edit = _TranslationsProfilePageEditJa._(_root);
 	@override late final _TranslationsProfilePagePlaceholderJa placeholder = _TranslationsProfilePagePlaceholderJa._(_root);
@@ -321,6 +323,18 @@ class _TranslationsWeatherPersonalityConceptPageJa implements TranslationsWeathe
 	// Translations
 	@override String get title => 'ウェザーパーソナリティ診断';
 	@override late final _TranslationsWeatherPersonalityConceptPageContentTextJa contentText = _TranslationsWeatherPersonalityConceptPageContentTextJa._(_root);
+}
+
+// Path: weatherPersonalityDetailPage
+class _TranslationsWeatherPersonalityDetailPageJa implements TranslationsWeatherPersonalityDetailPageEn {
+	_TranslationsWeatherPersonalityDetailPageJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '診断結果';
+	@override String get nullCase => '診断結果の取得に失敗しました。';
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionJa section = _TranslationsWeatherPersonalityDetailPageSectionJa._(_root);
 }
 
 // Path: weatherPersonalityTestJudgingPage
@@ -415,6 +429,7 @@ class _TranslationsDialogJa implements TranslationsDialogEn {
 	@override late final _TranslationsDialogDestructionChangesJa destructionChanges = _TranslationsDialogDestructionChangesJa._(_root);
 	@override late final _TranslationsDialogInterruptTestJa interruptTest = _TranslationsDialogInterruptTestJa._(_root);
 	@override late final _TranslationsDialogCompleteTestJa completeTest = _TranslationsDialogCompleteTestJa._(_root);
+	@override late final _TranslationsDialogReTestJa reTest = _TranslationsDialogReTestJa._(_root);
 }
 
 // Path: modalSheet
@@ -461,6 +476,7 @@ class _TranslationsButtonJa implements TranslationsButtonEn {
 	@override String get weatherPersonalityTest => 'ウェザーパーソナリティ診断';
 	@override String get goTochatPage => 'チャット画面へ';
 	@override String get rainbowLike => 'レインボーいいね！';
+	@override String get retest => '再診断';
 }
 
 // Path: segmentedSwitch
@@ -761,6 +777,23 @@ class _TranslationsWeatherPersonalityConceptPageContentTextJa implements Transla
 	@override String get contentText4 => '16タイプのキャラ';
 	@override String get contentText5 => 'に分類されます\n\n';
 	@override String get contentText6 => '16の質問に答えて、\nあなたのウェザーパーソナルタイプを\n診断しましょう';
+}
+
+// Path: weatherPersonalityDetailPage.section
+class _TranslationsWeatherPersonalityDetailPageSectionJa implements TranslationsWeatherPersonalityDetailPageSectionEn {
+	_TranslationsWeatherPersonalityDetailPageSectionJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionMainResultJa mainResult = _TranslationsWeatherPersonalityDetailPageSectionMainResultJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionGodsRulingJa godsRuling = _TranslationsWeatherPersonalityDetailPageSectionGodsRulingJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyJa behaviorTendency = _TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisFeatureJa axisFeature = _TranslationsWeatherPersonalityDetailPageSectionAxisFeatureJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisScoreJa axisScore = _TranslationsWeatherPersonalityDetailPageSectionAxisScoreJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeJa compatibleType = _TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeJa incompatibleType = _TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionGodsMessageJa godsMessage = _TranslationsWeatherPersonalityDetailPageSectionGodsMessageJa._(_root);
 }
 
 // Path: weatherPersonalityTestJudgingPage.contentText
@@ -1207,6 +1240,17 @@ class _TranslationsDialogCompleteTestJa implements TranslationsDialogCompleteTes
 	// Translations
 	@override String get title => '診断完了の確認';
 	@override String get contentText => '回答した内容を送信し、診断を完了しますか？';
+}
+
+// Path: dialog.reTest
+class _TranslationsDialogReTestJa implements TranslationsDialogReTestEn {
+	_TranslationsDialogReTestJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '再診断の確認';
+	@override String get contentText => '診断をやり直すと、現在の診断結果は削除されます。\n本当に再診断しますか？';
 }
 
 // Path: modalSheet.sortUser
@@ -1794,6 +1838,88 @@ class _TranslationsProfilePagePlaceholderBasicInformationJa implements Translati
 	@override String get toolTip => 'この項目は変更できません。';
 }
 
+// Path: weatherPersonalityDetailPage.section.mainResult
+class _TranslationsWeatherPersonalityDetailPageSectionMainResultJa implements TranslationsWeatherPersonalityDetailPageSectionMainResultEn {
+	_TranslationsWeatherPersonalityDetailPageSectionMainResultJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get typeCode => ' 診断タイプコード';
+	@override String get you => 'あなたは';
+}
+
+// Path: weatherPersonalityDetailPage.section.godsRuling
+class _TranslationsWeatherPersonalityDetailPageSectionGodsRulingJa implements TranslationsWeatherPersonalityDetailPageSectionGodsRulingEn {
+	_TranslationsWeatherPersonalityDetailPageSectionGodsRulingJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '神様の裁定文';
+}
+
+// Path: weatherPersonalityDetailPage.section.behaviorTendency
+class _TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyJa implements TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyEn {
+	_TranslationsWeatherPersonalityDetailPageSectionBehaviorTendencyJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '行動傾向';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisFeature
+class _TranslationsWeatherPersonalityDetailPageSectionAxisFeatureJa implements TranslationsWeatherPersonalityDetailPageSectionAxisFeatureEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisFeatureJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '4軸の特徴';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore
+class _TranslationsWeatherPersonalityDetailPageSectionAxisScoreJa implements TranslationsWeatherPersonalityDetailPageSectionAxisScoreEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisScoreJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '4軸スコア';
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisJa axis = _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisJa._(_root);
+}
+
+// Path: weatherPersonalityDetailPage.section.compatibleType
+class _TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeJa implements TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeEn {
+	_TranslationsWeatherPersonalityDetailPageSectionCompatibleTypeJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'あなたと相性の良いタイプ';
+}
+
+// Path: weatherPersonalityDetailPage.section.incompatibleType
+class _TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeJa implements TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeEn {
+	_TranslationsWeatherPersonalityDetailPageSectionIncompatibleTypeJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '注意が必要なタイプ';
+}
+
+// Path: weatherPersonalityDetailPage.section.godsMessage
+class _TranslationsWeatherPersonalityDetailPageSectionGodsMessageJa implements TranslationsWeatherPersonalityDetailPageSectionGodsMessageEn {
+	_TranslationsWeatherPersonalityDetailPageSectionGodsMessageJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '神様からの一言';
+}
+
 // Path: weatherPersonalityTestResultPage.section.mainResult
 class _TranslationsWeatherPersonalityTestResultPageSectionMainResultJa implements TranslationsWeatherPersonalityTestResultPageSectionMainResultEn {
 	_TranslationsWeatherPersonalityTestResultPageSectionMainResultJa._(this._root);
@@ -2061,6 +2187,19 @@ class _TranslationsProfilePagePlaceholderSubPhotoLabelsJa implements Translation
 	@override String get holiday => '休日';
 }
 
+// Path: weatherPersonalityDetailPage.section.axisScore.axis
+class _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisJa implements TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityJa sensitivity = _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessJa preparedness = _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityJa activity = _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityJa._(_root);
+	@override late final _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationJa motivation = _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationJa._(_root);
+}
+
 // Path: weatherPersonalityTestResultPage.section.axisScore.axis
 class _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisJa implements TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisEn {
 	_TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisJa._(this._root);
@@ -2072,6 +2211,50 @@ class _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisJa implem
 	@override late final _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisPreparednessJa preparedness = _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisPreparednessJa._(_root);
 	@override late final _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisActivityJa activity = _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisActivityJa._(_root);
 	@override late final _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisMotivationJa motivation = _TranslationsWeatherPersonalityTestResultPageSectionAxisScoreAxisMotivationJa._(_root);
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.sensitivity
+class _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityJa implements TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisSensitivityJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get sensitive => 'S（高感受）';
+	@override String get neutral => 'N（低感受）';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.preparedness
+class _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessJa implements TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisPreparednessJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get planned => 'P（計画）';
+	@override String get flexible => 'F（柔軟）';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.activity
+class _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityJa implements TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisActivityJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get outdoor => 'O（外向）';
+	@override String get indoor => 'I（内向）';
+}
+
+// Path: weatherPersonalityDetailPage.section.axisScore.axis.motivation
+class _TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationJa implements TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationEn {
+	_TranslationsWeatherPersonalityDetailPageSectionAxisScoreAxisMotivationJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get emotional => 'E（情緒）';
+	@override String get rational => 'R（実用）';
 }
 
 // Path: weatherPersonalityTestResultPage.section.axisScore.axis.sensitivity
@@ -2211,6 +2394,7 @@ extension on TranslationsJa {
 			'weatherReportDetailPage.label.forecast' => '五感予想',
 			'accountPage.nullCase' => 'ユーザー情報が取得できませんでした。',
 			'profilePage.title' => 'プロフィール編集',
+			'profilePage.nullCase' => 'プロフィール情報が取得できませんでした。',
 			'profilePage.section.mainPhoto' => 'メイン写真',
 			'profilePage.section.subPhoto' => 'サブ写真',
 			'profilePage.section.weatherPersonality' => 'ウェザーパーソナリティ',
@@ -2264,6 +2448,25 @@ extension on TranslationsJa {
 			'weatherPersonalityConceptPage.contentText.contentText4' => '16タイプのキャラ',
 			'weatherPersonalityConceptPage.contentText.contentText5' => 'に分類されます\n\n',
 			'weatherPersonalityConceptPage.contentText.contentText6' => '16の質問に答えて、\nあなたのウェザーパーソナルタイプを\n診断しましょう',
+			'weatherPersonalityDetailPage.title' => '診断結果',
+			'weatherPersonalityDetailPage.nullCase' => '診断結果の取得に失敗しました。',
+			'weatherPersonalityDetailPage.section.mainResult.typeCode' => ' 診断タイプコード',
+			'weatherPersonalityDetailPage.section.mainResult.you' => 'あなたは',
+			'weatherPersonalityDetailPage.section.godsRuling.title' => '神様の裁定文',
+			'weatherPersonalityDetailPage.section.behaviorTendency.title' => '行動傾向',
+			'weatherPersonalityDetailPage.section.axisFeature.title' => '4軸の特徴',
+			'weatherPersonalityDetailPage.section.axisScore.title' => '4軸スコア',
+			'weatherPersonalityDetailPage.section.axisScore.axis.sensitivity.sensitive' => 'S（高感受）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.sensitivity.neutral' => 'N（低感受）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.preparedness.planned' => 'P（計画）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.preparedness.flexible' => 'F（柔軟）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.activity.outdoor' => 'O（外向）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.activity.indoor' => 'I（内向）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.motivation.emotional' => 'E（情緒）',
+			'weatherPersonalityDetailPage.section.axisScore.axis.motivation.rational' => 'R（実用）',
+			'weatherPersonalityDetailPage.section.compatibleType.title' => 'あなたと相性の良いタイプ',
+			'weatherPersonalityDetailPage.section.incompatibleType.title' => '注意が必要なタイプ',
+			'weatherPersonalityDetailPage.section.godsMessage.title' => '神様からの一言',
 			'weatherPersonalityTestJudgingPage.loading' => '診断中',
 			'weatherPersonalityTestJudgingPage.contentText.contentTitle' => '診断完了',
 			'weatherPersonalityTestJudgingPage.contentText.contentText1' => '神様は、前世の行動記録を\nすべて見終えました。',
@@ -2401,6 +2604,8 @@ extension on TranslationsJa {
 			'dialog.interruptTest.contentText' => '回答内容は保存されません。\n本当に診断を中断しますか？',
 			'dialog.completeTest.title' => '診断完了の確認',
 			'dialog.completeTest.contentText' => '回答した内容を送信し、診断を完了しますか？',
+			'dialog.reTest.title' => '再診断の確認',
+			'dialog.reTest.contentText' => '診断をやり直すと、現在の診断結果は削除されます。\n本当に再診断しますか？',
 			'modalSheet.sortUser.title' => '並び替え',
 			'modalSheet.refineSearchUser.title' => '絞り込み条件',
 			'modalSheet.refineSearchUser.section.age' => '年齢',
@@ -2442,6 +2647,7 @@ extension on TranslationsJa {
 			'button.weatherPersonalityTest' => 'ウェザーパーソナリティ診断',
 			'button.goTochatPage' => 'チャット画面へ',
 			'button.rainbowLike' => 'レインボーいいね！',
+			'button.retest' => '再診断',
 			'segmentedSwitch.like.fromUser' => '相手から',
 			'segmentedSwitch.like.toUser' => '自分から',
 			'segmentedSwitch.chat.message' => 'メッセージ',
@@ -2615,6 +2821,8 @@ extension on TranslationsJa {
 			'kEnum.holiday.irregular' => '不定休',
 			'kEnum.occupation.universityStudent' => '大学生',
 			'kEnum.occupation.graduateStudent' => '大学院生',
+			_ => null,
+		} ?? switch (path) {
 			'kEnum.occupation.vocationalStudent' => '専門学生',
 			'kEnum.occupation.juniorCollegeStudent' => '短大生',
 			'kEnum.occupation.technicalCollegeStudent' => '高専生',
@@ -2638,8 +2846,6 @@ extension on TranslationsJa {
 			'kEnum.occupation.consulting' => 'コンサル',
 			'kEnum.occupation.massMedia' => 'マスコミ',
 			'kEnum.occupation.advertising' => '広告',
-			_ => null,
-		} ?? switch (path) {
 			'kEnum.occupation.publishing' => '出版',
 			'kEnum.occupation.education' => '教育関係',
 			'kEnum.occupation.retail' => '小売',

--- a/reimi/frontend/reimi_app/lib/core/router/app_router.dart
+++ b/reimi/frontend/reimi_app/lib/core/router/app_router.dart
@@ -22,6 +22,7 @@ import 'package:reimi_app/presentation/features/user_registration/pages/user_int
 import 'package:reimi_app/presentation/features/user_registration/pages/user_main_photo_page.dart';
 import 'package:reimi_app/presentation/features/user_registration/pages/user_name_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_concept_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_test_judging_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_test_q10_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_test_q11_page.dart';
@@ -284,6 +285,13 @@ GoRouter goRouter(Ref ref) {
         name: WeatherPersonalityConceptPage.routeName,
         builder: (context, state) {
           return const WeatherPersonalityConceptPage();
+        },
+      ),
+      GoRoute(
+        path: WeatherPersonalityDetailPage.routeLocation,
+        name: WeatherPersonalityDetailPage.routeName,
+        builder: (context, state) {
+          return const WeatherPersonalityDetailPage();
         },
       ),
       GoRoute(

--- a/reimi/frontend/reimi_app/lib/core/router/app_router.dart
+++ b/reimi/frontend/reimi_app/lib/core/router/app_router.dart
@@ -291,7 +291,9 @@ GoRouter goRouter(Ref ref) {
         path: WeatherPersonalityDetailPage.routeLocation,
         name: WeatherPersonalityDetailPage.routeName,
         builder: (context, state) {
-          return const WeatherPersonalityDetailPage();
+          final extra = state.extra! as Map<String, Object?>;
+          final userId = extra['userId'] as String?;
+          return WeatherPersonalityDetailPage(userId: userId);
         },
       ),
       GoRoute(

--- a/reimi/frontend/reimi_app/lib/core/router/app_router.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/router/app_router.g.dart
@@ -6,7 +6,7 @@ part of 'app_router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'5f361f1557a9c0c32c389d09eecdd7ce3bbbdc95';
+String _$goRouterHash() => r'e31476f35548fe3151bfa64bb4f1a3de03d2a8d4';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/reimi/frontend/reimi_app/lib/core/router/app_router.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/router/app_router.g.dart
@@ -6,7 +6,7 @@ part of 'app_router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'e31476f35548fe3151bfa64bb4f1a3de03d2a8d4';
+String _$goRouterHash() => r'6321940996e8e0ca460f24fdc57d90e8baf578ea';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_personality_mock_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_personality_mock_datasource.dart
@@ -19,8 +19,8 @@ class WeatherPersonalityMockDataSource
   }
 
   @override
-  Future<WeatherPersonalityDetailReadModel>
-      fetchWeatherPersonalityDetail() async {
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(
+      String userId) async {
     return mockWeatherPersonalityDetail;
   }
 }

--- a/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_personality_mock_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_personality_mock_datasource.dart
@@ -1,5 +1,7 @@
 import 'package:reimi_app/data/datasources/remote/weather_personality_remote_datasource.dart';
 import 'package:reimi_app/data/dtos/test_weather_personality_dto.dart';
+import 'package:reimi_app/domain/read_models/type_compatibility_read_model.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_result_read_model.dart';
 import 'package:reimi_app/gen/assets.gen.dart';
 
@@ -14,6 +16,12 @@ class WeatherPersonalityMockDataSource
   Future<WeatherPersonalityResultReadModel>
       fetchWeatherPersonalityResult() async {
     return mockWeatherPersonalityResult;
+  }
+
+  @override
+  Future<WeatherPersonalityDetailReadModel>
+      fetchWeatherPersonalityDetail() async {
+    return mockWeatherPersonalityDetail;
   }
 }
 
@@ -45,4 +53,66 @@ final mockWeatherPersonalityResult = WeatherPersonalityResultReadModel(
   godsMessage: 'あなたは、感情を弱点にせず、扱い方を知っていた珍しい存在です。\n\n'
       '揺れるのは悪いことではありません。\n'
       '揺れながらも浮いていられるなら、それは才能です。',
+);
+
+final mockWeatherPersonalityDetail = WeatherPersonalityDetailReadModel(
+  typeCode: 'SP0E',
+  typeName: 'トレーニーラッコ',
+  typeCatchphrase: '感情で揺れ、計画で浮かぶ。天気予報を信じすぎるラッコ。',
+  typeCharacterImageUrl:
+      Assets.images.weatherPersonality.spoeTraineeSeaOtterImage.path,
+  rulingStatement: '神様は、前世のあなたが\n'
+      '空模様を確認してから一日を始める姿を、何度も見ていました。\n\n'
+      '雨が降りそうな日は少し不安そうに、\n'
+      '晴れの日には理由もなく機嫌がよくなる——\n\n'
+      'その姿は、まるで波に身を任せるラッコのようでした。',
+  axisFeatures: [
+    '天気・空気・人の機嫌を即座に察知。ちょっとした曇り空でも「今日はそういう日かも」と感じ取る。',
+    '感情が揺れることを前提に、「落ちた時用の逃げ道」をあらかじめ用意する賢さ。',
+    '家にこもると余計に気分が沈むタイプ。気分が良い日は、理由なく外に出たくなる。',
+    '効率よりも「気持ちよくできたか」を重視。心が納得しないと、どんな正解でも選ばない。',
+  ],
+  axisScore: [8, 0, 7, -5],
+  behaviorTendencyList: [
+    '天気予報を見てから予定を組み直す。「雨か…じゃあカフェ多めの日にしよう」と柔軟に修正。',
+    '落ち込む未来を想定して先回りする。元気なうちに好きな音楽や予定をストックしておく。',
+    '周囲の空気が悪いと、無意識に整えにいく。雑談を振ったり、ちょっとした冗談を入れたり。',
+    '気分が乗ると一気に行動量が跳ね上がる。晴れの日は「今日いける気がする」で全部片付ける。',
+    '自分より他人の感情に敏感。「あ、この人今日ちょっと沈んでるな」にすぐ気づく。',
+  ],
+  godsMessage: 'あなたは、感情を弱点にせず、扱い方を知っていた珍しい存在です。\n\n'
+      '揺れるのは悪いことではありません。\n'
+      '揺れながらも浮いていられるなら、それは才能です。',
+  compatibleTypes: [
+    TypeCompatibilityReadModel(
+      typeCode: 'SPOE',
+      typeName: 'トレーニーラッコ',
+      typeCharacterImageUrl:
+          Assets.images.weatherPersonality.spoeTraineeSeaOtterImage.path,
+      compatibilityPoint: '感受性と外向性が近く、計画と即応が自然に役割分担できる。',
+    ),
+    TypeCompatibilityReadModel(
+      typeCode: 'NFIE',
+      typeName: 'やわらかタコ',
+      typeCharacterImageUrl:
+          Assets.images.weatherPersonality.nfieSoftOctopusImage.path,
+      compatibilityPoint: '気分や空気感を共有しやすく、一緒にいるだけで前向きになれる。',
+    ),
+  ],
+  incompatibleTypes: [
+    TypeCompatibilityReadModel(
+      typeCode: 'SPOE',
+      typeName: 'トレーニーラッコ',
+      typeCharacterImageUrl:
+          Assets.images.weatherPersonality.spoeTraineeSeaOtterImage.path,
+      compatibilityPoint: '判断が合理と内向に寄りがちで、感情ベースの動きが伝わりにくい。',
+    ),
+    TypeCompatibilityReadModel(
+      typeCode: 'NFIE',
+      typeName: 'やわらかタコ',
+      typeCharacterImageUrl:
+          Assets.images.weatherPersonality.nfieSoftOctopusImage.path,
+      compatibilityPoint: '行動は噛み合っても、感情への向き合い方がズレやすい。',
+    ),
+  ],
 );

--- a/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_report_mock_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_report_mock_datasource.dart
@@ -55,11 +55,11 @@ final List<WeatherReportSimpleReadModel> mockSimpleWeatherReports = [
     mediaType: MediaType.image,
     url:
         'https://images.unsplash.com/photo-1495616811223-4d98c6e9c869?auto=format&fit=crop&q=80&w=1000',
-    createdAt: DateTime.now().subtract(const Duration(minutes: 5)),
+    createdAt: DateTime.now().subtract(const Duration(days: 1)),
   ),
   WeatherReportSimpleReadModel(
     reportId: 'report_003',
-    userId: 'user_c789',
+    userId: 'user_000',
     comment: '入道雲が出てきました。夏本番という感じですね。',
     mediaType: MediaType.image,
     url:
@@ -165,6 +165,23 @@ final List<WeatherReportReadModel> mockWeatherReports = [
     reportComment: ['#夕焼け', '#マジックアワー'],
     likeCount: 89,
     commentCount: 3,
+    createdAt: DateTime.now().subtract(const Duration(hours: 3)),
+  ),
+  WeatherReportReadModel(
+    reportId: 'report_003',
+    userId: 'user_000',
+    userName: 'メンダコ',
+    mainPhotoUrl: Assets.images.sample.user000SampleImage.path,
+    comment: '入道雲が出てきました。夏本番という感じですね。',
+    weatherType: WeatherType.noStar,
+    feelingType: FeelingType.warm,
+    forecastType: ForecastType.noChange,
+    mediaType: MediaType.image,
+    url:
+        'https://images.unsplash.com/photo-1534088568595-a066f410bcda?auto=format&fit=crop&q=80&w=1000',
+    reportComment: ['#入道雲', '#夏'],
+    likeCount: 96,
+    commentCount: 4,
     createdAt: DateTime.now().subtract(const Duration(hours: 3)),
   ),
 ];

--- a/reimi/frontend/reimi_app/lib/data/datasources/remote/weather_personality_remote_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/remote/weather_personality_remote_datasource.dart
@@ -5,7 +5,7 @@ import 'package:reimi_app/domain/read_models/weather_personality_result_read_mod
 abstract class WeatherPersonalityRemoteDataSource {
   Future<void> testWeatherPersonality(TestWeatherPersonalityDto dto);
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult();
-  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail();
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(String userId);
 }
 
 class WeatherPersonalityRemoteDataSourceImpl
@@ -25,7 +25,7 @@ class WeatherPersonalityRemoteDataSourceImpl
   }
   
   @override
-  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail() {
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(String userId) {
     // TODO: implement fetchWeatherPersonalityDetail
     throw UnimplementedError();
   }

--- a/reimi/frontend/reimi_app/lib/data/datasources/remote/weather_personality_remote_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/remote/weather_personality_remote_datasource.dart
@@ -1,9 +1,11 @@
 import 'package:reimi_app/data/dtos/test_weather_personality_dto.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_result_read_model.dart';
 
 abstract class WeatherPersonalityRemoteDataSource {
   Future<void> testWeatherPersonality(TestWeatherPersonalityDto dto);
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult();
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail();
 }
 
 class WeatherPersonalityRemoteDataSourceImpl
@@ -15,10 +17,16 @@ class WeatherPersonalityRemoteDataSourceImpl
     // TODO: implement postWeatherReport
     throw UnimplementedError();
   }
-  
+
   @override
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult() {
     // TODO: implement fetchWeatherPersonalityResult
+    throw UnimplementedError();
+  }
+  
+  @override
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail() {
+    // TODO: implement fetchWeatherPersonalityDetail
     throw UnimplementedError();
   }
 }

--- a/reimi/frontend/reimi_app/lib/data/repositories/weather_personality_repository_impl.dart
+++ b/reimi/frontend/reimi_app/lib/data/repositories/weather_personality_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:reimi_app/data/datasources/remote/weather_personality_remote_datasource.dart';
 import 'package:reimi_app/data/extensions/test_weather_personality_dto_extension.dart';
 import 'package:reimi_app/domain/params/test_weather_personality_params.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_result_read_model.dart';
 import 'package:reimi_app/domain/repositories/weather_personality_repository.dart';
 
@@ -17,5 +18,10 @@ class WeatherPersonalityRepositoryImpl implements WeatherPersonalityRepository {
   @override
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult() {
     return _remote.fetchWeatherPersonalityResult();
+  }
+
+  @override
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail() {
+    return _remote.fetchWeatherPersonalityDetail();
   }
 }

--- a/reimi/frontend/reimi_app/lib/data/repositories/weather_personality_repository_impl.dart
+++ b/reimi/frontend/reimi_app/lib/data/repositories/weather_personality_repository_impl.dart
@@ -21,7 +21,7 @@ class WeatherPersonalityRepositoryImpl implements WeatherPersonalityRepository {
   }
 
   @override
-  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail() {
-    return _remote.fetchWeatherPersonalityDetail();
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(String userId) {
+    return _remote.fetchWeatherPersonalityDetail(userId);
   }
 }

--- a/reimi/frontend/reimi_app/lib/domain/read_models/type_compatibility_read_model.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/type_compatibility_read_model.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'type_compatibility_read_model.freezed.dart';
+part 'type_compatibility_read_model.g.dart';
+
+@freezed
+abstract class TypeCompatibilityReadModel
+    with _$TypeCompatibilityReadModel {
+  const factory TypeCompatibilityReadModel({
+    required String typeCode,
+    required String typeName,
+    required String typeCharacterImageUrl,
+    required String compatibilityPoint,
+  }) = _TypeCompatibilityReadModel;
+
+  factory TypeCompatibilityReadModel.fromJson(
+          Map<String, dynamic> json) =>
+      _$TypeCompatibilityReadModelFromJson(json);
+}

--- a/reimi/frontend/reimi_app/lib/domain/read_models/type_compatibility_read_model.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/type_compatibility_read_model.freezed.dart
@@ -1,0 +1,395 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'type_compatibility_read_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$TypeCompatibilityReadModel {
+  String get typeCode;
+  String get typeName;
+  String get typeCharacterImageUrl;
+  String get compatibilityPoint;
+
+  /// Create a copy of TypeCompatibilityReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $TypeCompatibilityReadModelCopyWith<TypeCompatibilityReadModel>
+      get copyWith =>
+          _$TypeCompatibilityReadModelCopyWithImpl<TypeCompatibilityReadModel>(
+              this as TypeCompatibilityReadModel, _$identity);
+
+  /// Serializes this TypeCompatibilityReadModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is TypeCompatibilityReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCharacterImageUrl, typeCharacterImageUrl) ||
+                other.typeCharacterImageUrl == typeCharacterImageUrl) &&
+            (identical(other.compatibilityPoint, compatibilityPoint) ||
+                other.compatibilityPoint == compatibilityPoint));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, typeCode, typeName,
+      typeCharacterImageUrl, compatibilityPoint);
+
+  @override
+  String toString() {
+    return 'TypeCompatibilityReadModel(typeCode: $typeCode, typeName: $typeName, typeCharacterImageUrl: $typeCharacterImageUrl, compatibilityPoint: $compatibilityPoint)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $TypeCompatibilityReadModelCopyWith<$Res> {
+  factory $TypeCompatibilityReadModelCopyWith(TypeCompatibilityReadModel value,
+          $Res Function(TypeCompatibilityReadModel) _then) =
+      _$TypeCompatibilityReadModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String typeCode,
+      String typeName,
+      String typeCharacterImageUrl,
+      String compatibilityPoint});
+}
+
+/// @nodoc
+class _$TypeCompatibilityReadModelCopyWithImpl<$Res>
+    implements $TypeCompatibilityReadModelCopyWith<$Res> {
+  _$TypeCompatibilityReadModelCopyWithImpl(this._self, this._then);
+
+  final TypeCompatibilityReadModel _self;
+  final $Res Function(TypeCompatibilityReadModel) _then;
+
+  /// Create a copy of TypeCompatibilityReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCharacterImageUrl = null,
+    Object? compatibilityPoint = null,
+  }) {
+    return _then(_self.copyWith(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCharacterImageUrl: null == typeCharacterImageUrl
+          ? _self.typeCharacterImageUrl
+          : typeCharacterImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      compatibilityPoint: null == compatibilityPoint
+          ? _self.compatibilityPoint
+          : compatibilityPoint // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [TypeCompatibilityReadModel].
+extension TypeCompatibilityReadModelPatterns on TypeCompatibilityReadModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_TypeCompatibilityReadModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TypeCompatibilityReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_TypeCompatibilityReadModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TypeCompatibilityReadModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_TypeCompatibilityReadModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TypeCompatibilityReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String typeCode, String typeName,
+            String typeCharacterImageUrl, String compatibilityPoint)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _TypeCompatibilityReadModel() when $default != null:
+        return $default(_that.typeCode, _that.typeName,
+            _that.typeCharacterImageUrl, _that.compatibilityPoint);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String typeCode, String typeName,
+            String typeCharacterImageUrl, String compatibilityPoint)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TypeCompatibilityReadModel():
+        return $default(_that.typeCode, _that.typeName,
+            _that.typeCharacterImageUrl, _that.compatibilityPoint);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String typeCode, String typeName,
+            String typeCharacterImageUrl, String compatibilityPoint)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _TypeCompatibilityReadModel() when $default != null:
+        return $default(_that.typeCode, _that.typeName,
+            _that.typeCharacterImageUrl, _that.compatibilityPoint);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _TypeCompatibilityReadModel implements TypeCompatibilityReadModel {
+  const _TypeCompatibilityReadModel(
+      {required this.typeCode,
+      required this.typeName,
+      required this.typeCharacterImageUrl,
+      required this.compatibilityPoint});
+  factory _TypeCompatibilityReadModel.fromJson(Map<String, dynamic> json) =>
+      _$TypeCompatibilityReadModelFromJson(json);
+
+  @override
+  final String typeCode;
+  @override
+  final String typeName;
+  @override
+  final String typeCharacterImageUrl;
+  @override
+  final String compatibilityPoint;
+
+  /// Create a copy of TypeCompatibilityReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TypeCompatibilityReadModelCopyWith<_TypeCompatibilityReadModel>
+      get copyWith => __$TypeCompatibilityReadModelCopyWithImpl<
+          _TypeCompatibilityReadModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$TypeCompatibilityReadModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _TypeCompatibilityReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCharacterImageUrl, typeCharacterImageUrl) ||
+                other.typeCharacterImageUrl == typeCharacterImageUrl) &&
+            (identical(other.compatibilityPoint, compatibilityPoint) ||
+                other.compatibilityPoint == compatibilityPoint));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, typeCode, typeName,
+      typeCharacterImageUrl, compatibilityPoint);
+
+  @override
+  String toString() {
+    return 'TypeCompatibilityReadModel(typeCode: $typeCode, typeName: $typeName, typeCharacterImageUrl: $typeCharacterImageUrl, compatibilityPoint: $compatibilityPoint)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$TypeCompatibilityReadModelCopyWith<$Res>
+    implements $TypeCompatibilityReadModelCopyWith<$Res> {
+  factory _$TypeCompatibilityReadModelCopyWith(
+          _TypeCompatibilityReadModel value,
+          $Res Function(_TypeCompatibilityReadModel) _then) =
+      __$TypeCompatibilityReadModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String typeCode,
+      String typeName,
+      String typeCharacterImageUrl,
+      String compatibilityPoint});
+}
+
+/// @nodoc
+class __$TypeCompatibilityReadModelCopyWithImpl<$Res>
+    implements _$TypeCompatibilityReadModelCopyWith<$Res> {
+  __$TypeCompatibilityReadModelCopyWithImpl(this._self, this._then);
+
+  final _TypeCompatibilityReadModel _self;
+  final $Res Function(_TypeCompatibilityReadModel) _then;
+
+  /// Create a copy of TypeCompatibilityReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCharacterImageUrl = null,
+    Object? compatibilityPoint = null,
+  }) {
+    return _then(_TypeCompatibilityReadModel(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCharacterImageUrl: null == typeCharacterImageUrl
+          ? _self.typeCharacterImageUrl
+          : typeCharacterImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      compatibilityPoint: null == compatibilityPoint
+          ? _self.compatibilityPoint
+          : compatibilityPoint // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/domain/read_models/type_compatibility_read_model.g.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/type_compatibility_read_model.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'type_compatibility_read_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_TypeCompatibilityReadModel _$TypeCompatibilityReadModelFromJson(
+        Map<String, dynamic> json) =>
+    _TypeCompatibilityReadModel(
+      typeCode: json['typeCode'] as String,
+      typeName: json['typeName'] as String,
+      typeCharacterImageUrl: json['typeCharacterImageUrl'] as String,
+      compatibilityPoint: json['compatibilityPoint'] as String,
+    );
+
+Map<String, dynamic> _$TypeCompatibilityReadModelToJson(
+        _TypeCompatibilityReadModel instance) =>
+    <String, dynamic>{
+      'typeCode': instance.typeCode,
+      'typeName': instance.typeName,
+      'typeCharacterImageUrl': instance.typeCharacterImageUrl,
+      'compatibilityPoint': instance.compatibilityPoint,
+    };

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_detail_read_model.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_detail_read_model.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/domain/read_models/type_compatibility_read_model.dart';
+
+part 'weather_personality_detail_read_model.freezed.dart';
+part 'weather_personality_detail_read_model.g.dart';
+
+@freezed
+abstract class WeatherPersonalityDetailReadModel
+    with _$WeatherPersonalityDetailReadModel {
+  const factory WeatherPersonalityDetailReadModel({
+    required String typeCode,
+    required String typeName,
+    required String typeCatchphrase,
+    required String typeCharacterImageUrl,
+    required String rulingStatement,
+    required List<String> axisFeatures,
+    required List<int> axisScore,
+    required List<String> behaviorTendencyList,
+    required List<TypeCompatibilityReadModel> compatibleTypes,
+    required List<TypeCompatibilityReadModel> incompatibleTypes,
+    required String godsMessage,
+  }) = _WeatherPersonalityDetailReadModel;
+
+  factory WeatherPersonalityDetailReadModel.fromJson(
+          Map<String, dynamic> json) =>
+      _$WeatherPersonalityDetailReadModelFromJson(json);
+}

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_detail_read_model.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_detail_read_model.freezed.dart
@@ -1,0 +1,658 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_personality_detail_read_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WeatherPersonalityDetailReadModel {
+  String get typeCode;
+  String get typeName;
+  String get typeCatchphrase;
+  String get typeCharacterImageUrl;
+  String get rulingStatement;
+  List<String> get axisFeatures;
+  List<int> get axisScore;
+  List<String> get behaviorTendencyList;
+  List<TypeCompatibilityReadModel> get compatibleTypes;
+  List<TypeCompatibilityReadModel> get incompatibleTypes;
+  String get godsMessage;
+
+  /// Create a copy of WeatherPersonalityDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityDetailReadModelCopyWith<WeatherPersonalityDetailReadModel>
+      get copyWith => _$WeatherPersonalityDetailReadModelCopyWithImpl<
+              WeatherPersonalityDetailReadModel>(
+          this as WeatherPersonalityDetailReadModel, _$identity);
+
+  /// Serializes this WeatherPersonalityDetailReadModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WeatherPersonalityDetailReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCatchphrase, typeCatchphrase) ||
+                other.typeCatchphrase == typeCatchphrase) &&
+            (identical(other.typeCharacterImageUrl, typeCharacterImageUrl) ||
+                other.typeCharacterImageUrl == typeCharacterImageUrl) &&
+            (identical(other.rulingStatement, rulingStatement) ||
+                other.rulingStatement == rulingStatement) &&
+            const DeepCollectionEquality()
+                .equals(other.axisFeatures, axisFeatures) &&
+            const DeepCollectionEquality().equals(other.axisScore, axisScore) &&
+            const DeepCollectionEquality()
+                .equals(other.behaviorTendencyList, behaviorTendencyList) &&
+            const DeepCollectionEquality()
+                .equals(other.compatibleTypes, compatibleTypes) &&
+            const DeepCollectionEquality()
+                .equals(other.incompatibleTypes, incompatibleTypes) &&
+            (identical(other.godsMessage, godsMessage) ||
+                other.godsMessage == godsMessage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      typeCode,
+      typeName,
+      typeCatchphrase,
+      typeCharacterImageUrl,
+      rulingStatement,
+      const DeepCollectionEquality().hash(axisFeatures),
+      const DeepCollectionEquality().hash(axisScore),
+      const DeepCollectionEquality().hash(behaviorTendencyList),
+      const DeepCollectionEquality().hash(compatibleTypes),
+      const DeepCollectionEquality().hash(incompatibleTypes),
+      godsMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityDetailReadModel(typeCode: $typeCode, typeName: $typeName, typeCatchphrase: $typeCatchphrase, typeCharacterImageUrl: $typeCharacterImageUrl, rulingStatement: $rulingStatement, axisFeatures: $axisFeatures, axisScore: $axisScore, behaviorTendencyList: $behaviorTendencyList, compatibleTypes: $compatibleTypes, incompatibleTypes: $incompatibleTypes, godsMessage: $godsMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WeatherPersonalityDetailReadModelCopyWith<$Res> {
+  factory $WeatherPersonalityDetailReadModelCopyWith(
+          WeatherPersonalityDetailReadModel value,
+          $Res Function(WeatherPersonalityDetailReadModel) _then) =
+      _$WeatherPersonalityDetailReadModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String typeCode,
+      String typeName,
+      String typeCatchphrase,
+      String typeCharacterImageUrl,
+      String rulingStatement,
+      List<String> axisFeatures,
+      List<int> axisScore,
+      List<String> behaviorTendencyList,
+      List<TypeCompatibilityReadModel> compatibleTypes,
+      List<TypeCompatibilityReadModel> incompatibleTypes,
+      String godsMessage});
+}
+
+/// @nodoc
+class _$WeatherPersonalityDetailReadModelCopyWithImpl<$Res>
+    implements $WeatherPersonalityDetailReadModelCopyWith<$Res> {
+  _$WeatherPersonalityDetailReadModelCopyWithImpl(this._self, this._then);
+
+  final WeatherPersonalityDetailReadModel _self;
+  final $Res Function(WeatherPersonalityDetailReadModel) _then;
+
+  /// Create a copy of WeatherPersonalityDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCatchphrase = null,
+    Object? typeCharacterImageUrl = null,
+    Object? rulingStatement = null,
+    Object? axisFeatures = null,
+    Object? axisScore = null,
+    Object? behaviorTendencyList = null,
+    Object? compatibleTypes = null,
+    Object? incompatibleTypes = null,
+    Object? godsMessage = null,
+  }) {
+    return _then(_self.copyWith(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCatchphrase: null == typeCatchphrase
+          ? _self.typeCatchphrase
+          : typeCatchphrase // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCharacterImageUrl: null == typeCharacterImageUrl
+          ? _self.typeCharacterImageUrl
+          : typeCharacterImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      rulingStatement: null == rulingStatement
+          ? _self.rulingStatement
+          : rulingStatement // ignore: cast_nullable_to_non_nullable
+              as String,
+      axisFeatures: null == axisFeatures
+          ? _self.axisFeatures
+          : axisFeatures // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      axisScore: null == axisScore
+          ? _self.axisScore
+          : axisScore // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+      behaviorTendencyList: null == behaviorTendencyList
+          ? _self.behaviorTendencyList
+          : behaviorTendencyList // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      compatibleTypes: null == compatibleTypes
+          ? _self.compatibleTypes
+          : compatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      incompatibleTypes: null == incompatibleTypes
+          ? _self.incompatibleTypes
+          : incompatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      godsMessage: null == godsMessage
+          ? _self.godsMessage
+          : godsMessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [WeatherPersonalityDetailReadModel].
+extension WeatherPersonalityDetailReadModelPatterns
+    on WeatherPersonalityDetailReadModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityDetailReadModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityDetailReadModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailReadModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_WeatherPersonalityDetailReadModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String typeCode,
+            String typeName,
+            String typeCatchphrase,
+            String typeCharacterImageUrl,
+            String rulingStatement,
+            List<String> axisFeatures,
+            List<int> axisScore,
+            List<String> behaviorTendencyList,
+            List<TypeCompatibilityReadModel> compatibleTypes,
+            List<TypeCompatibilityReadModel> incompatibleTypes,
+            String godsMessage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailReadModel() when $default != null:
+        return $default(
+            _that.typeCode,
+            _that.typeName,
+            _that.typeCatchphrase,
+            _that.typeCharacterImageUrl,
+            _that.rulingStatement,
+            _that.axisFeatures,
+            _that.axisScore,
+            _that.behaviorTendencyList,
+            _that.compatibleTypes,
+            _that.incompatibleTypes,
+            _that.godsMessage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String typeCode,
+            String typeName,
+            String typeCatchphrase,
+            String typeCharacterImageUrl,
+            String rulingStatement,
+            List<String> axisFeatures,
+            List<int> axisScore,
+            List<String> behaviorTendencyList,
+            List<TypeCompatibilityReadModel> compatibleTypes,
+            List<TypeCompatibilityReadModel> incompatibleTypes,
+            String godsMessage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailReadModel():
+        return $default(
+            _that.typeCode,
+            _that.typeName,
+            _that.typeCatchphrase,
+            _that.typeCharacterImageUrl,
+            _that.rulingStatement,
+            _that.axisFeatures,
+            _that.axisScore,
+            _that.behaviorTendencyList,
+            _that.compatibleTypes,
+            _that.incompatibleTypes,
+            _that.godsMessage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String typeCode,
+            String typeName,
+            String typeCatchphrase,
+            String typeCharacterImageUrl,
+            String rulingStatement,
+            List<String> axisFeatures,
+            List<int> axisScore,
+            List<String> behaviorTendencyList,
+            List<TypeCompatibilityReadModel> compatibleTypes,
+            List<TypeCompatibilityReadModel> incompatibleTypes,
+            String godsMessage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailReadModel() when $default != null:
+        return $default(
+            _that.typeCode,
+            _that.typeName,
+            _that.typeCatchphrase,
+            _that.typeCharacterImageUrl,
+            _that.rulingStatement,
+            _that.axisFeatures,
+            _that.axisScore,
+            _that.behaviorTendencyList,
+            _that.compatibleTypes,
+            _that.incompatibleTypes,
+            _that.godsMessage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _WeatherPersonalityDetailReadModel
+    implements WeatherPersonalityDetailReadModel {
+  const _WeatherPersonalityDetailReadModel(
+      {required this.typeCode,
+      required this.typeName,
+      required this.typeCatchphrase,
+      required this.typeCharacterImageUrl,
+      required this.rulingStatement,
+      required final List<String> axisFeatures,
+      required final List<int> axisScore,
+      required final List<String> behaviorTendencyList,
+      required final List<TypeCompatibilityReadModel> compatibleTypes,
+      required final List<TypeCompatibilityReadModel> incompatibleTypes,
+      required this.godsMessage})
+      : _axisFeatures = axisFeatures,
+        _axisScore = axisScore,
+        _behaviorTendencyList = behaviorTendencyList,
+        _compatibleTypes = compatibleTypes,
+        _incompatibleTypes = incompatibleTypes;
+  factory _WeatherPersonalityDetailReadModel.fromJson(
+          Map<String, dynamic> json) =>
+      _$WeatherPersonalityDetailReadModelFromJson(json);
+
+  @override
+  final String typeCode;
+  @override
+  final String typeName;
+  @override
+  final String typeCatchphrase;
+  @override
+  final String typeCharacterImageUrl;
+  @override
+  final String rulingStatement;
+  final List<String> _axisFeatures;
+  @override
+  List<String> get axisFeatures {
+    if (_axisFeatures is EqualUnmodifiableListView) return _axisFeatures;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_axisFeatures);
+  }
+
+  final List<int> _axisScore;
+  @override
+  List<int> get axisScore {
+    if (_axisScore is EqualUnmodifiableListView) return _axisScore;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_axisScore);
+  }
+
+  final List<String> _behaviorTendencyList;
+  @override
+  List<String> get behaviorTendencyList {
+    if (_behaviorTendencyList is EqualUnmodifiableListView)
+      return _behaviorTendencyList;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_behaviorTendencyList);
+  }
+
+  final List<TypeCompatibilityReadModel> _compatibleTypes;
+  @override
+  List<TypeCompatibilityReadModel> get compatibleTypes {
+    if (_compatibleTypes is EqualUnmodifiableListView) return _compatibleTypes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_compatibleTypes);
+  }
+
+  final List<TypeCompatibilityReadModel> _incompatibleTypes;
+  @override
+  List<TypeCompatibilityReadModel> get incompatibleTypes {
+    if (_incompatibleTypes is EqualUnmodifiableListView)
+      return _incompatibleTypes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_incompatibleTypes);
+  }
+
+  @override
+  final String godsMessage;
+
+  /// Create a copy of WeatherPersonalityDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$WeatherPersonalityDetailReadModelCopyWith<
+          _WeatherPersonalityDetailReadModel>
+      get copyWith => __$WeatherPersonalityDetailReadModelCopyWithImpl<
+          _WeatherPersonalityDetailReadModel>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$WeatherPersonalityDetailReadModelToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WeatherPersonalityDetailReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCatchphrase, typeCatchphrase) ||
+                other.typeCatchphrase == typeCatchphrase) &&
+            (identical(other.typeCharacterImageUrl, typeCharacterImageUrl) ||
+                other.typeCharacterImageUrl == typeCharacterImageUrl) &&
+            (identical(other.rulingStatement, rulingStatement) ||
+                other.rulingStatement == rulingStatement) &&
+            const DeepCollectionEquality()
+                .equals(other._axisFeatures, _axisFeatures) &&
+            const DeepCollectionEquality()
+                .equals(other._axisScore, _axisScore) &&
+            const DeepCollectionEquality()
+                .equals(other._behaviorTendencyList, _behaviorTendencyList) &&
+            const DeepCollectionEquality()
+                .equals(other._compatibleTypes, _compatibleTypes) &&
+            const DeepCollectionEquality()
+                .equals(other._incompatibleTypes, _incompatibleTypes) &&
+            (identical(other.godsMessage, godsMessage) ||
+                other.godsMessage == godsMessage));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      typeCode,
+      typeName,
+      typeCatchphrase,
+      typeCharacterImageUrl,
+      rulingStatement,
+      const DeepCollectionEquality().hash(_axisFeatures),
+      const DeepCollectionEquality().hash(_axisScore),
+      const DeepCollectionEquality().hash(_behaviorTendencyList),
+      const DeepCollectionEquality().hash(_compatibleTypes),
+      const DeepCollectionEquality().hash(_incompatibleTypes),
+      godsMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityDetailReadModel(typeCode: $typeCode, typeName: $typeName, typeCatchphrase: $typeCatchphrase, typeCharacterImageUrl: $typeCharacterImageUrl, rulingStatement: $rulingStatement, axisFeatures: $axisFeatures, axisScore: $axisScore, behaviorTendencyList: $behaviorTendencyList, compatibleTypes: $compatibleTypes, incompatibleTypes: $incompatibleTypes, godsMessage: $godsMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$WeatherPersonalityDetailReadModelCopyWith<$Res>
+    implements $WeatherPersonalityDetailReadModelCopyWith<$Res> {
+  factory _$WeatherPersonalityDetailReadModelCopyWith(
+          _WeatherPersonalityDetailReadModel value,
+          $Res Function(_WeatherPersonalityDetailReadModel) _then) =
+      __$WeatherPersonalityDetailReadModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String typeCode,
+      String typeName,
+      String typeCatchphrase,
+      String typeCharacterImageUrl,
+      String rulingStatement,
+      List<String> axisFeatures,
+      List<int> axisScore,
+      List<String> behaviorTendencyList,
+      List<TypeCompatibilityReadModel> compatibleTypes,
+      List<TypeCompatibilityReadModel> incompatibleTypes,
+      String godsMessage});
+}
+
+/// @nodoc
+class __$WeatherPersonalityDetailReadModelCopyWithImpl<$Res>
+    implements _$WeatherPersonalityDetailReadModelCopyWith<$Res> {
+  __$WeatherPersonalityDetailReadModelCopyWithImpl(this._self, this._then);
+
+  final _WeatherPersonalityDetailReadModel _self;
+  final $Res Function(_WeatherPersonalityDetailReadModel) _then;
+
+  /// Create a copy of WeatherPersonalityDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCatchphrase = null,
+    Object? typeCharacterImageUrl = null,
+    Object? rulingStatement = null,
+    Object? axisFeatures = null,
+    Object? axisScore = null,
+    Object? behaviorTendencyList = null,
+    Object? compatibleTypes = null,
+    Object? incompatibleTypes = null,
+    Object? godsMessage = null,
+  }) {
+    return _then(_WeatherPersonalityDetailReadModel(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCatchphrase: null == typeCatchphrase
+          ? _self.typeCatchphrase
+          : typeCatchphrase // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCharacterImageUrl: null == typeCharacterImageUrl
+          ? _self.typeCharacterImageUrl
+          : typeCharacterImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      rulingStatement: null == rulingStatement
+          ? _self.rulingStatement
+          : rulingStatement // ignore: cast_nullable_to_non_nullable
+              as String,
+      axisFeatures: null == axisFeatures
+          ? _self._axisFeatures
+          : axisFeatures // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      axisScore: null == axisScore
+          ? _self._axisScore
+          : axisScore // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+      behaviorTendencyList: null == behaviorTendencyList
+          ? _self._behaviorTendencyList
+          : behaviorTendencyList // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      compatibleTypes: null == compatibleTypes
+          ? _self._compatibleTypes
+          : compatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      incompatibleTypes: null == incompatibleTypes
+          ? _self._incompatibleTypes
+          : incompatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      godsMessage: null == godsMessage
+          ? _self.godsMessage
+          : godsMessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_detail_read_model.g.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_detail_read_model.g.dart
@@ -1,0 +1,51 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_personality_detail_read_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_WeatherPersonalityDetailReadModel _$WeatherPersonalityDetailReadModelFromJson(
+        Map<String, dynamic> json) =>
+    _WeatherPersonalityDetailReadModel(
+      typeCode: json['typeCode'] as String,
+      typeName: json['typeName'] as String,
+      typeCatchphrase: json['typeCatchphrase'] as String,
+      typeCharacterImageUrl: json['typeCharacterImageUrl'] as String,
+      rulingStatement: json['rulingStatement'] as String,
+      axisFeatures: (json['axisFeatures'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      axisScore: (json['axisScore'] as List<dynamic>)
+          .map((e) => (e as num).toInt())
+          .toList(),
+      behaviorTendencyList: (json['behaviorTendencyList'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      compatibleTypes: (json['compatibleTypes'] as List<dynamic>)
+          .map((e) =>
+              TypeCompatibilityReadModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      incompatibleTypes: (json['incompatibleTypes'] as List<dynamic>)
+          .map((e) =>
+              TypeCompatibilityReadModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      godsMessage: json['godsMessage'] as String,
+    );
+
+Map<String, dynamic> _$WeatherPersonalityDetailReadModelToJson(
+        _WeatherPersonalityDetailReadModel instance) =>
+    <String, dynamic>{
+      'typeCode': instance.typeCode,
+      'typeName': instance.typeName,
+      'typeCatchphrase': instance.typeCatchphrase,
+      'typeCharacterImageUrl': instance.typeCharacterImageUrl,
+      'rulingStatement': instance.rulingStatement,
+      'axisFeatures': instance.axisFeatures,
+      'axisScore': instance.axisScore,
+      'behaviorTendencyList': instance.behaviorTendencyList,
+      'compatibleTypes': instance.compatibleTypes,
+      'incompatibleTypes': instance.incompatibleTypes,
+      'godsMessage': instance.godsMessage,
+    };

--- a/reimi/frontend/reimi_app/lib/domain/repositories/weather_personality_repository.dart
+++ b/reimi/frontend/reimi_app/lib/domain/repositories/weather_personality_repository.dart
@@ -1,7 +1,9 @@
 import 'package:reimi_app/domain/params/test_weather_personality_params.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_result_read_model.dart';
 
 abstract class WeatherPersonalityRepository {
   Future<void> testWeatherPersonality(TestWeatherPersonalityParams params);
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult();
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail();
 }

--- a/reimi/frontend/reimi_app/lib/domain/repositories/weather_personality_repository.dart
+++ b/reimi/frontend/reimi_app/lib/domain/repositories/weather_personality_repository.dart
@@ -5,5 +5,5 @@ import 'package:reimi_app/domain/read_models/weather_personality_result_read_mod
 abstract class WeatherPersonalityRepository {
   Future<void> testWeatherPersonality(TestWeatherPersonalityParams params);
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult();
-  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail();
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(String userId);
 }

--- a/reimi/frontend/reimi_app/lib/presentation/features/account/account_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/account/account_page.dart
@@ -8,7 +8,8 @@ import 'package:reimi_app/gen/assets.gen.dart';
 import 'package:reimi_app/core/i18n/strings.g.dart';
 import 'package:reimi_app/presentation/features/account/notifiers/account_notifier.dart';
 import 'package:reimi_app/presentation/features/account/states/account_state.dart';
-import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_concept_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_test_result_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/widgets/weather_personality_button.dart';
 import 'package:reimi_app/presentation/shared/widgets/app_snack_bar.dart';
 import 'package:reimi_app/presentation/shared/widgets/circle_icon_button.dart';
@@ -148,29 +149,60 @@ class AccountPage extends HookConsumerWidget {
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                        const SizedBox(height: 12),
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 8,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.white.withValues(alpha: 0.7),
-                            borderRadius: BorderRadius.circular(24),
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              const Icon(Icons.wb_sunny, color: Colors.orange),
-                              const SizedBox(width: 8),
-                              Text(
-                                '晴れ男',
-                                style: theme.textTheme.bodyMedium,
-                              ),
-                            ],
+                        const SizedBox(height: 24),
+                        GestureDetector(
+                          onTap: () {
+                            context.push(
+                              WeatherPersonalityDetailPage.routeLocation,
+                              extra: {'userId': user.id},
+                            );
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.all(4),
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.7),
+                              borderRadius: BorderRadius.circular(32),
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                CircleAvatar(
+                                  radius: 20,
+                                  backgroundColor: Colors.white,
+                                  child: CircleAvatar(
+                                    radius: 18,
+                                    backgroundColor: theme.colorScheme.primary,
+                                    backgroundImage: Assets
+                                        .images
+                                        .weatherPersonality
+                                        .spoeTraineeSeaOtterImage
+                                        .path
+                                        .toImageProvider(),
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'SPOE',
+                                  style: theme.textTheme.titleSmall!.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  '(トレーニーラッコ)',
+                                  style: theme.textTheme.titleSmall!.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                              ],
+                            ),
                           ),
                         ),
-                        const SizedBox(height: 32),
+                        const SizedBox(height: 24),
                         Row(
                           children: [
                             Expanded(
@@ -199,7 +231,7 @@ class AccountPage extends HookConsumerWidget {
                           label: t.button.weatherPersonalityTest,
                           onPressed: () {
                             context.push(
-                              WeatherPersonalityConceptPage.routeLocation,
+                              WeatherPersonalityTestResultPage.routeLocation,
                             );
                           },
                         ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/chat/pages/chat_detail_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/chat/pages/chat_detail_page.dart
@@ -83,11 +83,11 @@ class ChatDetailPage extends HookConsumerWidget {
                   elevation: 0,
                   title: Text(
                     userProfile?.name ?? '',
-                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.black87,
-                        ),
+                    style: theme.textTheme.titleMedium!.copyWith(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.black87,
+                    ),
                   ),
                   actions: userProfile == null
                       ? null

--- a/reimi/frontend/reimi_app/lib/presentation/features/chat/widgets/chat_user_profile.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/chat/widgets/chat_user_profile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:reimi_app/core/extensions/datetime_extensions.dart';
 import 'package:reimi_app/core/extensions/image_path_extension.dart';
 import 'package:reimi_app/core/extensions/value_objects/address_extension.dart';
@@ -21,6 +22,7 @@ import 'package:reimi_app/presentation/features/profile/widgets/glass_tile.dart'
 import 'package:reimi_app/presentation/features/profile/widgets/main_photo_card.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/rank_input_tile.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/sub_photo_card.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
 import 'package:reimi_app/presentation/shared/widgets/custom_divider.dart';
 import 'package:reimi_app/presentation/shared/widgets/sliver_widgets.dart';
 
@@ -90,8 +92,7 @@ List<Widget> chatUserProfile({
       ),
     ),
     const Gap(height: 32),
-    if (userProfile.subPhotos == null ||
-        userProfile.subPhotos!.isEmpty) ...[
+    if (userProfile.subPhotos == null || userProfile.subPhotos!.isEmpty) ...[
       const SliverToBoxAdapter(
         child: SizedBox.shrink(),
       ),
@@ -137,18 +138,51 @@ List<Widget> chatUserProfile({
       padding: const EdgeInsets.symmetric(horizontal: 24),
       sliver: SliverToBoxAdapter(
         child: GlassTile(
-          onTap: () {},
+          onTap: () {
+            context.push(
+              WeatherPersonalityDetailPage.routeLocation,
+              extra: {'userId': userProfile.id},
+            );
+          },
           child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const Icon(Icons.wb_sunny, color: Colors.orange),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  '晴れ男',
-                  style: theme.textTheme.bodyMedium,
-                ),
+              Row(
+                children: [
+                  CircleAvatar(
+                    radius: 22,
+                    backgroundColor: Colors.white,
+                    child: CircleAvatar(
+                      radius: 20,
+                      backgroundColor: theme.colorScheme.primary,
+                      backgroundImage: Assets.images.weatherPersonality
+                          .spoeTraineeSeaOtterImage.path
+                          .toImageProvider(),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'SPOE',
+                    style: theme.textTheme.bodyMedium!.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '(トレーニーラッコ)',
+                    style: theme.textTheme.bodyMedium!.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
               ),
-              const Icon(Icons.chevron_right),
+              Icon(
+                Icons.chevron_right,
+                size: 22,
+                color: Colors.black87.withValues(alpha: 0.4),
+              ),
             ],
           ),
         ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_detail_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:reimi_app/core/extensions/datetime_extensions.dart';
 import 'package:reimi_app/core/extensions/image_path_extension.dart';
@@ -26,6 +27,7 @@ import 'package:reimi_app/presentation/features/profile/widgets/rank_input_tile.
 import 'package:reimi_app/presentation/features/profile/widgets/show_rainbow_like_modal_sheet.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/sub_photo_card.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/bottom_action_buttons_bar.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
 import 'package:reimi_app/presentation/shared/widgets/app_snack_bar.dart';
 import 'package:reimi_app/presentation/shared/widgets/background_container_noon.dart';
 import 'package:reimi_app/presentation/shared/widgets/custom_divider.dart';
@@ -89,11 +91,11 @@ class ProfileDetailPage extends HookConsumerWidget {
                   snap: true,
                   title: Text(
                     t.profileDetailPage.title,
-                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                          fontSize: 15,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.black87,
-                        ),
+                    style: theme.textTheme.titleMedium!.copyWith(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.black87,
+                    ),
                   ),
                   backgroundColor: Colors.transparent,
                   elevation: 0,
@@ -175,7 +177,8 @@ class ProfileDetailPage extends HookConsumerWidget {
                     ),
                   ),
                   const Gap(height: 32),
-                  if (profile.subPhotos == null) ...[
+                  if (profile.subPhotos == null ||
+                      profile.subPhotos!.isEmpty) ...[
                     const SliverToBoxAdapter(
                       child: SizedBox.shrink(),
                     ),
@@ -222,18 +225,54 @@ class ProfileDetailPage extends HookConsumerWidget {
                     padding: const EdgeInsets.symmetric(horizontal: 24),
                     sliver: SliverToBoxAdapter(
                       child: GlassTile(
-                        onTap: () {},
+                        onTap: () {
+                          context.push(
+                            WeatherPersonalityDetailPage.routeLocation,
+                            extra: {'userId': userId},
+                          );
+                        },
                         child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            const Icon(Icons.wb_sunny, color: Colors.orange),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Text(
-                                '晴れ男',
-                                style: theme.textTheme.bodyMedium,
-                              ),
+                            Row(
+                              children: [
+                                CircleAvatar(
+                                  radius: 22,
+                                  backgroundColor: Colors.white,
+                                  child: CircleAvatar(
+                                    radius: 20,
+                                    backgroundColor: theme.colorScheme.primary,
+                                    backgroundImage: Assets
+                                        .images
+                                        .weatherPersonality
+                                        .spoeTraineeSeaOtterImage
+                                        .path
+                                        .toImageProvider(),
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'SPOE',
+                                  style: theme.textTheme.bodyMedium!.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                                const SizedBox(width: 4),
+                                Text(
+                                  '(トレーニーラッコ)',
+                                  style: theme.textTheme.bodyMedium!.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ],
                             ),
-                            const Icon(Icons.chevron_right),
+                            Icon(
+                              Icons.chevron_right,
+                              size: 22,
+                              color: Colors.black87.withValues(alpha: 0.4),
+                            ),
                           ],
                         ),
                       ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_edit_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_edit_page.dart
@@ -41,11 +41,11 @@ class ProfileEditPage extends HookConsumerWidget {
       appBar: AppBar(
         title: Text(
           title,
-          style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: Colors.black87,
-              ),
+          style: theme.textTheme.titleMedium!.copyWith(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: Colors.black87,
+          ),
         ),
         backgroundColor: Colors.transparent,
         elevation: 0,

--- a/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/profile/pages/profile_page.dart
@@ -30,10 +30,12 @@ import 'package:reimi_app/domain/value_objects/holiday.dart';
 import 'package:reimi_app/domain/value_objects/occupation.dart';
 import 'package:reimi_app/domain/value_objects/smoking.dart';
 import 'package:reimi_app/core/i18n/strings.g.dart';
+import 'package:reimi_app/gen/assets.gen.dart';
 import 'package:reimi_app/presentation/features/profile/notifiers/profile_edit_notifier.dart';
 import 'package:reimi_app/presentation/features/profile/states/profile_edit_state.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/basic_info_tile.dart';
 import 'package:reimi_app/presentation/features/profile/pages/profile_edit_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
 import 'package:reimi_app/presentation/shared/utils/enum_picker.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/glass_tile.dart';
 import 'package:reimi_app/presentation/features/profile/widgets/main_photo_card.dart';
@@ -67,6 +69,8 @@ class ProfilePage extends HookConsumerWidget {
     final isChanged = ref.watch(
       profileEditNotifierProvider.select((state) => state.isChanged),
     );
+    final userId =
+        ref.watch(profileEditNotifierProvider.select((state) => state.id));
     final mainPhotoUrl = ref.watch(
         profileEditNotifierProvider.select((state) => state.mainPhotoUrl));
     final subPhotos = ref
@@ -109,6 +113,8 @@ class ProfilePage extends HookConsumerWidget {
         .select((state) => state.communicationStyle));
     final status =
         ref.watch(profileEditNotifierProvider.select((state) => state.status));
+    final isLoading = ref
+        .watch(profileEditNotifierProvider.select((state) => state.isLoading));
 
     useEffect(() {
       Future.microtask(() {
@@ -186,605 +192,665 @@ class ProfilePage extends HookConsumerWidget {
                 const SizedBox(width: 24),
               ],
             ),
-            const Gap(height: 16),
-            SliverSectionTitle(
-              title: t.profilePage.section.mainPhoto,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: MainPhotoCard(
-                  image: mainPhotoUrl.toImageProvider(),
-                  onTap: () async {
-                    final file = await pickImageFromGallery();
-                    if (file != null) {
-                      notifier.updateMainPhotoUrl(file.path);
-                    }
-                  },
+            if (isLoading) ...[
+              const SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(
+                  child: CircularProgressIndicator(),
                 ),
               ),
-            ),
-            const Gap(height: 32),
-            SliverSectionTitle(
-              title: t.profilePage.section.subPhoto,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverGrid(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 3,
-                  crossAxisSpacing: 12,
-                  mainAxisSpacing: 12,
-                  childAspectRatio: 1,
+            ] else if (userId == null) ...[
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
                 ),
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final subPhoto =
-                        (subPhotos != null && index < subPhotos.length)
-                            ? subPhotos[index]
-                            : null;
-                    return SubPhotoCard(
-                      label: labels[index],
-                      subPhotoUrl: subPhoto,
-                      onTap: () async {
-                        final file = await pickImageFromGallery();
-                        if (file != null) {
-                          notifier.setSubPhoto(
-                            url: file.path,
-                            index: index,
-                          );
-                        }
-                      },
-                      onDelete: () async {
-                        await customConfirmationDialog(
-                          context: context,
-                          title: t.dialog.deletePhoto.title,
-                          contentText: t.dialog.deletePhoto.contentText,
-                          buttonLabel: t.button.delete,
-                          accentColor: Colors.red,
-                          onPressed: () {
-                            notifier.removeSubPhoto(index);
-                          },
-                        );
-                      },
-                    );
-                  },
-                  childCount: labels.length,
-                ),
-              ),
-            ),
-            const Gap(height: 32),
-            SliverSectionTitle(
-              title: t.profilePage.section.weatherPersonality,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: GlassTile(
-                  onTap: () {},
-                  child: Row(
-                    children: [
-                      const Icon(Icons.wb_sunny, color: Colors.orange),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Text(
-                          '晴れ男',
-                          style: theme.textTheme.bodyMedium,
-                        ),
-                      ),
-                      const Icon(Icons.chevron_right),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            const Gap(height: 32),
-            SliverSectionTitle(
-              title: t.profilePage.section.introduction,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: GlassTile(
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.title(
-                          item: t.profilePage.section.introduction,
-                        ),
-                        'initValue': introduction,
-                        'onSave': notifier.updateIntroduction,
-                        'isMultiline': true,
-                      },
-                    );
-                  },
-                  child: Text(
-                    introduction ?? '',
-                    style: theme.textTheme.bodyMedium!.copyWith(
-                      height: 1.6,
+                sliver: SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Center(
+                    child: Text(
+                      t.profilePage.nullCase,
+                      style: theme.textTheme.bodyMedium,
                     ),
                   ),
                 ),
               ),
-            ),
-            const Gap(height: 32),
-            SliverSectionTitle(
-              title: t.profilePage.section.sunnyDayHobbies,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: RankInputTile(
-                  rank: 1,
-                  hint: t.profilePage.placeholder.sunnyDayHobbies.top1,
-                  value: sunnyDayHobbies?[0],
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.sunnyDayHobbies.top1,
-                        'initValue': sunnyDayHobbies?[0],
-                        'onSave': (hobby) {
-                          notifier.setSunnyDayHobby(hobby: hobby, index: 0);
-                        },
-                        'isMultiline': false,
-                      },
-                    );
-                  },
-                  onDelete: () {
-                    notifier.removeSunnyDayHobby(0);
-                  },
-                ),
+            ] else ...[
+              const Gap(height: 16),
+              SliverSectionTitle(
+                title: t.profilePage.section.mainPhoto,
+                paddingHorizontal: 24,
               ),
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: RankInputTile(
-                  rank: 2,
-                  hint: t.profilePage.placeholder.sunnyDayHobbies.top2,
-                  value: sunnyDayHobbies?[1],
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.sunnyDayHobbies.top2,
-                        'initValue': sunnyDayHobbies?[1],
-                        'onSave': (hobby) {
-                          notifier.setSunnyDayHobby(hobby: hobby, index: 1);
-                        },
-                        'isMultiline': false,
-                      },
-                    );
-                  },
-                  onDelete: () {
-                    notifier.removeSunnyDayHobby(1);
-                  },
-                ),
-              ),
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: RankInputTile(
-                  rank: 3,
-                  hint: t.profilePage.placeholder.sunnyDayHobbies.top3,
-                  value: sunnyDayHobbies?[2],
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.sunnyDayHobbies.top3,
-                        'initValue': sunnyDayHobbies?[2],
-                        'onSave': (hobby) {
-                          notifier.setSunnyDayHobby(hobby: hobby, index: 2);
-                        },
-                        'isMultiline': false,
-                      },
-                    );
-                  },
-                  onDelete: () {
-                    notifier.removeSunnyDayHobby(2);
-                  },
-                ),
-              ),
-            ),
-            const Gap(height: 32),
-            SliverSectionTitle(
-              title: t.profilePage.section.rainyDayHobbies,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: RankInputTile(
-                  rank: 1,
-                  hint: t.profilePage.placeholder.rainyDayHobbies.top1,
-                  value: rainyDayHobbies?[0],
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.rainyDayHobbies.top1,
-                        'initValue': rainyDayHobbies?[0],
-                        'onSave': (hobby) {
-                          notifier.setRainyDayHobby(hobby: hobby, index: 0);
-                        },
-                        'isMultiline': false,
-                      },
-                    );
-                  },
-                  onDelete: () {
-                    notifier.removeRainyDayHobby(0);
-                  },
-                ),
-              ),
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: RankInputTile(
-                  rank: 2,
-                  hint: t.profilePage.placeholder.rainyDayHobbies.top2,
-                  value: rainyDayHobbies?[1],
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.rainyDayHobbies.top2,
-                        'initValue': rainyDayHobbies?[1],
-                        'onSave': (hobby) {
-                          notifier.setRainyDayHobby(hobby: hobby, index: 1);
-                        },
-                        'isMultiline': false,
-                      },
-                    );
-                  },
-                  onDelete: () {
-                    notifier.removeRainyDayHobby(1);
-                  },
-                ),
-              ),
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: RankInputTile(
-                  rank: 3,
-                  hint: t.profilePage.placeholder.rainyDayHobbies.top3,
-                  value: rainyDayHobbies?[2],
-                  onTap: () {
-                    context.push(
-                      ProfileEditPage.routeLocation,
-                      extra: {
-                        'title': t.profilePage.edit.rainyDayHobbies.top3,
-                        'initValue': rainyDayHobbies?[2],
-                        'onSave': (hobby) {
-                          notifier.setRainyDayHobby(hobby: hobby, index: 2);
-                        },
-                        'isMultiline': false,
-                      },
-                    );
-                  },
-                  onDelete: () {
-                    notifier.removeRainyDayHobby(2);
-                  },
-                ),
-              ),
-            ),
-            const Gap(height: 32),
-            SliverSectionTitle(
-              title: t.profilePage.section.basicInformation.title,
-              paddingHorizontal: 24,
-            ),
-            const Gap(height: 12),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              sliver: SliverToBoxAdapter(
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.5),
-                    borderRadius: BorderRadius.circular(16),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: MainPhotoCard(
+                    image: mainPhotoUrl.toImageProvider(),
+                    onTap: () async {
+                      final file = await pickImageFromGallery();
+                      if (file != null) {
+                        notifier.updateMainPhotoUrl(file.path);
+                      }
+                    },
                   ),
-                  child: Column(
-                    children: [
-                      BasicInfoTile(
-                        title:
-                            t.profilePage.section.basicInformation.items.name,
-                        value: name,
-                        onTap: () {
-                          context.push(
-                            ProfileEditPage.routeLocation,
-                            extra: {
-                              'title': t.profilePage.edit.title(
-                                item: t.profilePage.section.basicInformation
-                                    .items.name,
+                ),
+              ),
+              const Gap(height: 32),
+              SliverSectionTitle(
+                title: t.profilePage.section.subPhoto,
+                paddingHorizontal: 24,
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverGrid(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    crossAxisSpacing: 12,
+                    mainAxisSpacing: 12,
+                    childAspectRatio: 1,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final subPhoto =
+                          (subPhotos != null && index < subPhotos.length)
+                              ? subPhotos[index]
+                              : null;
+                      return SubPhotoCard(
+                        label: labels[index],
+                        subPhotoUrl: subPhoto,
+                        onTap: () async {
+                          final file = await pickImageFromGallery();
+                          if (file != null) {
+                            notifier.setSubPhoto(
+                              url: file.path,
+                              index: index,
+                            );
+                          }
+                        },
+                        onDelete: () async {
+                          await customConfirmationDialog(
+                            context: context,
+                            title: t.dialog.deletePhoto.title,
+                            contentText: t.dialog.deletePhoto.contentText,
+                            buttonLabel: t.button.delete,
+                            accentColor: Colors.red,
+                            onPressed: () {
+                              notifier.removeSubPhoto(index);
+                            },
+                          );
+                        },
+                      );
+                    },
+                    childCount: labels.length,
+                  ),
+                ),
+              ),
+              const Gap(height: 32),
+              SliverSectionTitle(
+                title: t.profilePage.section.weatherPersonality,
+                paddingHorizontal: 24,
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: GlassTile(
+                    onTap: () {
+                      context.push(
+                        WeatherPersonalityDetailPage.routeLocation,
+                        extra: {'userId': userId},
+                      );
+                    },
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Row(
+                          children: [
+                            CircleAvatar(
+                              radius: 22,
+                              backgroundColor: Colors.white,
+                              child: CircleAvatar(
+                                radius: 20,
+                                backgroundColor: theme.colorScheme.primary,
+                                backgroundImage: Assets
+                                    .images
+                                    .weatherPersonality
+                                    .spoeTraineeSeaOtterImage
+                                    .path
+                                    .toImageProvider(),
                               ),
-                              'initValue': name,
-                              'onSave': notifier.updateName,
-                              'isMultiline': false,
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title:
-                            t.profilePage.section.basicInformation.items.gender,
-                        value: gender?.displayName(context),
-                        onTap: () {
-                          enumPicker<Gender>(
-                            context: context,
-                            items: Gender.values,
-                            initialValue: gender,
-                            displayBuilder: (gender, context) {
-                              return gender.displayName(context);
-                            },
-                            onSelected: (gender) {
-                              notifier.updateGender(gender);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .birthDate,
-                        value: birthDate?.toJapaneseDateyyyyMMdd,
-                        onTap: null,
-                        isReadOnly: true,
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t
-                            .profilePage.section.basicInformation.items.address,
-                        value: address?.displayName(context),
-                        onTap: () {
-                          enumPicker<Address>(
-                            context: context,
-                            items: Address.values,
-                            initialValue: address,
-                            displayBuilder: (address, context) {
-                              return address.displayName(context);
-                            },
-                            onSelected: (address) {
-                              notifier.updateAddress(address);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .hometown,
-                        value: hometown?.displayName(context),
-                        onTap: () {
-                          enumPicker<Address>(
-                            context: context,
-                            items: Address.values,
-                            initialValue: hometown,
-                            displayBuilder: (hometown, context) {
-                              return hometown.displayName(context);
-                            },
-                            onSelected: (hometown) {
-                              notifier.updateHometown(hometown);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .bloodType,
-                        value: bloodType?.displayName(context),
-                        onTap: () {
-                          enumPicker<BloodType>(
-                            context: context,
-                            items: BloodType.values,
-                            initialValue: bloodType,
-                            displayBuilder: (bloodType, context) {
-                              return bloodType.displayName(context);
-                            },
-                            onSelected: (bloodType) {
-                              notifier.updateBloodType(bloodType);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title:
-                            t.profilePage.section.basicInformation.items.height,
-                        value: height?.displayName(context),
-                        onTap: () {
-                          enumPicker<Height>(
-                            context: context,
-                            items: Height.values,
-                            initialValue: height,
-                            displayBuilder: (height, context) {
-                              return height.displayName(context);
-                            },
-                            onSelected: (height) {
-                              notifier.updateHeight(height);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .bodyShape,
-                        value: bodyShape?.displayName(context),
-                        onTap: () {
-                          enumPicker<BodyShape>(
-                            context: context,
-                            items: BodyShape.values,
-                            initialValue: bodyShape,
-                            displayBuilder: (bodyShape, context) {
-                              return bodyShape.displayName(context);
-                            },
-                            onSelected: (bodyShape) {
-                              notifier.updateBodyShape(bodyShape);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .education,
-                        value: education?.displayName(context),
-                        onTap: () {
-                          enumPicker<Education>(
-                            context: context,
-                            items: Education.values,
-                            initialValue: education,
-                            displayBuilder: (education, context) {
-                              return education.displayName(context);
-                            },
-                            onSelected: (education) {
-                              notifier.updateEducation(education);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .occupation,
-                        value: occupation?.displayName(context),
-                        onTap: () {
-                          enumPicker<Occupation>(
-                            context: context,
-                            items: Occupation.values,
-                            initialValue: occupation,
-                            displayBuilder: (occupation, context) {
-                              return occupation.displayName(context);
-                            },
-                            onSelected: (occupation) {
-                              notifier.updateOccupation(occupation);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .annualIncome,
-                        value: annualIncome?.displayName(context),
-                        onTap: () {
-                          enumPicker<AnnualIncome>(
-                            context: context,
-                            items: AnnualIncome.values,
-                            initialValue: annualIncome,
-                            displayBuilder: (annualIncome, context) {
-                              return annualIncome.displayName(context);
-                            },
-                            onSelected: (annualIncome) {
-                              notifier.updateAnnualIncome(annualIncome);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t
-                            .profilePage.section.basicInformation.items.smoking,
-                        value: smoking?.displayName(context),
-                        onTap: () {
-                          enumPicker<Smoking>(
-                            context: context,
-                            items: Smoking.values,
-                            initialValue: smoking,
-                            displayBuilder: (smoking, context) {
-                              return smoking.displayName(context);
-                            },
-                            onSelected: (smoking) {
-                              notifier.updateSmoking(smoking);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t
-                            .profilePage.section.basicInformation.items.alcohol,
-                        value: alcohol?.displayName(context),
-                        onTap: () {
-                          enumPicker<Alcohol>(
-                            context: context,
-                            items: Alcohol.values,
-                            initialValue: alcohol,
-                            displayBuilder: (alcohol, context) {
-                              return alcohol.displayName(context);
-                            },
-                            onSelected: (alcohol) {
-                              notifier.updateAlcohol(alcohol);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t
-                            .profilePage.section.basicInformation.items.holiday,
-                        value: holiday?.displayName(context),
-                        onTap: () {
-                          enumPicker<Holiday>(
-                            context: context,
-                            items: Holiday.values,
-                            initialValue: holiday,
-                            displayBuilder: (holiday, context) {
-                              return holiday.displayName(context);
-                            },
-                            onSelected: (holiday) {
-                              notifier.updateHoliday(holiday);
-                            },
-                          );
-                        },
-                      ),
-                      const CustomDivider(),
-                      BasicInfoTile(
-                        title: t.profilePage.section.basicInformation.items
-                            .communicationStyle,
-                        value: communicationStyle?.displayName(context),
-                        onTap: () {
-                          enumPicker<CommunicationStyle>(
-                            context: context,
-                            items: CommunicationStyle.values,
-                            initialValue: communicationStyle,
-                            displayBuilder: (communicationStyle, context) {
-                              return communicationStyle.displayName(context);
-                            },
-                            onSelected: (communicationStyle) {
-                              notifier
-                                  .updateCommunicationStyle(communicationStyle);
-                            },
-                          );
-                        },
-                      ),
-                    ],
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              'SPOE',
+                              style: theme.textTheme.bodyMedium!.copyWith(
+                                color: theme.colorScheme.primary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '(トレーニーラッコ)',
+                              style: theme.textTheme.bodyMedium!.copyWith(
+                                color: theme.colorScheme.primary,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                          ],
+                        ),
+                        Icon(
+                          Icons.chevron_right,
+                          size: 22,
+                          color: Colors.black87.withValues(alpha: 0.4),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               ),
-            ),
-            const Gap(height: 40),
+              const Gap(height: 32),
+              SliverSectionTitle(
+                title: t.profilePage.section.introduction,
+                paddingHorizontal: 24,
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: GlassTile(
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.title(
+                            item: t.profilePage.section.introduction,
+                          ),
+                          'initValue': introduction,
+                          'onSave': notifier.updateIntroduction,
+                          'isMultiline': true,
+                        },
+                      );
+                    },
+                    child: Text(
+                      introduction ?? '',
+                      style: theme.textTheme.bodyMedium!.copyWith(
+                        height: 1.6,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const Gap(height: 32),
+              SliverSectionTitle(
+                title: t.profilePage.section.sunnyDayHobbies,
+                paddingHorizontal: 24,
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: RankInputTile(
+                    rank: 1,
+                    hint: t.profilePage.placeholder.sunnyDayHobbies.top1,
+                    value: sunnyDayHobbies?[0],
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.sunnyDayHobbies.top1,
+                          'initValue': sunnyDayHobbies?[0],
+                          'onSave': (hobby) {
+                            notifier.setSunnyDayHobby(hobby: hobby, index: 0);
+                          },
+                          'isMultiline': false,
+                        },
+                      );
+                    },
+                    onDelete: () {
+                      notifier.removeSunnyDayHobby(0);
+                    },
+                  ),
+                ),
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: RankInputTile(
+                    rank: 2,
+                    hint: t.profilePage.placeholder.sunnyDayHobbies.top2,
+                    value: sunnyDayHobbies?[1],
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.sunnyDayHobbies.top2,
+                          'initValue': sunnyDayHobbies?[1],
+                          'onSave': (hobby) {
+                            notifier.setSunnyDayHobby(hobby: hobby, index: 1);
+                          },
+                          'isMultiline': false,
+                        },
+                      );
+                    },
+                    onDelete: () {
+                      notifier.removeSunnyDayHobby(1);
+                    },
+                  ),
+                ),
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: RankInputTile(
+                    rank: 3,
+                    hint: t.profilePage.placeholder.sunnyDayHobbies.top3,
+                    value: sunnyDayHobbies?[2],
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.sunnyDayHobbies.top3,
+                          'initValue': sunnyDayHobbies?[2],
+                          'onSave': (hobby) {
+                            notifier.setSunnyDayHobby(hobby: hobby, index: 2);
+                          },
+                          'isMultiline': false,
+                        },
+                      );
+                    },
+                    onDelete: () {
+                      notifier.removeSunnyDayHobby(2);
+                    },
+                  ),
+                ),
+              ),
+              const Gap(height: 32),
+              SliverSectionTitle(
+                title: t.profilePage.section.rainyDayHobbies,
+                paddingHorizontal: 24,
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: RankInputTile(
+                    rank: 1,
+                    hint: t.profilePage.placeholder.rainyDayHobbies.top1,
+                    value: rainyDayHobbies?[0],
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.rainyDayHobbies.top1,
+                          'initValue': rainyDayHobbies?[0],
+                          'onSave': (hobby) {
+                            notifier.setRainyDayHobby(hobby: hobby, index: 0);
+                          },
+                          'isMultiline': false,
+                        },
+                      );
+                    },
+                    onDelete: () {
+                      notifier.removeRainyDayHobby(0);
+                    },
+                  ),
+                ),
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: RankInputTile(
+                    rank: 2,
+                    hint: t.profilePage.placeholder.rainyDayHobbies.top2,
+                    value: rainyDayHobbies?[1],
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.rainyDayHobbies.top2,
+                          'initValue': rainyDayHobbies?[1],
+                          'onSave': (hobby) {
+                            notifier.setRainyDayHobby(hobby: hobby, index: 1);
+                          },
+                          'isMultiline': false,
+                        },
+                      );
+                    },
+                    onDelete: () {
+                      notifier.removeRainyDayHobby(1);
+                    },
+                  ),
+                ),
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: RankInputTile(
+                    rank: 3,
+                    hint: t.profilePage.placeholder.rainyDayHobbies.top3,
+                    value: rainyDayHobbies?[2],
+                    onTap: () {
+                      context.push(
+                        ProfileEditPage.routeLocation,
+                        extra: {
+                          'title': t.profilePage.edit.rainyDayHobbies.top3,
+                          'initValue': rainyDayHobbies?[2],
+                          'onSave': (hobby) {
+                            notifier.setRainyDayHobby(hobby: hobby, index: 2);
+                          },
+                          'isMultiline': false,
+                        },
+                      );
+                    },
+                    onDelete: () {
+                      notifier.removeRainyDayHobby(2);
+                    },
+                  ),
+                ),
+              ),
+              const Gap(height: 32),
+              SliverSectionTitle(
+                title: t.profilePage.section.basicInformation.title,
+                paddingHorizontal: 24,
+              ),
+              const Gap(height: 12),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                sliver: SliverToBoxAdapter(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Column(
+                      children: [
+                        BasicInfoTile(
+                          title:
+                              t.profilePage.section.basicInformation.items.name,
+                          value: name,
+                          onTap: () {
+                            context.push(
+                              ProfileEditPage.routeLocation,
+                              extra: {
+                                'title': t.profilePage.edit.title(
+                                  item: t.profilePage.section.basicInformation
+                                      .items.name,
+                                ),
+                                'initValue': name,
+                                'onSave': notifier.updateName,
+                                'isMultiline': false,
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .gender,
+                          value: gender?.displayName(context),
+                          onTap: () {
+                            enumPicker<Gender>(
+                              context: context,
+                              items: Gender.values,
+                              initialValue: gender,
+                              displayBuilder: (gender, context) {
+                                return gender.displayName(context);
+                              },
+                              onSelected: (gender) {
+                                notifier.updateGender(gender);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .birthDate,
+                          value: birthDate?.toJapaneseDateyyyyMMdd,
+                          onTap: null,
+                          isReadOnly: true,
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .address,
+                          value: address?.displayName(context),
+                          onTap: () {
+                            enumPicker<Address>(
+                              context: context,
+                              items: Address.values,
+                              initialValue: address,
+                              displayBuilder: (address, context) {
+                                return address.displayName(context);
+                              },
+                              onSelected: (address) {
+                                notifier.updateAddress(address);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .hometown,
+                          value: hometown?.displayName(context),
+                          onTap: () {
+                            enumPicker<Address>(
+                              context: context,
+                              items: Address.values,
+                              initialValue: hometown,
+                              displayBuilder: (hometown, context) {
+                                return hometown.displayName(context);
+                              },
+                              onSelected: (hometown) {
+                                notifier.updateHometown(hometown);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .bloodType,
+                          value: bloodType?.displayName(context),
+                          onTap: () {
+                            enumPicker<BloodType>(
+                              context: context,
+                              items: BloodType.values,
+                              initialValue: bloodType,
+                              displayBuilder: (bloodType, context) {
+                                return bloodType.displayName(context);
+                              },
+                              onSelected: (bloodType) {
+                                notifier.updateBloodType(bloodType);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .height,
+                          value: height?.displayName(context),
+                          onTap: () {
+                            enumPicker<Height>(
+                              context: context,
+                              items: Height.values,
+                              initialValue: height,
+                              displayBuilder: (height, context) {
+                                return height.displayName(context);
+                              },
+                              onSelected: (height) {
+                                notifier.updateHeight(height);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .bodyShape,
+                          value: bodyShape?.displayName(context),
+                          onTap: () {
+                            enumPicker<BodyShape>(
+                              context: context,
+                              items: BodyShape.values,
+                              initialValue: bodyShape,
+                              displayBuilder: (bodyShape, context) {
+                                return bodyShape.displayName(context);
+                              },
+                              onSelected: (bodyShape) {
+                                notifier.updateBodyShape(bodyShape);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .education,
+                          value: education?.displayName(context),
+                          onTap: () {
+                            enumPicker<Education>(
+                              context: context,
+                              items: Education.values,
+                              initialValue: education,
+                              displayBuilder: (education, context) {
+                                return education.displayName(context);
+                              },
+                              onSelected: (education) {
+                                notifier.updateEducation(education);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .occupation,
+                          value: occupation?.displayName(context),
+                          onTap: () {
+                            enumPicker<Occupation>(
+                              context: context,
+                              items: Occupation.values,
+                              initialValue: occupation,
+                              displayBuilder: (occupation, context) {
+                                return occupation.displayName(context);
+                              },
+                              onSelected: (occupation) {
+                                notifier.updateOccupation(occupation);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .annualIncome,
+                          value: annualIncome?.displayName(context),
+                          onTap: () {
+                            enumPicker<AnnualIncome>(
+                              context: context,
+                              items: AnnualIncome.values,
+                              initialValue: annualIncome,
+                              displayBuilder: (annualIncome, context) {
+                                return annualIncome.displayName(context);
+                              },
+                              onSelected: (annualIncome) {
+                                notifier.updateAnnualIncome(annualIncome);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .smoking,
+                          value: smoking?.displayName(context),
+                          onTap: () {
+                            enumPicker<Smoking>(
+                              context: context,
+                              items: Smoking.values,
+                              initialValue: smoking,
+                              displayBuilder: (smoking, context) {
+                                return smoking.displayName(context);
+                              },
+                              onSelected: (smoking) {
+                                notifier.updateSmoking(smoking);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .alcohol,
+                          value: alcohol?.displayName(context),
+                          onTap: () {
+                            enumPicker<Alcohol>(
+                              context: context,
+                              items: Alcohol.values,
+                              initialValue: alcohol,
+                              displayBuilder: (alcohol, context) {
+                                return alcohol.displayName(context);
+                              },
+                              onSelected: (alcohol) {
+                                notifier.updateAlcohol(alcohol);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .holiday,
+                          value: holiday?.displayName(context),
+                          onTap: () {
+                            enumPicker<Holiday>(
+                              context: context,
+                              items: Holiday.values,
+                              initialValue: holiday,
+                              displayBuilder: (holiday, context) {
+                                return holiday.displayName(context);
+                              },
+                              onSelected: (holiday) {
+                                notifier.updateHoliday(holiday);
+                              },
+                            );
+                          },
+                        ),
+                        const CustomDivider(),
+                        BasicInfoTile(
+                          title: t.profilePage.section.basicInformation.items
+                              .communicationStyle,
+                          value: communicationStyle?.displayName(context),
+                          onTap: () {
+                            enumPicker<CommunicationStyle>(
+                              context: context,
+                              items: CommunicationStyle.values,
+                              initialValue: communicationStyle,
+                              displayBuilder: (communicationStyle, context) {
+                                return communicationStyle.displayName(context);
+                              },
+                              onSelected: (communicationStyle) {
+                                notifier.updateCommunicationStyle(
+                                    communicationStyle);
+                              },
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const Gap(height: 40),
+            ],
           ],
         ),
       ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_detail_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_detail_notifier.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:reimi_app/core/di/usecase_providers.dart';
+import 'package:reimi_app/presentation/features/weather_personality/states/weather_personality_detail_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'weather_personality_detail_notifier.g.dart';
+
+@riverpod
+class WeatherPersonalityDetailNotifier
+    extends _$WeatherPersonalityDetailNotifier {
+  @override
+  WeatherPersonalityDetailState build() {
+    return const WeatherPersonalityDetailState();
+  }
+
+  Future<void> init(String? userId) async {
+    await loadWeatherPersonality(userId);
+  }
+
+  Future<void> loadWeatherPersonality(String? userId) async {
+    if (userId == null) return;
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final weatherPersonality = await ref
+          .read(getWeatherPersonalityDetailUseCaseProvider)
+          .call(userId);
+      state = state.copyWith(
+        weatherPersonality: weatherPersonality,
+        isLoading: false,
+      );
+      await isMyWeatherPersonality(userId);
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: e.toString(),
+      );
+    }
+  }
+
+  Future<void> isMyWeatherPersonality(String userId) async {
+    final user = await ref.read(getCurrentUserUseCaseProvider).call();
+    final isMyWeatherPersonality = userId == user.id;
+    state = state.copyWith(isMyWeatherPersonality: isMyWeatherPersonality);
+  }
+
+  Future<void> refresh(String userId) async {
+    await loadWeatherPersonality(userId);
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_detail_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_detail_notifier.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_personality_detail_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$weatherPersonalityDetailNotifierHash() =>
+    r'e7a4e7b08f64f055f3c1940100030f2916cfc04b';
+
+/// See also [WeatherPersonalityDetailNotifier].
+@ProviderFor(WeatherPersonalityDetailNotifier)
+final weatherPersonalityDetailNotifierProvider = AutoDisposeNotifierProvider<
+    WeatherPersonalityDetailNotifier, WeatherPersonalityDetailState>.internal(
+  WeatherPersonalityDetailNotifier.new,
+  name: r'weatherPersonalityDetailNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$weatherPersonalityDetailNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WeatherPersonalityDetailNotifier
+    = AutoDisposeNotifier<WeatherPersonalityDetailState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_concept_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_concept_page.dart
@@ -20,11 +20,11 @@ class WeatherPersonalityConceptPage extends StatelessWidget {
       appBar: AppBar(
         title: Text(
           t.weatherPersonalityConceptPage.title,
-          style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: Colors.black87,
-              ),
+          style: theme.textTheme.titleMedium!.copyWith(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: Colors.black87,
+          ),
         ),
         backgroundColor: Colors.transparent,
         elevation: 0,

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_detail_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_detail_page.dart
@@ -1,0 +1,842 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:reimi_app/core/extensions/image_path_extension.dart';
+import 'package:reimi_app/core/services/share/share_payload.dart';
+import 'package:reimi_app/core/services/share/share_provider.dart';
+import 'package:reimi_app/domain/read_models/type_compatibility_read_model.dart';
+import 'package:reimi_app/gen/assets.gen.dart';
+import 'package:reimi_app/core/i18n/strings.g.dart';
+import 'package:reimi_app/presentation/features/weather_personality/notifiers/weather_personality_detail_notifier.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_test_q1_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/states/weather_personality_detail_state.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/action_button.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/axis_feature_card.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/axis_score_bar.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/text_card.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/weather_personality_share_card.dart';
+import 'package:reimi_app/presentation/shared/utils/custom_confirmation_dialog.dart';
+import 'package:reimi_app/presentation/shared/widgets/app_snack_bar.dart';
+import 'package:reimi_app/presentation/shared/widgets/background_container_noon.dart';
+import 'package:reimi_app/presentation/shared/widgets/section_title.dart';
+import 'package:reimi_app/presentation/shared/widgets/sliver_widgets.dart';
+import 'package:screenshot/screenshot.dart';
+
+class WeatherPersonalityDetailPage extends HookConsumerWidget {
+  static String get routeName => 'weather_personality_detail';
+  static String get routeLocation => '/$routeName';
+  const WeatherPersonalityDetailPage({
+    super.key,
+    required this.userId,
+  });
+  final String? userId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+    final notifier =
+        ref.read(weatherPersonalityDetailNotifierProvider.notifier);
+    final weatherPersonality = ref.watch(
+        weatherPersonalityDetailNotifierProvider
+            .select((state) => state.weatherPersonality));
+    final isLoading = ref.watch(weatherPersonalityDetailNotifierProvider
+        .select((state) => state.isLoading));
+    final isMyWeatherPersonality = ref.watch(
+        weatherPersonalityDetailNotifierProvider
+            .select((state) => state.isMyWeatherPersonality));
+
+    final mainController = useAnimationController(
+      duration: const Duration(milliseconds: 600),
+    )..forward();
+
+    final subController = useAnimationController(
+      duration: const Duration(milliseconds: 500),
+    );
+
+    final screenshotController = useMemoized(() => ScreenshotController());
+
+    Future<void> onShareTestResult() async {
+      if (weatherPersonality == null) return;
+
+      final bytes = await screenshotController.captureFromWidget(
+        WeatherPersonalityShareCard(
+          typeCode: weatherPersonality.typeCode,
+          typeName: weatherPersonality.typeName,
+          catchphrase: weatherPersonality.typeCatchphrase,
+          characterImageUrl: weatherPersonality.typeCharacterImageUrl,
+        ),
+        delay: const Duration(milliseconds: 100),
+      );
+
+      final shareService = ref.read(shareServiceProvider);
+
+      await shareService.share(
+        ImageSharePayload(
+          bytes: bytes,
+          fileName: 'test_result.png',
+          text: 'あなたの診断結果はこちら✨',
+        ),
+      );
+    }
+
+    useEffect(() {
+      Future.microtask(() {
+        notifier.init(userId);
+      });
+      final timer = Timer(
+        const Duration(milliseconds: 400),
+        () => subController.forward(),
+      );
+
+      final subscription = ref.listenManual<WeatherPersonalityDetailState>(
+        weatherPersonalityDetailNotifierProvider,
+        (prev, next) {
+          if (next.errorMessage == null) return;
+          AppSnackBar.error(context, next.errorMessage!);
+        },
+      );
+
+      return () {
+        timer.cancel;
+        subscription.close;
+      };
+    }, []);
+
+    return Scaffold(
+      body: BackgroundContainerNoon(
+        child: SafeArea(
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: [
+              SliverAppBar(
+                floating: true,
+                snap: true,
+                centerTitle: true,
+                title: Text(
+                  t.weatherPersonalityDetailPage.title,
+                  style: theme.textTheme.titleMedium!.copyWith(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.black87,
+                  ),
+                ),
+                actions: isMyWeatherPersonality
+                    ? [
+                        TextButton(
+                          onPressed: () async {
+                            await customConfirmationDialog(
+                              context: context,
+                              title: t.dialog.reTest.title,
+                              contentText: t.dialog.reTest.contentText,
+                              buttonLabel: t.button.retest,
+                              onPressed: () {
+                                context.go(
+                                    WeatherPersonalityTestQ1Page.routeLocation);
+                              },
+                              accentColor: theme.colorScheme.primary,
+                            );
+                          },
+                          child: Text(
+                            t.button.retest,
+                            style: theme.textTheme.labelLarge!.copyWith(
+                              color: Colors.teal,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                      ]
+                    : null,
+                backgroundColor: Colors.transparent,
+                elevation: 0,
+              ),
+              if (isLoading) ...[
+                const SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                ),
+              ] else if (weatherPersonality == null) ...[
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                  ),
+                  sliver: SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: Center(
+                      child: Text(
+                        t.weatherPersonalityDetailPage.nullCase,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                  ),
+                ),
+              ] else ...[
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: ScaleTransition(
+                      scale: Tween(begin: 0.9, end: 1.0).animate(
+                        CurvedAnimation(
+                          parent: mainController,
+                          curve: Curves.easeOutBack,
+                        ),
+                      ),
+                      child: FadeTransition(
+                        opacity: mainController,
+                        child: _MainResultCard(
+                          typeCode: weatherPersonality.typeCode,
+                          typeName: weatherPersonality.typeName,
+                          typeCatchphrase: weatherPersonality.typeCatchphrase,
+                          typeCharacterImageUrl:
+                              weatherPersonality.typeCharacterImageUrl,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: SlideTransition(
+                      position: Tween(
+                        begin: const Offset(0, 0.15),
+                        end: Offset.zero,
+                      ).animate(
+                        CurvedAnimation(
+                          parent: subController,
+                          curve: Curves.easeOut,
+                        ),
+                      ),
+                      child: FadeTransition(
+                        opacity: subController,
+                        child: _GodsRulingCard(
+                          ruling: weatherPersonality.rulingStatement,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: TextCard(
+                      child: Column(
+                        children: [
+                          SectionTitle(
+                            title: t.weatherPersonalityDetailPage.section
+                                .axisScore.title,
+                          ),
+                          const SizedBox(height: 16),
+                          AxisScoreBar(
+                            leftLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.sensitivity.neutral,
+                            rightLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.sensitivity.sensitive,
+                            score: weatherPersonality.axisScore[0],
+                          ),
+                          const SizedBox(height: 20),
+                          AxisScoreBar(
+                            leftLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.preparedness.flexible,
+                            rightLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.preparedness.planned,
+                            score: weatherPersonality.axisScore[1],
+                          ),
+                          const SizedBox(height: 20),
+                          AxisScoreBar(
+                            leftLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.activity.indoor,
+                            rightLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.activity.outdoor,
+                            score: weatherPersonality.axisScore[2],
+                          ),
+                          const SizedBox(height: 20),
+                          AxisScoreBar(
+                            leftLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.motivation.rational,
+                            rightLabel: t.weatherPersonalityDetailPage.section
+                                .axisScore.axis.motivation.emotional,
+                            score: weatherPersonality.axisScore[3],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: Column(
+                      children: [
+                        SectionTitle(
+                          title: t.weatherPersonalityDetailPage.section
+                              .axisFeature.title,
+                        ),
+                        const SizedBox(height: 16),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '感受性',
+                          code: 'S（高）',
+                          description: weatherPersonality.axisFeatures[0],
+                        ),
+                        const SizedBox(height: 12),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '準備性',
+                          code: 'P（計画型）',
+                          description: weatherPersonality.axisFeatures[1],
+                        ),
+                        const SizedBox(height: 12),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '外行動性',
+                          code: 'O（Outdoor）',
+                          description: weatherPersonality.axisFeatures[2],
+                        ),
+                        const SizedBox(height: 12),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '動機特性',
+                          code: 'E（情緒）',
+                          description: weatherPersonality.axisFeatures[3],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: BehaviorTendencyCard(
+                      behaviorTendencyList:
+                          weatherPersonality.behaviorTendencyList,
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: CompatibleTypeCard(
+                      compatibleTypes: weatherPersonality.compatibleTypes,
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: IncompatibleTypeCard(
+                      incompatibleTypes: weatherPersonality.incompatibleTypes,
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: GodsMessageCard(
+                      godsMessage: weatherPersonality.godsMessage,
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                isMyWeatherPersonality
+                    ? SliverPadding(
+                        padding: const EdgeInsets.symmetric(horizontal: 20),
+                        sliver: SliverToBoxAdapter(
+                          child: ActionButton(
+                            icon: const Icon(Icons.share),
+                            label: Text(
+                              t.button.shareResults,
+                              style: theme.textTheme.labelLarge!.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                              ),
+                            ),
+                            foregroundColor: Colors.white,
+                            backgroundColor: theme.colorScheme.primary,
+                            onPressed: () async {
+                              await onShareTestResult();
+                            },
+                          ),
+                        ),
+                      )
+                    : const SliverToBoxAdapter(
+                        child: SizedBox.shrink(),
+                      ),
+                const Gap(height: 40),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MainResultCard extends StatelessWidget {
+  const _MainResultCard({
+    required this.typeCode,
+    required this.typeName,
+    required this.typeCatchphrase,
+    required this.typeCharacterImageUrl,
+  });
+  final String typeCode;
+  final String typeName;
+  final String typeCatchphrase;
+  final String typeCharacterImageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        color: const Color(0xFFE9F7FB),
+        borderRadius: BorderRadius.circular(32),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Text(
+            t.weatherPersonalityDetailPage.section.mainResult.typeCode,
+            style: theme.textTheme.titleSmall!.copyWith(
+              color: Colors.black54,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            typeCode,
+            style: theme.textTheme.titleLarge!.copyWith(
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Container(
+            width: 140,
+            height: 140,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  theme.colorScheme.secondary.withValues(alpha: 0.7),
+                  theme.colorScheme.tertiary.withValues(alpha: 0.7),
+                  theme.colorScheme.primary.withValues(alpha: 0.7),
+                ],
+              ),
+            ),
+            alignment: Alignment.center,
+            child: Image(
+              image: typeCharacterImageUrl.toImageProvider(),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            t.weatherPersonalityDetailPage.section.mainResult.you,
+            style: theme.textTheme.titleSmall!.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            typeName,
+            style: theme.textTheme.titleLarge!.copyWith(
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+                colors: [
+                  theme.colorScheme.secondary.withValues(alpha: 0.15),
+                  theme.colorScheme.tertiary.withValues(alpha: 0.15),
+                  theme.colorScheme.primary.withValues(alpha: 0.15),
+                ],
+              ),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              typeCatchphrase,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium!.copyWith(
+                fontSize: 13,
+                height: 1.6,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GodsRulingCard extends StatelessWidget {
+  const _GodsRulingCard({
+    required this.ruling,
+  });
+  final String ruling;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.godsRuling.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            ruling,
+            style: theme.textTheme.bodyMedium!.copyWith(height: 1.6),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class BehaviorTendencyCard extends StatelessWidget {
+  const BehaviorTendencyCard({
+    super.key,
+    required this.behaviorTendencyList,
+  });
+  final List<String> behaviorTendencyList;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.behaviorTendency.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Column(
+            children:
+                behaviorTendencyList.map((text) => _BulletText(text)).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BulletText extends StatelessWidget {
+  const _BulletText(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 14),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 9),
+            child: Icon(
+              Icons.circle,
+              size: 6,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodyMedium!.copyWith(
+                color: const Color(0xFF4A5F72),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CompatibleTypeCard extends StatelessWidget {
+  const CompatibleTypeCard({
+    super.key,
+    required this.compatibleTypes,
+  });
+  final List<TypeCompatibilityReadModel> compatibleTypes;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      padding: const EdgeInsets.symmetric(
+        vertical: 24,
+        horizontal: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.compatibleType.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children:
+                compatibleTypes.map((type) => TypeCard(type: type)).toList(),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class IncompatibleTypeCard extends StatelessWidget {
+  const IncompatibleTypeCard({
+    super.key,
+    required this.incompatibleTypes,
+  });
+  final List<TypeCompatibilityReadModel> incompatibleTypes;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      padding: const EdgeInsets.symmetric(
+        vertical: 24,
+        horizontal: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.incompatibleType.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children:
+                incompatibleTypes.map((type) => TypeCard(type: type)).toList(),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class TypeCard extends StatelessWidget {
+  const TypeCard({
+    super.key,
+    required this.type,
+  });
+  final TypeCompatibilityReadModel type;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            theme.colorScheme.secondary.withValues(alpha: 0.1),
+            theme.colorScheme.tertiary.withValues(alpha: 0.1),
+            theme.colorScheme.primary.withValues(alpha: 0.1),
+          ],
+        ),
+      ),
+      width: 150,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Container(
+            width: 140,
+            height: 140,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  theme.colorScheme.secondary.withValues(alpha: 0.7),
+                  theme.colorScheme.tertiary.withValues(alpha: 0.7),
+                  theme.colorScheme.primary.withValues(alpha: 0.7),
+                ],
+              ),
+            ),
+            alignment: Alignment.center,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: Image(
+                  image: type.typeCharacterImageUrl.toImageProvider(),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  type.typeCode,
+                  softWrap: true,
+                  style: theme.textTheme.bodyMedium!.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                Text(
+                  '(${type.typeName})',
+                  softWrap: true,
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  'Point:',
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  type.compatibilityPoint,
+                  softWrap: true,
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class GodsMessageCard extends StatelessWidget {
+  const GodsMessageCard({
+    super.key,
+    required this.godsMessage,
+  });
+  final String godsMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      colors: const [
+        Color(0xFFCDDCD7),
+        Color(0xFFB7E3DB),
+      ],
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 32,
+                backgroundColor: Colors.transparent,
+                backgroundImage: Assets
+                    .images.weatherPersonality.reimiGodIcon.path
+                    .toImageProvider(),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                t.weatherPersonalityDetailPage.section.godsMessage.title,
+                style: theme.textTheme.titleSmall!.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            godsMessage,
+            style: theme.textTheme.bodyMedium!.copyWith(
+              height: 1.6,
+              color: const Color(0xFF334155),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_test_result_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_test_result_page.dart
@@ -214,48 +214,6 @@ class WeatherPersonalityTestResultPage extends HookConsumerWidget {
                 SliverPadding(
                   padding: const EdgeInsets.symmetric(horizontal: 20),
                   sliver: SliverToBoxAdapter(
-                    child: Column(
-                      children: [
-                        SectionTitle(
-                          title: t.weatherPersonalityTestResultPage.section
-                              .axisFeature.title,
-                        ),
-                        const SizedBox(height: 16),
-                        AxisFeatureCard(
-                          //TODO: スコアによって title、code が変わる
-                          title: '感受性',
-                          code: 'S（高）',
-                          description: weatherPersonality.axisFeatures[0],
-                        ),
-                        const SizedBox(height: 12),
-                        AxisFeatureCard(
-                          //TODO: スコアによって title、code が変わる
-                          title: '準備性',
-                          code: 'P（計画型）',
-                          description: weatherPersonality.axisFeatures[1],
-                        ),
-                        const SizedBox(height: 12),
-                        AxisFeatureCard(
-                          //TODO: スコアによって title、code が変わる
-                          title: '外行動性',
-                          code: 'O（Outdoor）',
-                          description: weatherPersonality.axisFeatures[2],
-                        ),
-                        const SizedBox(height: 12),
-                        AxisFeatureCard(
-                          //TODO: スコアによって title、code が変わる
-                          title: '動機特性',
-                          code: 'E（情緒）',
-                          description: weatherPersonality.axisFeatures[3],
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                const Gap(height: 32),
-                SliverPadding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  sliver: SliverToBoxAdapter(
                     child: TextCard(
                       child: Column(
                         children: [
@@ -297,6 +255,48 @@ class WeatherPersonalityTestResultPage extends HookConsumerWidget {
                           ),
                         ],
                       ),
+                    ),
+                  ),
+                ),
+                const Gap(height: 32),
+                SliverPadding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  sliver: SliverToBoxAdapter(
+                    child: Column(
+                      children: [
+                        SectionTitle(
+                          title: t.weatherPersonalityTestResultPage.section
+                              .axisFeature.title,
+                        ),
+                        const SizedBox(height: 16),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '感受性',
+                          code: 'S（高）',
+                          description: weatherPersonality.axisFeatures[0],
+                        ),
+                        const SizedBox(height: 12),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '準備性',
+                          code: 'P（計画型）',
+                          description: weatherPersonality.axisFeatures[1],
+                        ),
+                        const SizedBox(height: 12),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '外行動性',
+                          code: 'O（Outdoor）',
+                          description: weatherPersonality.axisFeatures[2],
+                        ),
+                        const SizedBox(height: 12),
+                        AxisFeatureCard(
+                          //TODO: スコアによって title、code が変わる
+                          title: '動機特性',
+                          code: 'E（情緒）',
+                          description: weatherPersonality.axisFeatures[3],
+                        ),
+                      ],
                     ),
                   ),
                 ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_detail_state.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_detail_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
+
+part 'weather_personality_detail_state.freezed.dart';
+
+@freezed
+abstract class WeatherPersonalityDetailState
+    with _$WeatherPersonalityDetailState {
+  const factory WeatherPersonalityDetailState({
+    WeatherPersonalityDetailReadModel? weatherPersonality,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+    @Default(false) bool isMyWeatherPersonality,
+  }) = _WeatherPersonalityDetailState;
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_detail_state.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_detail_state.freezed.dart
@@ -1,0 +1,420 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_personality_detail_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WeatherPersonalityDetailState {
+  WeatherPersonalityDetailReadModel? get weatherPersonality;
+  bool get isLoading;
+  String? get errorMessage;
+  bool get isMyWeatherPersonality;
+
+  /// Create a copy of WeatherPersonalityDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityDetailStateCopyWith<WeatherPersonalityDetailState>
+      get copyWith => _$WeatherPersonalityDetailStateCopyWithImpl<
+              WeatherPersonalityDetailState>(
+          this as WeatherPersonalityDetailState, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WeatherPersonalityDetailState &&
+            (identical(other.weatherPersonality, weatherPersonality) ||
+                other.weatherPersonality == weatherPersonality) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.isMyWeatherPersonality, isMyWeatherPersonality) ||
+                other.isMyWeatherPersonality == isMyWeatherPersonality));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, weatherPersonality, isLoading,
+      errorMessage, isMyWeatherPersonality);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityDetailState(weatherPersonality: $weatherPersonality, isLoading: $isLoading, errorMessage: $errorMessage, isMyWeatherPersonality: $isMyWeatherPersonality)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WeatherPersonalityDetailStateCopyWith<$Res> {
+  factory $WeatherPersonalityDetailStateCopyWith(
+          WeatherPersonalityDetailState value,
+          $Res Function(WeatherPersonalityDetailState) _then) =
+      _$WeatherPersonalityDetailStateCopyWithImpl;
+  @useResult
+  $Res call(
+      {WeatherPersonalityDetailReadModel? weatherPersonality,
+      bool isLoading,
+      String? errorMessage,
+      bool isMyWeatherPersonality});
+
+  $WeatherPersonalityDetailReadModelCopyWith<$Res>? get weatherPersonality;
+}
+
+/// @nodoc
+class _$WeatherPersonalityDetailStateCopyWithImpl<$Res>
+    implements $WeatherPersonalityDetailStateCopyWith<$Res> {
+  _$WeatherPersonalityDetailStateCopyWithImpl(this._self, this._then);
+
+  final WeatherPersonalityDetailState _self;
+  final $Res Function(WeatherPersonalityDetailState) _then;
+
+  /// Create a copy of WeatherPersonalityDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? weatherPersonality = freezed,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+    Object? isMyWeatherPersonality = null,
+  }) {
+    return _then(_self.copyWith(
+      weatherPersonality: freezed == weatherPersonality
+          ? _self.weatherPersonality
+          : weatherPersonality // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityDetailReadModel?,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isMyWeatherPersonality: null == isMyWeatherPersonality
+          ? _self.isMyWeatherPersonality
+          : isMyWeatherPersonality // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+
+  /// Create a copy of WeatherPersonalityDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityDetailReadModelCopyWith<$Res>? get weatherPersonality {
+    if (_self.weatherPersonality == null) {
+      return null;
+    }
+
+    return $WeatherPersonalityDetailReadModelCopyWith<$Res>(
+        _self.weatherPersonality!, (value) {
+      return _then(_self.copyWith(weatherPersonality: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [WeatherPersonalityDetailState].
+extension WeatherPersonalityDetailStatePatterns
+    on WeatherPersonalityDetailState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityDetailState value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailState() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityDetailState value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailState():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_WeatherPersonalityDetailState value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailState() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(WeatherPersonalityDetailReadModel? weatherPersonality,
+            bool isLoading, String? errorMessage, bool isMyWeatherPersonality)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailState() when $default != null:
+        return $default(_that.weatherPersonality, _that.isLoading,
+            _that.errorMessage, _that.isMyWeatherPersonality);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(WeatherPersonalityDetailReadModel? weatherPersonality,
+            bool isLoading, String? errorMessage, bool isMyWeatherPersonality)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailState():
+        return $default(_that.weatherPersonality, _that.isLoading,
+            _that.errorMessage, _that.isMyWeatherPersonality);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(WeatherPersonalityDetailReadModel? weatherPersonality,
+            bool isLoading, String? errorMessage, bool isMyWeatherPersonality)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityDetailState() when $default != null:
+        return $default(_that.weatherPersonality, _that.isLoading,
+            _that.errorMessage, _that.isMyWeatherPersonality);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _WeatherPersonalityDetailState implements WeatherPersonalityDetailState {
+  const _WeatherPersonalityDetailState(
+      {this.weatherPersonality,
+      this.isLoading = false,
+      this.errorMessage,
+      this.isMyWeatherPersonality = false});
+
+  @override
+  final WeatherPersonalityDetailReadModel? weatherPersonality;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+  @override
+  @JsonKey()
+  final bool isMyWeatherPersonality;
+
+  /// Create a copy of WeatherPersonalityDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$WeatherPersonalityDetailStateCopyWith<_WeatherPersonalityDetailState>
+      get copyWith => __$WeatherPersonalityDetailStateCopyWithImpl<
+          _WeatherPersonalityDetailState>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WeatherPersonalityDetailState &&
+            (identical(other.weatherPersonality, weatherPersonality) ||
+                other.weatherPersonality == weatherPersonality) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.isMyWeatherPersonality, isMyWeatherPersonality) ||
+                other.isMyWeatherPersonality == isMyWeatherPersonality));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, weatherPersonality, isLoading,
+      errorMessage, isMyWeatherPersonality);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityDetailState(weatherPersonality: $weatherPersonality, isLoading: $isLoading, errorMessage: $errorMessage, isMyWeatherPersonality: $isMyWeatherPersonality)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$WeatherPersonalityDetailStateCopyWith<$Res>
+    implements $WeatherPersonalityDetailStateCopyWith<$Res> {
+  factory _$WeatherPersonalityDetailStateCopyWith(
+          _WeatherPersonalityDetailState value,
+          $Res Function(_WeatherPersonalityDetailState) _then) =
+      __$WeatherPersonalityDetailStateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {WeatherPersonalityDetailReadModel? weatherPersonality,
+      bool isLoading,
+      String? errorMessage,
+      bool isMyWeatherPersonality});
+
+  @override
+  $WeatherPersonalityDetailReadModelCopyWith<$Res>? get weatherPersonality;
+}
+
+/// @nodoc
+class __$WeatherPersonalityDetailStateCopyWithImpl<$Res>
+    implements _$WeatherPersonalityDetailStateCopyWith<$Res> {
+  __$WeatherPersonalityDetailStateCopyWithImpl(this._self, this._then);
+
+  final _WeatherPersonalityDetailState _self;
+  final $Res Function(_WeatherPersonalityDetailState) _then;
+
+  /// Create a copy of WeatherPersonalityDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? weatherPersonality = freezed,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+    Object? isMyWeatherPersonality = null,
+  }) {
+    return _then(_WeatherPersonalityDetailState(
+      weatherPersonality: freezed == weatherPersonality
+          ? _self.weatherPersonality
+          : weatherPersonality // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityDetailReadModel?,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isMyWeatherPersonality: null == isMyWeatherPersonality
+          ? _self.isMyWeatherPersonality
+          : isMyWeatherPersonality // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+
+  /// Create a copy of WeatherPersonalityDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityDetailReadModelCopyWith<$Res>? get weatherPersonality {
+    if (_self.weatherPersonality == null) {
+      return null;
+    }
+
+    return $WeatherPersonalityDetailReadModelCopyWith<$Res>(
+        _self.weatherPersonality!, (value) {
+      return _then(_self.copyWith(weatherPersonality: value));
+    });
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/widgets/axis_score_bar.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/widgets/axis_score_bar.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class AxisScoreBar extends StatelessWidget {
   final String leftLabel;
   final String rightLabel;
-  final int score; // -8 ~ +8 想定
+  final int score; // -8 ~ +8
 
   const AxisScoreBar({
     super.key,
@@ -15,30 +15,23 @@ class AxisScoreBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final double normalized = score / 16;
+
+    // 0.0 ~ 1.0（左右それぞれの最大幅に対する割合）
+    final double ratio = (score.abs() / 8).clamp(0, 1);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
           children: [
-            Text(
-              leftLabel,
-              style: theme.textTheme.titleSmall!.copyWith(
-                fontSize: 12,
-              ),
-            ),
+            Text(leftLabel, style: theme.textTheme.titleSmall),
             const Spacer(),
-            Text(
-              rightLabel,
-              style: theme.textTheme.titleSmall!.copyWith(
-                fontSize: 12,
-              ),
-            ),
+            Text(rightLabel, style: theme.textTheme.titleSmall),
           ],
         ),
         const SizedBox(height: 8),
         Stack(
+          alignment: Alignment.center,
           children: [
             Container(
               height: 22,
@@ -47,34 +40,53 @@ class AxisScoreBar extends StatelessWidget {
                 borderRadius: BorderRadius.circular(32),
               ),
             ),
-            FractionallySizedBox(
-              widthFactor: normalized,
-              child: Container(
-                height: 22,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(32),
-                  gradient: LinearGradient(
-                    colors: [
-                      theme.colorScheme.secondary,
-                      theme.colorScheme.primary,
-                    ],
+            Row(
+              children: [
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: score < 0
+                        ? FractionallySizedBox(
+                            widthFactor: ratio,
+                            alignment: Alignment.centerRight,
+                            child: _bar(theme.colorScheme.primary),
+                          )
+                        : const SizedBox.shrink(),
                   ),
                 ),
-              ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: score > 0
+                        ? FractionallySizedBox(
+                            widthFactor: ratio,
+                            alignment: Alignment.centerLeft,
+                            child: _bar(theme.colorScheme.secondary),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ),
+              ],
             ),
-            Positioned.fill(
-              child: Center(
-                child: Text(
-                  displayScore(score),
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
+            Text(
+              displayScore(score),
+              style: theme.textTheme.labelLarge!.copyWith(
+                fontWeight: FontWeight.bold,
               ),
             ),
           ],
         ),
       ],
+    );
+  }
+
+  Widget _bar(Color color) {
+    return Container(
+      height: 22,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(32),
+        color: color,
+      ),
     );
   }
 }

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/widgets/text_card.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/widgets/text_card.dart
@@ -6,15 +6,17 @@ class TextCard extends StatelessWidget {
     required this.child,
     this.color,
     this.colors,
+    this.padding,
   });
   final Widget? child;
   final Color? color;
   final List<Color>? colors;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(24),
+      padding: padding ?? const EdgeInsets.all(24),
       decoration: BoxDecoration(
         color: color ?? const Color(0xFFE9F7FB),
         borderRadius: BorderRadius.circular(24),

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_detail_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_detail_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:reimi_app/core/di/usecase_providers.dart';
+import 'package:reimi_app/domain/read_models/weather_report_read_model.dart';
 import 'package:reimi_app/presentation/features/weather_report/states/weather_report_detail_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -24,12 +25,20 @@ class WeatherReportDetailNotifier extends _$WeatherReportDetailNotifier {
         weatherReport: weatherReport,
         isLoading: false,
       );
+      await isMyReport(weatherReport);
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
         errorMessage: e.toString(),
       );
     }
+  }
+
+  Future<void> isMyReport(WeatherReportReadModel? weatherReport) async {
+    if (weatherReport == null) return;
+    final user = await ref.read(getCurrentUserUseCaseProvider).call();
+    final isMyReport = weatherReport.userId == user.id;
+    state = state.copyWith(isMyReport: isMyReport);
   }
 
   Future<void> refresh(String reportId) async {

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_detail_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_detail_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'weather_report_detail_notifier.dart';
 // **************************************************************************
 
 String _$weatherReportDetailNotifierHash() =>
-    r'a1b575f5a452d5c3a05f4778827457da7896e17b';
+    r'4b9a9609f4f40802ccc4a649f2c23e0884f0c965';
 
 /// See also [WeatherReportDetailNotifier].
 @ProviderFor(WeatherReportDetailNotifier)

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_detail_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_detail_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'weather_report_detail_notifier.dart';
 // **************************************************************************
 
 String _$weatherReportDetailNotifierHash() =>
-    r'1193052eed2df43dc8fcff087bc0c13cf84b4669';
+    r'a1b575f5a452d5c3a05f4778827457da7896e17b';
 
 /// See also [WeatherReportDetailNotifier].
 @ProviderFor(WeatherReportDetailNotifier)

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/my_weather_report_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/my_weather_report_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:reimi_app/core/extensions/datetime_extensions.dart';
+import 'package:reimi_app/core/extensions/image_path_extension.dart';
 import 'package:reimi_app/core/i18n/strings.g.dart';
 import 'package:reimi_app/domain/read_models/weather_report_simple_read_model.dart';
 import 'package:reimi_app/presentation/features/weather_report/notifiers/my_weather_report_notifier.dart';
@@ -332,63 +333,68 @@ class _CalendarDayCell extends StatelessWidget {
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
-      child: Container(
-        color: const Color(0xFF3F566B),
-        child: Stack(
-          children: [
-            if (report != null)
-              GestureDetector(
-                onTap: () {
-                  context.push(
-                    WeatherReportDetailPage.routeLocation,
-                    extra: {'reportId': report!.reportId},
-                  );
-                },
-                child: ClipRRect(
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: report == null
+            ? null
+            : () {
+                context.push(
+                  WeatherReportDetailPage.routeLocation,
+                  extra: {'reportId': report!.reportId},
+                );
+              },
+        child: Container(
+          color: const Color(0xFF3F566B),
+          child: Stack(
+            children: [
+              if (report != null)
+                ClipRRect(
                   borderRadius: BorderRadius.circular(8),
-                  child: Image.network(
-                    report!.url,
+                  child: Image(
+                    image: report!.url.toImageProvider(),
                     fit: BoxFit.cover,
                     width: double.infinity,
                     height: double.infinity,
                   ),
                 ),
-              )
-            else
-              const SizedBox.shrink(),
-            Positioned(
-              top: 6,
-              left: 6,
-              child: Text(
-                '${date.day}',
-                style: theme.textTheme.titleMedium!.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  shadows: report != null
-                      ? const [
-                          Shadow(
-                            blurRadius: 4,
-                            color: Colors.black54,
-                          ),
-                        ]
-                      : null,
-                ),
-              ),
-            ),
-            if (isToday)
               Positioned(
-                top: 4,
-                right: 4,
-                child: Container(
-                  width: 8,
-                  height: 8,
-                  decoration: const BoxDecoration(
-                    color: Colors.orange,
-                    shape: BoxShape.circle,
+                top: 6,
+                left: 6,
+                child: IgnorePointer(
+                  child: Text(
+                    '${date.day}',
+                    style: theme.textTheme.titleMedium!.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      shadows: report != null
+                          ? const [
+                              Shadow(
+                                blurRadius: 4,
+                                color: Colors.black54,
+                              ),
+                            ]
+                          : null,
+                    ),
                   ),
                 ),
               ),
-          ],
+              if (isToday)
+                Positioned(
+                  top: 4,
+                  right: 4,
+                  child: IgnorePointer(
+                    child: Container(
+                      width: 8,
+                      height: 8,
+                      decoration: const BoxDecoration(
+                        color: Colors.orange,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/weather_report_detail_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/weather_report_detail_page.dart
@@ -33,6 +33,9 @@ class WeatherReportDetailPage extends HookConsumerWidget {
         .select((state) => state.weatherReport));
     final isLoading = ref.watch(
         weatherReportDetailNotifierProvider.select((state) => state.isLoading));
+    // コメントアウトしているReportBodyあたりを参照 ↓↓
+    // final isMyReport = ref.watch(weatherReportDetailNotifierProvider
+    //     .select((state) => state.isMyReport));
 
     useEffect(() {
       Future.microtask(() {
@@ -261,6 +264,29 @@ class WeatherReportDetailPage extends HookConsumerWidget {
     );
   }
 }
+
+// TODO: 
+// 自分の投稿の時だけ背景デザインを夜パターンに変更すると、
+// マイウェザーリポート画面から遷移する時の違和感がなくなりそう
+// class ReportBody extends StatelessWidget {
+//   const ReportBody({
+//     super.key,
+//     required this.isMyReport,
+//     required this.child,
+//   });
+
+//   final bool isMyReport;
+//   final Widget? child;
+
+//   @override
+//   Widget build(BuildContext context) {
+//     if (isMyReport) {
+//       return BackgroundContainerNight(child: child);
+//     } else {
+//       return BackgroundContainerNoon(child: child);
+//     }
+//   }
+// }
 
 class _InfoRow extends StatelessWidget {
   const _InfoRow({

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/weather_report_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/weather_report_page.dart
@@ -67,11 +67,11 @@ class WeatherReportPage extends HookConsumerWidget {
                     centerTitle: false,
                     title: Text(
                       t.weatherReportPage.title,
-                      style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w600,
-                            color: Colors.black87,
-                          ),
+                      style: theme.textTheme.titleMedium!.copyWith(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.black87,
+                      ),
                     ),
                     actions: [
                       CircleIconButton(

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/weather_report_post_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/pages/weather_report_post_page.dart
@@ -109,11 +109,11 @@ class WeatherReportPostPage extends HookConsumerWidget {
         ),
         title: Text(
           t.weatherReportPostPage.title,
-          style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                fontSize: 15,
-                fontWeight: FontWeight.w600,
-                color: Colors.white,
-              ),
+          style: theme.textTheme.titleMedium!.copyWith(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
         ),
         backgroundColor: Colors.transparent,
         elevation: 0,

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/states/weather_report_detail_state.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/states/weather_report_detail_state.dart
@@ -8,5 +8,6 @@ abstract class WeatherReportDetailState with _$WeatherReportDetailState {
     WeatherReportReadModel? weatherReport,
     @Default(false) bool isLoading,
     String? errorMessage,
+    @Default(false) bool isMyReport,
   }) = _WeatherReportDetailState;
 }

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/states/weather_report_detail_state.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/states/weather_report_detail_state.freezed.dart
@@ -17,6 +17,7 @@ mixin _$WeatherReportDetailState {
   WeatherReportReadModel? get weatherReport;
   bool get isLoading;
   String? get errorMessage;
+  bool get isMyReport;
 
   /// Create a copy of WeatherReportDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -36,16 +37,18 @@ mixin _$WeatherReportDetailState {
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading) &&
             (identical(other.errorMessage, errorMessage) ||
-                other.errorMessage == errorMessage));
+                other.errorMessage == errorMessage) &&
+            (identical(other.isMyReport, isMyReport) ||
+                other.isMyReport == isMyReport));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, weatherReport, isLoading, errorMessage);
+  int get hashCode => Object.hash(
+      runtimeType, weatherReport, isLoading, errorMessage, isMyReport);
 
   @override
   String toString() {
-    return 'WeatherReportDetailState(weatherReport: $weatherReport, isLoading: $isLoading, errorMessage: $errorMessage)';
+    return 'WeatherReportDetailState(weatherReport: $weatherReport, isLoading: $isLoading, errorMessage: $errorMessage, isMyReport: $isMyReport)';
   }
 }
 
@@ -58,7 +61,8 @@ abstract mixin class $WeatherReportDetailStateCopyWith<$Res> {
   $Res call(
       {WeatherReportReadModel? weatherReport,
       bool isLoading,
-      String? errorMessage});
+      String? errorMessage,
+      bool isMyReport});
 
   $WeatherReportReadModelCopyWith<$Res>? get weatherReport;
 }
@@ -79,6 +83,7 @@ class _$WeatherReportDetailStateCopyWithImpl<$Res>
     Object? weatherReport = freezed,
     Object? isLoading = null,
     Object? errorMessage = freezed,
+    Object? isMyReport = null,
   }) {
     return _then(_self.copyWith(
       weatherReport: freezed == weatherReport
@@ -93,6 +98,10 @@ class _$WeatherReportDetailStateCopyWithImpl<$Res>
           ? _self.errorMessage
           : errorMessage // ignore: cast_nullable_to_non_nullable
               as String?,
+      isMyReport: null == isMyReport
+          ? _self.isMyReport
+          : isMyReport // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 
@@ -205,15 +214,15 @@ extension WeatherReportDetailStatePatterns on WeatherReportDetailState {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
     TResult Function(WeatherReportReadModel? weatherReport, bool isLoading,
-            String? errorMessage)?
+            String? errorMessage, bool isMyReport)?
         $default, {
     required TResult orElse(),
   }) {
     final _that = this;
     switch (_that) {
       case _WeatherReportDetailState() when $default != null:
-        return $default(
-            _that.weatherReport, _that.isLoading, _that.errorMessage);
+        return $default(_that.weatherReport, _that.isLoading,
+            _that.errorMessage, _that.isMyReport);
       case _:
         return orElse();
     }
@@ -235,14 +244,14 @@ extension WeatherReportDetailStatePatterns on WeatherReportDetailState {
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
     TResult Function(WeatherReportReadModel? weatherReport, bool isLoading,
-            String? errorMessage)
+            String? errorMessage, bool isMyReport)
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _WeatherReportDetailState():
-        return $default(
-            _that.weatherReport, _that.isLoading, _that.errorMessage);
+        return $default(_that.weatherReport, _that.isLoading,
+            _that.errorMessage, _that.isMyReport);
       case _:
         throw StateError('Unexpected subclass');
     }
@@ -263,14 +272,14 @@ extension WeatherReportDetailStatePatterns on WeatherReportDetailState {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
     TResult? Function(WeatherReportReadModel? weatherReport, bool isLoading,
-            String? errorMessage)?
+            String? errorMessage, bool isMyReport)?
         $default,
   ) {
     final _that = this;
     switch (_that) {
       case _WeatherReportDetailState() when $default != null:
-        return $default(
-            _that.weatherReport, _that.isLoading, _that.errorMessage);
+        return $default(_that.weatherReport, _that.isLoading,
+            _that.errorMessage, _that.isMyReport);
       case _:
         return null;
     }
@@ -281,7 +290,10 @@ extension WeatherReportDetailStatePatterns on WeatherReportDetailState {
 
 class _WeatherReportDetailState implements WeatherReportDetailState {
   const _WeatherReportDetailState(
-      {this.weatherReport, this.isLoading = false, this.errorMessage});
+      {this.weatherReport,
+      this.isLoading = false,
+      this.errorMessage,
+      this.isMyReport = false});
 
   @override
   final WeatherReportReadModel? weatherReport;
@@ -290,6 +302,9 @@ class _WeatherReportDetailState implements WeatherReportDetailState {
   final bool isLoading;
   @override
   final String? errorMessage;
+  @override
+  @JsonKey()
+  final bool isMyReport;
 
   /// Create a copy of WeatherReportDetailState
   /// with the given fields replaced by the non-null parameter values.
@@ -310,16 +325,18 @@ class _WeatherReportDetailState implements WeatherReportDetailState {
             (identical(other.isLoading, isLoading) ||
                 other.isLoading == isLoading) &&
             (identical(other.errorMessage, errorMessage) ||
-                other.errorMessage == errorMessage));
+                other.errorMessage == errorMessage) &&
+            (identical(other.isMyReport, isMyReport) ||
+                other.isMyReport == isMyReport));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, weatherReport, isLoading, errorMessage);
+  int get hashCode => Object.hash(
+      runtimeType, weatherReport, isLoading, errorMessage, isMyReport);
 
   @override
   String toString() {
-    return 'WeatherReportDetailState(weatherReport: $weatherReport, isLoading: $isLoading, errorMessage: $errorMessage)';
+    return 'WeatherReportDetailState(weatherReport: $weatherReport, isLoading: $isLoading, errorMessage: $errorMessage, isMyReport: $isMyReport)';
   }
 }
 
@@ -334,7 +351,8 @@ abstract mixin class _$WeatherReportDetailStateCopyWith<$Res>
   $Res call(
       {WeatherReportReadModel? weatherReport,
       bool isLoading,
-      String? errorMessage});
+      String? errorMessage,
+      bool isMyReport});
 
   @override
   $WeatherReportReadModelCopyWith<$Res>? get weatherReport;
@@ -356,6 +374,7 @@ class __$WeatherReportDetailStateCopyWithImpl<$Res>
     Object? weatherReport = freezed,
     Object? isLoading = null,
     Object? errorMessage = freezed,
+    Object? isMyReport = null,
   }) {
     return _then(_WeatherReportDetailState(
       weatherReport: freezed == weatherReport
@@ -370,6 +389,10 @@ class __$WeatherReportDetailStateCopyWithImpl<$Res>
           ? _self.errorMessage
           : errorMessage // ignore: cast_nullable_to_non_nullable
               as String?,
+      isMyReport: null == isMyReport
+          ? _self.isMyReport
+          : isMyReport // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 


### PR DESCRIPTION
## 対応Issue

- #133 

close #133

## 対応したこと

<!-- このプルリクで何をしたのか記述する -->
- core
  - di
    - ウェザーパーソナリティ関連のユースケースのdi追加
     
- data
  - datasource
    - weather_personality
      - ウェザーパーソナリティの詳細情報を取得する項目を追加、モックデータも追加
      - ウェザーパーソナリティ詳細を取得する項目を追加 
    - weather_report
      - 自分の投稿が見れるようにモックデータ追加・修正 
       
- domain
  - read_model
    - タイプ間の相性を取得するReadモデル実装
    - ウェザーパーソナリティ詳細取得のReadモデル実装  
  - repository
    - ウェザーパーソナリティ詳細を取得する項目を追加
     
- application
  - usecase
    - ウェザーパーソナリティ詳細を取得するユースケースを実装
      
- presentaiton
  - account, profile, profile_detail
    - ウェザーパーソナリティのUI実装、詳細画面への導線も追加 
  - weather_personality
    - ウェザーパーソナリティ詳細画面のUI実装
    -  再診断できる導線も設けた
    - ウェザーパーソナリティ詳細画面を状態管理するstate実装
    - ウェザーパーソナリティ詳細画面を状態管理するnotifier実装
    - スコア表示の軸が中央から始まり、-8 ~ +8の間で表すようにデザインを修正
    - 表示順が、軸特徴 → 軸スコア だったのを、軸スコア → 軸特徴 に変更 
  - weather_report
    - ウェザーリポート詳細の画面のデザインで、自分と他ユーザーでデザイン分けする案をコメント 
    - 自分の投稿かどうかわかるstateを追加
    - 自分の投稿かどうかわかるメソッドを追加
    - セルのPositionedで表示されているウィジェット上をタップしたら、遷移処理がうまく反応しなかったので修正 
    
- 修正
  - Theme.of(context)を変数化して使用


## 参考資料
<!-- 参考にした資料のリンクを貼る -->

## 対応しきれなかったこと
- ウェザーパーソナリティのロジック実装
  - #93  

<!-- 修正が必要そうな部分や別チケットで解決したい部分をあげる -->

## 画面キャプチャ

<!-- 実装前と実装後でどう変わったかわかるキャプチャを貼る -->

| ウェザーパーソナリティ詳細(デフォルト) | ウェザーパーソナリティ詳細(相性) |
| -- | -- |
| <img width="200" alt="Simulator Screenshot - iPhone 16e - 2026-01-25 at 00 04 04" src="https://github.com/user-attachments/assets/c7e5315c-5e90-4504-80b3-6cd4e9cff428" /> | <img width="200" alt="Simulator Screenshot - iPhone 16e - 2026-01-25 at 00 04 23" src="https://github.com/user-attachments/assets/79dd83db-233b-4997-9611-6fb172aaffc0" /> |