### PR TITLE
マッチング成立時のPush通知機能を実装

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/ReimiAppApplication.java
@@ -3,10 +3,12 @@ package com.reimi.reimi_app;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication(
 	exclude = UserDetailsServiceAutoConfiguration.class
 )
+@EnableAsync
 public class ReimiAppApplication {
 
 	public static void main(String[] args) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/DeviceTokenService.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/DeviceTokenService.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.application.service;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public interface DeviceTokenService {
+    void register(UserId userId, String token);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/NotificationService.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/NotificationService.java
@@ -1,7 +1,8 @@
 package com.reimi.reimi_app.application.service;
 
+import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
 
 public interface NotificationService {
-    void notifyMatchCreated(UserId fromUserId, UserId toUserId);
+    void notifyMatchCreated(User fromUser, UserId toUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/NotificationService.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/service/NotificationService.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.application.service;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public interface NotificationService {
+    void notifyMatchCreated(UserId fromUserId, UserId toUserId);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/AsyncConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/AsyncConfig.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AsyncConfig {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/notification/FcmPushNotificationSender.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/notification/FcmPushNotificationSender.java
@@ -1,0 +1,43 @@
+package com.reimi.reimi_app.infrastructure.notification;
+
+import java.util.concurrent.Executors;
+
+import org.springframework.stereotype.Component;
+
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+
+@Component
+public class FcmPushNotificationSender implements PushNotificationSender {
+
+    @Override
+    public void sendMatchNotification(
+        String deviceToken,
+        String title,
+        String body
+    ) {
+        Message message = Message.builder()
+            .setToken(deviceToken)
+            .setNotification(
+                Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build()
+            )
+            .putData("type", "MATCH")
+            .build();
+
+        ApiFuture<String> future = FirebaseMessaging.getInstance().sendAsync(message);
+
+        future.addListener(() -> {
+            try {
+                String response = future.get();
+                System.out.println("マッチング通知成功: " + response);
+            } catch (Exception e) {
+                System.err.println("マッチング通知失敗: " + e.getMessage());
+            }
+        }, Executors.newSingleThreadExecutor());
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/notification/FcmPushNotificationSender.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/notification/FcmPushNotificationSender.java
@@ -1,10 +1,7 @@
 package com.reimi.reimi_app.infrastructure.notification;
 
-import java.util.concurrent.Executors;
-
 import org.springframework.stereotype.Component;
 
-import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
@@ -29,15 +26,11 @@ public class FcmPushNotificationSender implements PushNotificationSender {
             .putData("type", "MATCH")
             .build();
 
-        ApiFuture<String> future = FirebaseMessaging.getInstance().sendAsync(message);
-
-        future.addListener(() -> {
-            try {
-                String response = future.get();
-                System.out.println("マッチング通知成功: " + response);
-            } catch (Exception e) {
-                System.err.println("マッチング通知失敗: " + e.getMessage());
-            }
-        }, Executors.newSingleThreadExecutor());
+        try {
+            String response = FirebaseMessaging.getInstance().sendAsync(message).get();
+            System.out.println("マッチング通知成功: " + response);
+        } catch (Exception e) {
+            System.err.println("マッチング通知失敗: " + e.getMessage());
+        }
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/notification/PushNotificationSender.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/notification/PushNotificationSender.java
@@ -1,0 +1,9 @@
+package com.reimi.reimi_app.infrastructure.notification;
+
+public interface PushNotificationSender {
+    void sendMatchNotification(
+        String deviceToken,
+        String title,
+        String body
+    );
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/DeviceTokenEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/DeviceTokenEntity.java
@@ -1,0 +1,52 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(
+    name = "device_tokens",
+    uniqueConstraints = @UniqueConstraint(columnNames = "token")
+)
+public class DeviceTokenEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "last_used_at", nullable = false)
+    private OffsetDateTime lastUsedAt;
+
+    protected DeviceTokenEntity() {}
+
+    public static DeviceTokenEntity create(UUID userId, String token) {
+
+        DeviceTokenEntity entity = new DeviceTokenEntity();
+
+        entity.id = UUID.randomUUID();
+        entity.userId = userId;
+        entity.token = token;
+        entity.lastUsedAt = OffsetDateTime.now();
+
+        return entity;
+    }
+
+    public void reassign(UUID userId) {
+        this.userId = userId;
+        this.lastUsedAt = OffsetDateTime.now();
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/DeviceTokenRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/DeviceTokenRepository.java
@@ -9,11 +9,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public class DeviceTokenRepositoryImpl {
+public class DeviceTokenRepository {
 
     private final JpaDeviceTokenRepository jpaDeviceTokenRepository;
 
-    public DeviceTokenRepositoryImpl(
+    public DeviceTokenRepository(
         JpaDeviceTokenRepository jpaDeviceTokenRepository
     ) {
         this.jpaDeviceTokenRepository = jpaDeviceTokenRepository;

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/DeviceTokenRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/DeviceTokenRepository.java
@@ -23,7 +23,7 @@ public class DeviceTokenRepository {
         return jpaDeviceTokenRepository.findByToken(token);
     }
 
-    public List<DeviceTokenEntity> findByUserId(UUID userId) {
+    public List<DeviceTokenEntity> findAllByUserId(UUID userId) {
         return jpaDeviceTokenRepository.findByUserId(userId);
     }
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/DeviceTokenRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/DeviceTokenRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.devicetoken;
+
+import org.springframework.stereotype.Repository;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.DeviceTokenEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class DeviceTokenRepositoryImpl {
+
+    private final JpaDeviceTokenRepository jpaDeviceTokenRepository;
+
+    public DeviceTokenRepositoryImpl(
+        JpaDeviceTokenRepository jpaDeviceTokenRepository
+    ) {
+        this.jpaDeviceTokenRepository = jpaDeviceTokenRepository;
+    }
+
+    public Optional<DeviceTokenEntity> findByToken(String token) {
+        return jpaDeviceTokenRepository.findByToken(token);
+    }
+
+    public List<DeviceTokenEntity> findByUserId(UUID userId) {
+        return jpaDeviceTokenRepository.findByUserId(userId);
+    }
+
+    public void save(DeviceTokenEntity entity) {
+        jpaDeviceTokenRepository.save(entity);
+    }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/JpaDeviceTokenRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/devicetoken/JpaDeviceTokenRepository.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.devicetoken;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.DeviceTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JpaDeviceTokenRepository extends JpaRepository<DeviceTokenEntity, UUID> {
+
+    Optional<DeviceTokenEntity> findByToken(String token);
+
+    List<DeviceTokenEntity> findByUserId(UUID userId);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/DeviceTokenServiceImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/DeviceTokenServiceImpl.java
@@ -1,0 +1,34 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import org.springframework.stereotype.Service;
+
+import com.reimi.reimi_app.application.service.DeviceTokenService;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.infrastructure.persistence.entity.DeviceTokenEntity;
+import com.reimi.reimi_app.infrastructure.persistence.repository.devicetoken.DeviceTokenRepository;
+
+import jakarta.transaction.Transactional;
+
+@Service
+@Transactional
+public class DeviceTokenServiceImpl implements DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    public DeviceTokenServiceImpl(
+        DeviceTokenRepository deviceTokenRepository
+    ) {
+        this.deviceTokenRepository = deviceTokenRepository;
+    }
+
+    @Override
+    public void register(UserId userId, String token) {
+        deviceTokenRepository.findByToken(token)
+            .ifPresentOrElse(
+                entity -> entity.reassign(userId.value()),
+                () -> deviceTokenRepository.save(
+                    DeviceTokenEntity.create(userId.value(), token)
+                )
+            );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -117,8 +117,10 @@ public class LikeUseCaseImpl implements LikeUseCase {
         ChatRoom chatRoom = ChatRoom.create(match.getId());
         chatRoomRepository.save(chatRoom);
 
+        User fromUser = userRepository.findUserByUserId(fromUserId)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
         // マッチングが成立したことを、先にいいねしていたユーザーに通知する
-        notificationService.notifyMatchCreated(fromUserId, toUserId);
+        notificationService.notifyMatchCreated(fromUser, toUserId);
     }
 
     @Override

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/LikeUseCaseImpl.java
@@ -10,6 +10,7 @@ import com.reimi.reimi_app.application.exception.client.LikeAlreadyExistsExcepti
 import com.reimi.reimi_app.application.exception.client.MatchAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.RainbowLikeAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.service.NotificationService;
 import com.reimi.reimi_app.application.usecase.LikeUseCase;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
 import com.reimi.reimi_app.domain.model.like.Like;
@@ -35,6 +36,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
     private final ChatRoomRepository chatRoomRepository;
     private final ImageStorageComponent imageStorage;
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final NotificationService notificationService;
 
     public LikeUseCaseImpl(
         UserRepository userRepository,
@@ -43,7 +45,8 @@ public class LikeUseCaseImpl implements LikeUseCase {
         MatchRepository matchRepository,
         ChatRoomRepository chatRoomRepository,
         ImageStorageComponent imageStorage,
-        AuthenticatedUserProvider authenticatedUserProvider
+        AuthenticatedUserProvider authenticatedUserProvider,
+        NotificationService notificationService
     ) {
         this.userRepository = userRepository;
         this.likeRepository = likeRepository;
@@ -52,6 +55,7 @@ public class LikeUseCaseImpl implements LikeUseCase {
         this.chatRoomRepository = chatRoomRepository;
         this.imageStorage = imageStorage;
         this.authenticatedUserProvider = authenticatedUserProvider;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -112,6 +116,9 @@ public class LikeUseCaseImpl implements LikeUseCase {
 
         ChatRoom chatRoom = ChatRoom.create(match.getId());
         chatRoomRepository.save(chatRoom);
+
+        // マッチングが成立したことを、先にいいねしていたユーザーに通知する
+        notificationService.notifyMatchCreated(fromUserId, toUserId);
     }
 
     @Override

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/NotificationServiceImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/NotificationServiceImpl.java
@@ -1,0 +1,49 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.service.NotificationService;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.infrastructure.notification.PushNotificationSender;
+import com.reimi.reimi_app.infrastructure.persistence.entity.DeviceTokenEntity;
+import com.reimi.reimi_app.infrastructure.persistence.repository.devicetoken.DeviceTokenRepository;
+
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final PushNotificationSender pushNotificationSender;
+    private final UserRepository userRepository;
+
+    public NotificationServiceImpl(
+        DeviceTokenRepository deviceTokenRepository,
+        PushNotificationSender pushNotificationSender,
+        UserRepository userRepository
+    ) {
+        this.deviceTokenRepository = deviceTokenRepository;
+        this.pushNotificationSender = pushNotificationSender;
+        this.userRepository = userRepository;
+    }
+
+    @Async
+    @Override
+    public void notifyMatchCreated(UserId fromUserId, UserId toUserId) {
+        User fromUser = userRepository.findUserByUserId(fromUserId)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+        List<DeviceTokenEntity> deviceTokens = deviceTokenRepository.findAllByUserId(toUserId.value());
+
+        for (DeviceTokenEntity token : deviceTokens) {
+            pushNotificationSender.sendMatchNotification(
+                token.getToken(),
+                "マッチング成立",
+                fromUser.getName() + "とのマッチングが成立しました！"
+            );
+        }
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/NotificationServiceImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/NotificationServiceImpl.java
@@ -5,11 +5,9 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.application.service.NotificationService;
 import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.user.UserId;
-import com.reimi.reimi_app.domain.repository.UserRepository;
 import com.reimi.reimi_app.infrastructure.notification.PushNotificationSender;
 import com.reimi.reimi_app.infrastructure.persistence.entity.DeviceTokenEntity;
 import com.reimi.reimi_app.infrastructure.persistence.repository.devicetoken.DeviceTokenRepository;
@@ -19,23 +17,18 @@ public class NotificationServiceImpl implements NotificationService {
 
     private final DeviceTokenRepository deviceTokenRepository;
     private final PushNotificationSender pushNotificationSender;
-    private final UserRepository userRepository;
 
     public NotificationServiceImpl(
         DeviceTokenRepository deviceTokenRepository,
-        PushNotificationSender pushNotificationSender,
-        UserRepository userRepository
+        PushNotificationSender pushNotificationSender
     ) {
         this.deviceTokenRepository = deviceTokenRepository;
         this.pushNotificationSender = pushNotificationSender;
-        this.userRepository = userRepository;
     }
 
     @Async
     @Override
-    public void notifyMatchCreated(UserId fromUserId, UserId toUserId) {
-        User fromUser = userRepository.findUserByUserId(fromUserId)
-            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+    public void notifyMatchCreated(User fromUser, UserId toUserId) {
         List<DeviceTokenEntity> deviceTokens = deviceTokenRepository.findAllByUserId(toUserId.value());
 
         for (DeviceTokenEntity token : deviceTokens) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -135,7 +135,10 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
 
         messageRepository.save(message);
 
+        User fromUser = userRepository.findUserByUserId(fromUserId)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
         // マッチングが成立したことを、先にレインボーいいねしていたユーザーに通知する
-        notificationService.notifyMatchCreated(fromUserId, toUserId);
+        notificationService.notifyMatchCreated(fromUser, toUserId);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -9,6 +9,7 @@ import com.reimi.reimi_app.application.exception.client.LikeAlreadyExistsExcepti
 import com.reimi.reimi_app.application.exception.client.MatchAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.RainbowLikeAlreadyExistsException;
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.service.NotificationService;
 import com.reimi.reimi_app.application.usecase.RainbowLikeUseCase;
 import com.reimi.reimi_app.domain.model.chatroom.ChatRoom;
 import com.reimi.reimi_app.domain.model.match.Match;
@@ -36,6 +37,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
     private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final NotificationService notificationService;
 
     public RainbowLikeUseCaseImpl(
         UserRepository userRepository,
@@ -45,7 +47,8 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         ChatRoomRepository chatRoomRepository,
         MessageRepository messageRepository,
         ImageStorageComponent imageStorage,
-        AuthenticatedUserProvider authenticatedUserProvider
+        AuthenticatedUserProvider authenticatedUserProvider,
+        NotificationService notificationService
     ) {
         this.userRepository = userRepository;
         this.rainbowLikeRepository = rainbowLikeRepository;
@@ -54,6 +57,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         this.chatRoomRepository = chatRoomRepository;
         this.messageRepository = messageRepository;
         this.authenticatedUserProvider = authenticatedUserProvider;
+        this.notificationService = notificationService;
     }
 
     @Override
@@ -130,5 +134,8 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         );
 
         messageRepository.save(message);
+
+        // マッチングが成立したことを、先にレインボーいいねしていたユーザーに通知する
+        notificationService.notifyMatchCreated(fromUserId, toUserId);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/DeviceTokenController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/DeviceTokenController.java
@@ -34,7 +34,7 @@ public class DeviceTokenController extends ApiV1Controller {
         this.authenticatedUserProvider = authenticatedUserProvider;
     }
 
-    @PostMapping(path = "/device-tokens")
+    @PostMapping(path = "/users/device-tokens")
     @RegisterDeviceTokenApi
     public ResponseEntity<Void> registerDeviceToken(@Valid @RequestBody RegisterDeviceTokenRequest request) {
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/DeviceTokenController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/DeviceTokenController.java
@@ -1,0 +1,49 @@
+package com.reimi.reimi_app.infrastructure.web.controller.v1;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.service.DeviceTokenService;
+import com.reimi.reimi_app.application.usecase.UserUseCase;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterDeviceTokenRequest;
+import com.reimi.reimi_app.infrastructure.web.openapi.user.RegisterDeviceTokenApi;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RestController
+@Tag(name = "User", description = "ユーザー関連のAPI")
+public class DeviceTokenController extends ApiV1Controller {
+
+    private final DeviceTokenService deviceTokenService;
+    private final UserUseCase userUseCase;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+
+    public DeviceTokenController(
+        DeviceTokenService deviceTokenService,
+        UserUseCase userUseCase,
+        AuthenticatedUserProvider authenticatedUserProvider
+    ) {
+        this.deviceTokenService = deviceTokenService;
+        this.userUseCase = userUseCase;
+        this.authenticatedUserProvider = authenticatedUserProvider;
+    }
+
+    @PostMapping(path = "/device-tokens")
+    @RegisterDeviceTokenApi
+    public ResponseEntity<Void> registerDeviceToken(@Valid @RequestBody RegisterDeviceTokenRequest request) {
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+        User user = userUseCase.getUser(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        deviceTokenService.register(user.getId(), request.token());
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/RegisterDeviceTokenRequest.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/request/RegisterDeviceTokenRequest.java
@@ -1,0 +1,12 @@
+package com.reimi.reimi_app.infrastructure.web.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "デバイストークン登録用リクエスト")
+public record RegisterDeviceTokenRequest(
+
+    @NotBlank(message = "デバイストークンは必須です")
+    @Schema(description = "デバイストークン", example = "eYxZzP1xQZK:APA91bF8QJm3yZf2k1H9lRk5...")
+    String token
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterDeviceTokenApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterDeviceTokenApi.java
@@ -1,0 +1,108 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.user;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.request.RegisterDeviceTokenRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ユーザーデバイストークン登録",
+    description = "ユーザーがデバイストークンを登録（再割り当て）できるAPI",
+    requestBody = @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = RegisterDeviceTokenRequest.class)
+        )
+    )
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "201",
+        description = "ユーザーのデバイストークン登録が完了しました",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "無効なリクエスト",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "フォーマット不正",
+                    description = "リクエスト形式が正しくない場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "無効なリクエストです"
+                    }
+                    """
+                ),
+                @ExampleObject(
+                    name = "バリデーションエラー",
+                    description = "入力値のバリデーションに失敗した場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "入力値が不正です",
+                        "details": {
+                            "email": "メールアドレスの形式が不正です",
+                            "introduction": "自己紹介文は20文字以上500文字以下で入力してください"
+                        }
+                    }
+                    """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface RegisterDeviceTokenApi {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterDeviceTokenApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterDeviceTokenApi.java
@@ -88,6 +88,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         )
     ),
     @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
         responseCode = "500",
         description = "サーバーエラー",
         content = @Content(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterDeviceTokenApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/user/RegisterDeviceTokenApi.java
@@ -31,7 +31,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 )
 @ApiResponses({
     @ApiResponse(
-        responseCode = "201",
+        responseCode = "200",
         description = "ユーザーのデバイストークン登録が完了しました",
         content = @Content(
             mediaType = "application/json"


### PR DESCRIPTION
## 概要

API名：ユーザーデバイストークン取得

種別：API開発

関連Issue：

- #142 

close #142 

## API設計

### 【やったこと・開発メモ】

### アプリケーション層

---

- デバイストークンサービスインターフェイスを作成
    - デバイストークン登録の業務操作を定義
- ノーティフィケーション（通知）サービスインターフェイスを作成
    - マッチング通知の業務操作を定義

### インフラストラクチャ層

---

- DeviceTokenエンティティの作成
    - デバイストークンを一意のものとするためユニーク制約を貼る
    - エンティティ作成メソッドを作成
    - 送られてきたtokenをログインユーザーに付け替えるメソッドを作成
        - token = **端末の識別子**であるため、1人のユーザーに紐づいている訳ではない
            
            →別のログインユーザーでも端末が同じならtokenは同じ
            
    - その他必要なアノテーションとカラム定義
- デバイストークンJPA Repositoryを使うためのインターフェイス作成
- デバイストークンのリポジトリ実装クラスを作成
    - トークンからDeviceTokenエンティティを取得してくる
    - ユーザーI DからDeviceTokenエンティティをリストで取得してくる
        - ログインユーザーに紐づく全ての端末を取得するため（複数端末に対応）
    - DeviceTokenエンティティを保存（登録）する
- デバイストークンの実装サービス作成
    - 登録処理をオーバーライド
        - 送信されたトークンが存在するか
            - 存在する場合：ユーザーIDをログインユーザーに再割り当てする
            - 存在しない場合：新しく登録（保存）する
- リクエストDTO作成
- デバイストークンのController作成
    - ユーザーのデバイストークン登録のPOST APIメソッドを定義
        - バリデーション処理追加
        - リクエストDTOからユーザーのデバイストークンを受け取る
- 定義アノテーションを作成
- ノーティフィケーションの実装サービス作成
    - マッチング通知処理をオーバーライド
        - いいねしたユーザーのデバイストークン（アカウント端末）を全て取得
        - 通知処理をしているコンポーネントクラスのメソッドに引数を渡す
- Push通知を送るためのインターフェース作成
- ↑の実装コンポーネントクラスを作成
    - 以下をセット
        - デバイストークン
        - タイトル・ボディ
        - putData（Map型）
    - 非同期通信で送られる様にする→メイン処理に戻すため

### その他

---

- 非同期処理を有効にする
    - アプリケーション起動クラスに`@EnableAsync`アノテーションを付与
    - 非同期処理の設定ファイルを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ユーザーデバイストークン取得 |
| URL | /api/v1/users/device-tokens |
| HTTPメソッド | POST |
| ステータスコード | 200 / 400 / 401 / 404 / 500 |

### 【リクエスト】

```json
{
  "token": string
}
```

### 【レスポンス】

特になし

### 【追加・変更したエンティティ】

- エンティティ名：DeviceTokenEntity
  - 役割：ユーザーのデバイストークンに関する情報を格納する
  - ドメインルール：
    - デバイストークンは一意（ユニーク）である

### 【追加・変更した設定ファイル】

 - 追加したファイル
 
```
 reimi_app
├─ application
│  └─ service
│     ├─ DeviceTokenService.java
│     └─ NotificationService.java
│
├─ config
│  └─ AsyncConfig.java
│
├─ infrastructure
│  ├─ notification
│  │  ├─ PushNotificationSender.java
│  │  └─ FcmPushNotificationSender.java
│  │
│  ├─ persistence
│  │  ├─ entity
│  │  │  └─ DeviceTokenEntity.java
│  │  │
│  │  └─ repository
│  │     └─ devicetoken
│  │        ├─ DeviceTokenRepository.java
│  │        └─ JpaDeviceTokenRepository.java
│  │
│  ├─ service
│  │  ├─ DeviceTokenServiceImpl.java
│  │  └─ NotificationServiceImpl.java
│  │
│  └─ web
│     ├─ controller
│     │  └─ v1
│     │     └─ DeviceTokenController.java
│     │
│     ├─ dto
│     │  └─ request
│     │     └─ RegisterDeviceTokenRequest.java
│     │
│     └─ openapi
│        └─ user
│           └─ RegisterDeviceTokenApi.java

```

 - 変更したファイル
   - reimi_app/ReimiAppApplication.java
   - reimi_app/infrastructure/service/LikeUseCaseImpl.java
   - reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java

## 参考資料

- Firebase Cloud Messaging（FCM）
  - https://firebase.google.com/docs/cloud-messaging/send/admin-sdk?hl=ja
- Optionalで値存在時/非存在時の処理
  - https://qiita.com/munieru_jp/items/22371ad39a034cd90c84
- @Asyncの使い方
  - https://zenn.dev/giragira/articles/c27ab98b798177

## その他・補足事項

- 正しいデバイストークンを渡してもらう必要があるため、動作確認に関してはフロントに任せる
