### PR TITLE
【API設計】自分がレインボーいいねされたユーザー一覧取得APIの設計（/rainbow-likes/users/received）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/RainbowLikeUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/RainbowLikeUseCase.java
@@ -1,7 +1,12 @@
 package com.reimi.reimi_app.application.usecase;
 
+import java.util.List;
+
 import com.reimi.reimi_app.application.command.SendRainbowLikeCommand;
+import com.reimi.reimi_app.domain.model.user.User;
 
 public interface RainbowLikeUseCase {
     void rainbowLikeUser(SendRainbowLikeCommand command);
+
+    List<User> getRainbowLikeReceivedUserList();
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/rainbowlike/RainbowLike.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/rainbowlike/RainbowLike.java
@@ -39,6 +39,20 @@ public class RainbowLike {
         );
     }
 
+    public static RainbowLike reconstruct(
+        RainbowLikeId id,
+        UserId fromUserId,
+        UserId toUserId,
+        String message
+    ) {
+        return new RainbowLike(
+            id,
+            fromUserId,
+            toUserId,
+            message
+        );
+    }
+
     public RainbowLikeId getId() { return id; }
     public UserId getFromUserId() { return fromUserId; }
     public UserId getToUserId() { return toUserId; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/user/User.java
@@ -120,9 +120,15 @@ public class User {
     public Status getStatus() { return status; }
     public Profile getProfile() { return profile; }
 
-    //メイン写真を署名URLとして管理したいためシリアライズ対象外とする
+    // メイン写真を署名URLとして管理したいためシリアライズ対象外とする
     private transient String signedMainPhotoUrl;
 
     public String getSignedMainPhotoUrl() { return signedMainPhotoUrl; }
     public void setSignedMainPhotoUrl(String signedMainPhotoUrl) { this.signedMainPhotoUrl = signedMainPhotoUrl; }
+
+    // レインボーいいねの一覧取得時にメッセージも一緒に送信したいため
+    private transient String rainbowLikeMessage;
+
+    public String getRainbowLikeMessage() { return rainbowLikeMessage; }
+    public void setRainbowLikeMessage(String rainbowLikeMessage) { this.rainbowLikeMessage = rainbowLikeMessage; }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/RainbowLikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/RainbowLikeRepository.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.List;
+
 import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
 import com.reimi.reimi_app.domain.model.user.UserId;
 
@@ -8,4 +10,6 @@ public interface RainbowLikeRepository {
     boolean exists(UserId fromUserId, UserId toUserId);
 
     void save(RainbowLike rainbowLike);
+
+    List<RainbowLike> findRainbowLikesReceivedByToUserId(UserId toUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/RainbowLikeMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/RainbowLikeMapper.java
@@ -1,11 +1,21 @@
 package com.reimi.reimi_app.infrastructure.persistence.mapper;
 
 import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
+import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLikeId;
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.persistence.entity.RainbowLikeEntity;
 
 public class RainbowLikeMapper {
 
-        public static RainbowLikeEntity toEntity(RainbowLike rainbowLike) {
+    public static RainbowLike toDomain(RainbowLikeEntity entity) {
+        return RainbowLike.reconstruct(
+                new RainbowLikeId(entity.getId()),
+                new UserId(entity.getFromUserId()),
+                new UserId(entity.getToUserId()),
+                entity.getMessage()
+        );
+    }
+    public static RainbowLikeEntity toEntity(RainbowLike rainbowLike) {
         RainbowLikeEntity entity = new RainbowLikeEntity();
         entity.setId(rainbowLike.getId().value());
         entity.setFromUserId(rainbowLike.getFromUserId().value());

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/JpaRainbowLikeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/JpaRainbowLikeRepository.java
@@ -1,11 +1,20 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.rainbowlike;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.reimi.reimi_app.infrastructure.persistence.entity.RainbowLikeEntity;
 
 public interface JpaRainbowLikeRepository extends JpaRepository<RainbowLikeEntity, UUID> {
     boolean existsByFromUserIdAndToUserId(UUID fromUserId, UUID toUserId);
+
+    @Query("""
+        select r
+        from RainbowLikeEntity r
+        where r.toUserId = :toUserId
+    """)
+    List<RainbowLikeEntity> findRainbowLikesReceivedByToUserId(UUID toUserId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/RainbowLikeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/rainbowlike/RainbowLikeRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.rainbowlike;
 
+import java.util.List;
+
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.domain.model.rainbowlike.RainbowLike;
@@ -30,4 +32,14 @@ public class RainbowLikeRepositoryImpl implements RainbowLikeRepository {
     public void save(RainbowLike rainbowLike) {
         jpaRainbowLikeRepository.save(RainbowLikeMapper.toEntity(rainbowLike));
     }
+
+    @Override
+    public List<RainbowLike> findRainbowLikesReceivedByToUserId(UserId toUserId) {
+        return jpaRainbowLikeRepository
+            .findRainbowLikesReceivedByToUserId(toUserId.value())
+            .stream()
+            .map(RainbowLikeMapper::toDomain)
+            .toList();
+    }
+
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
@@ -1,5 +1,11 @@
 package com.reimi.reimi_app.infrastructure.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +42,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
     private final MatchRepository matchRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final MessageRepository messageRepository;
+    private final ImageStorageComponent imageStorage;
     private final AuthenticatedUserProvider authenticatedUserProvider;
     private final NotificationService notificationService;
 
@@ -56,6 +63,7 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
         this.matchRepository = matchRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.messageRepository = messageRepository;
+        this.imageStorage = imageStorage;
         this.authenticatedUserProvider = authenticatedUserProvider;
         this.notificationService = notificationService;
     }
@@ -140,5 +148,39 @@ public class RainbowLikeUseCaseImpl implements RainbowLikeUseCase {
 
         // マッチングが成立したことを、先にレインボーいいねしていたユーザーに通知する
         notificationService.notifyMatchCreated(fromUser, toUserId);
+    }
+
+    @Override
+    public List<User> getRainbowLikeReceivedUserList() {
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        User toUser = userRepository.findMeByFirebaseUid(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        UserId toUserId = toUser.getId();
+
+        List<RainbowLike> rainbowLikes = rainbowLikeRepository.findRainbowLikesReceivedByToUserId(toUserId);
+
+        Map<UserId, RainbowLike> rainbowLikeMap = rainbowLikes.stream()
+            .collect(Collectors.toMap(RainbowLike::getFromUserId, Function.identity()));
+
+        List<UserId> rainbowLikedUserIds = new ArrayList<>(rainbowLikeMap.keySet());
+
+        if (rainbowLikedUserIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<User> users = userRepository.findByIds(rainbowLikedUserIds);
+
+        for (User user : users) {
+            RainbowLike rainbowLike = rainbowLikeMap.get(user.getId());
+            if (rainbowLike != null) {
+                user.setRainbowLikeMessage(rainbowLike.getMessage());
+            }
+            user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));
+        }
+
+        return users;
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/RainbowLikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/RainbowLikeController.java
@@ -1,7 +1,10 @@
 package com.reimi.reimi_app.infrastructure.web.controller.v1;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,6 +13,7 @@ import com.reimi.reimi_app.application.command.SendRainbowLikeCommand;
 import com.reimi.reimi_app.application.usecase.RainbowLikeUseCase;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.web.dto.request.SendRainbowLikeRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetRainbowLikedUserListResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike.RainbowLikeUserApi;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,7 +36,7 @@ public class RainbowLikeController extends ApiV1Controller {
 
     @PostMapping(path = "/rainbow-likes/{userId}")
     @RainbowLikeUserApi
-    public ResponseEntity<Void> RainbowLike(
+    public ResponseEntity<Void> rainbowLike(
         @PathVariable("userId") UserId toUserId,
         @Valid @RequestBody SendRainbowLikeRequest request
     ) {
@@ -44,5 +48,23 @@ public class RainbowLikeController extends ApiV1Controller {
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping(path = "/rainbow-likes/users/received")
+    public ResponseEntity<List<GetRainbowLikedUserListResponse>> getRainbowLikeReceivedUsers() {
+
+        List<GetRainbowLikedUserListResponse> response = rainbowLikeUseCase.getRainbowLikeReceivedUserList()
+                .stream()
+                .map(user -> new GetRainbowLikedUserListResponse(
+                    user.getId().value(),
+                    user.getName(),
+                    user.getBirthDate(),
+                    user.getAddress(),
+                    user.getSignedMainPhotoUrl(),
+                    user.getRainbowLikeMessage()
+                ))
+                .toList();
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/RainbowLikeController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/RainbowLikeController.java
@@ -14,6 +14,7 @@ import com.reimi.reimi_app.application.usecase.RainbowLikeUseCase;
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.infrastructure.web.dto.request.SendRainbowLikeRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.GetRainbowLikedUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike.GetRainbowLikeReceivedUsersApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike.RainbowLikeUserApi;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,6 +52,7 @@ public class RainbowLikeController extends ApiV1Controller {
     }
 
     @GetMapping(path = "/rainbow-likes/users/received")
+    @GetRainbowLikeReceivedUsersApi
     public ResponseEntity<List<GetRainbowLikedUserListResponse>> getRainbowLikeReceivedUsers() {
 
         List<GetRainbowLikedUserListResponse> response = rainbowLikeUseCase.getRainbowLikeReceivedUserList()

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetRainbowLikedUserListResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/GetRainbowLikedUserListResponse.java
@@ -1,0 +1,30 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.model.user.Address;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "自分がレインボーいいねした（された）ユーザー一覧取得用レスポンス")
+public record GetRainbowLikedUserListResponse (
+
+        @Schema(description = "ユーザーID", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
+        UUID id,
+
+        @Schema(description = "名前", example = "山田 太郎")
+        String name,
+
+        @Schema(description = "生年月日", example = "1996-04-18")
+        LocalDate birthDate,
+
+        @Schema(description = "居住地", example = "TOKYO")
+        Address address,
+
+        @Schema(description = "メイン写真URL")
+        String mainPhotoUrl,
+
+        @Schema(description = "特別なメッセージ", example = "プロフィール見て気になって、特別ないいねしました！！")
+        String message
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
-import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetLikedUserListResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         content = @Content(
             mediaType = "application/json",
             array = @ArraySchema(
-                schema = @Schema(implementation = GetUserListResponse.class)
+                schema = @Schema(implementation = GetLikedUserListResponse.class)
             )
         )
     ),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
-import com.reimi.reimi_app.infrastructure.web.dto.response.GetUserListResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetLikedUserListResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         content = @Content(
             mediaType = "application/json",
             array = @ArraySchema(
-                schema = @Schema(implementation = GetUserListResponse.class)
+                schema = @Schema(implementation = GetLikedUserListResponse.class)
             )
         )
     ),

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/GetRainbowLikeReceivedUsersApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/rainbowlike/GetRainbowLikeReceivedUsersApi.java
@@ -1,0 +1,86 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.rainbowlike;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.GetRainbowLikedUserListResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "自分がレインボーいいねされたユーザー一覧取得",
+    description = "自分がレインボーいいねされたユーザの一覧を取得できるAPI"
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "自分がレインボーいいねされたユーザーの一覧取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            array = @ArraySchema(
+                schema = @Schema(implementation = GetRainbowLikedUserListResponse.class)
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetRainbowLikeReceivedUsersApi {
+}


### PR DESCRIPTION
## 概要

API名：自分がレインボーいいねされたユーザー一覧取得

種別：API開発

関連Issue：

- #125 

close #125

## API設計

### 【やったこと・開発メモ】

### ドメイン層

---

- レインボーライクリポジトリインターフェイスにメソッドを追加
    - ログインユーザーがされたレインボーいいね一覧を取得
- RainbowLikeドメインモデルにメソッド追加
    - reconstructメソッドを作成
- Userドメインモデルにtransientフィールドを追加
    - レインボーいいねの一覧取得時にメッセージも一緒に送信したいため
    - DTOレスポンス用に定義

### アプリケーション層

---

- レインボーライクユースケースのインターフェイスに業務を追加
    - 自分がレインボーいいねされたユーザー一覧取得メソッド

### インフラストラクチャ層

---

- JPQLを用いてレインボーライクJPA Repositoryメソッド作成
    - toUserIdがログインユーザーのIDであるfromUserIdのRainbowLikeエンティティリストを取得
- レインボーライクの実装ユースケースにオーバーライドメソッドを定義
    - 自身のユーザーIDがtoUserIdになっているレインボーライクをリストで取得
    - Stream APIを使ってList型 → Map型に変換
        - key：レインボーいいねしたユーザーのID（fromUserId）
        - value：`Function.identity()`
            
            → 値をそのまま返すメソッドであるためRainbowLike自身
            
    - Mapのキーセット（fromUserId）をListに変換する
    - ↑のIDリストを元に、ユーザーリポジトリからユーザードメインモデルを取得
    - MapからuserIdをキー存在確認
        - する場合：valueのRainbowLikeのメッセージをtransientフィールドにセットしてドメインモデルに含める
- レインボーライクの実装リポジトリにオーバーライドメソッドを定義
    - RainbowLikeエンティティリストをドメインモデルに変換する
- Controllerに自分がレインボーいいねされたユーザー一覧取得のGETAPIを定義
- RainbowLikeMapperにメソッド追加
    - ドメインモデルへの変換
- レスポンスDTOを作成
- 定義アノテーションを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | 自分がレインボーいいねされたユーザー一覧取得 |
| URL | api/v1/rainbow-likes/users/received |
| HTTPメソッド | POST |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
{
  "id": string uuid
  "name": string
  "birthDate": string date
  "address": string
  "mainPhotoUrl": string
  "message": string
}
```

### 【追加・変更した設定ファイル】

 - 追加したファイル
 
```
reimi_app
└─ infrastructure
   └─ web
      ├─ dto
      │  └─ response
      │     └─ GetRainbowLikedUserListResponse.java
      │
      └─ openapi
         └─ rainbowlike
            └─ GetRainbowLikeReceivedUsersApi.java

```

 - 変更したファイル
   - reimi_app/application/usecase/RainbowLikeUseCase.java
   - reimi_app/domain/model/rainbowlike/RainbowLike.java
   - reimi_app/domain/model/user/User.java
   - reimi_app/domain/repository/RainbowLikeRepository.java
   - reimi_app/infrastructure/persistence/mapper/RainbowLikeMapper.java
   - reimi_app/infrastructure/persistence/repository/rainbowlike/JpaRainbowLikeRepository.java
   - reimi_app/infrastructure/persistence/repository/rainbowlike/RainbowLikeRepositoryImpl.java
   - reimi_app/infrastructure/service/RainbowLikeUseCaseImpl.java
   - reimi_app/infrastructure/web/controller/v1/RainbowLikeController.java
   - reimi_app/infrastructure/web/openapi/like/GetLikeGivenUsersApi.java
   - reimi_app/infrastructure/web/openapi/like/GetLikeReceivedUsersApi.java

## 参考資料

- Stream APIについて
  - https://qiita.com/Apacher-inf/items/0dd3178b5f3a3138e0c2
