### PR TITLE
【API設計＆修正】ウェザーパーソナリティ診断結果表示のAPI設計（/user-weather-personality-type）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/WeatherPersonalityUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/WeatherPersonalityUseCase.java
@@ -5,5 +5,7 @@ import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalit
 
 public interface WeatherPersonalityUseCase {
 
-    UserWeatherPersonalityType diagnose(DiagnoseWeatherPersonalityCommand command);
+    void diagnose(DiagnoseWeatherPersonalityCommand command);
+
+    UserWeatherPersonalityType getUserResult();
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
@@ -36,6 +36,29 @@ public class UserWeatherPersonalityType {
 
     }
 
+    public static UserWeatherPersonalityType reconstruct(
+        UserWeatherPersonalityTypeId id,
+        UserId userId,
+        WeatherPersonalityType type,
+        int sensitivity,
+        int preparedness,
+        int activity,
+        int motivation
+    ) {
+        WeatherPersonalityScore weatherPersonalityScore = new WeatherPersonalityScore(
+            sensitivity,
+            preparedness,
+            activity,
+            motivation
+        );
+        return new UserWeatherPersonalityType(
+            id,
+            userId,
+            type,
+            weatherPersonalityScore
+        );
+    }
+
     public UserWeatherPersonalityTypeId getId() { return id; }
     public UserId getUserId() { return userId; }
     public WeatherPersonalityType getWeatherPersonalityType() { return type; }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityScore.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/WeatherPersonalityScore.java
@@ -7,6 +7,22 @@ public class WeatherPersonalityScore {
     private int activity;
     private int motivation;
 
+    public WeatherPersonalityScore() {
+        this(0, 0, 0, 0);
+    }
+
+    public WeatherPersonalityScore(
+        int sensitivity,
+        int preparedness,
+        int activity,
+        int motivation
+    ) {
+        this.sensitivity = sensitivity;
+        this.preparedness = preparedness;
+        this.activity = activity;
+        this.motivation = motivation;
+    }
+
     public void addSensitivity(int value) {
         sensitivity += value;
     }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.Optional;
+
 import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 
@@ -8,4 +10,6 @@ public interface UserWeatherPersonalityTypeRepository {
     boolean exists(UserId UserId);
 
     void save(UserWeatherPersonalityType userWeatherPersonalityType);
+
+    Optional<UserWeatherPersonalityType> findByUserId(UserId userId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
@@ -1,11 +1,25 @@
 package com.reimi.reimi_app.infrastructure.persistence.mapper;
 
+import com.reimi.reimi_app.domain.model.user.UserId;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityTypeId;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserEntity;
 import com.reimi.reimi_app.infrastructure.persistence.entity.UserWeatherPersonalityTypeEntity;
 import com.reimi.reimi_app.infrastructure.persistence.entity.WeatherPersonalityTypeEntity;
 
 public class UserWeatherPersonalityTypeMapper {
+
+    public static UserWeatherPersonalityType toDomain(UserWeatherPersonalityTypeEntity entity) {
+        return UserWeatherPersonalityType.reconstruct(
+                new UserWeatherPersonalityTypeId(entity.getId()),
+                new UserId(entity.getUserId()),
+                WeatherPersonalityTypeMapper.toDomain(entity.getWeatherPersonalityType()),
+                entity.getScoreSensitivity(),
+                entity.getScorePreparedness(),
+                entity.getScoreActivity(),
+                entity.getScoreMotivation()
+        );
+    }
 
     public static UserWeatherPersonalityTypeEntity toEntity(
         UserWeatherPersonalityType userWeatherPersonalityType,

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
@@ -1,5 +1,6 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.userweatherpersonalitytype;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import com.reimi.reimi_app.infrastructure.persistence.entity.UserWeatherPersonal
 
 public interface JpaUserWeatherPersonalityTypeRepository extends JpaRepository<UserWeatherPersonalityTypeEntity, UUID> {
     boolean existsByUserId(UUID UserId);
+
+    Optional<UserWeatherPersonalityTypeEntity> findByUserId(UUID userId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.persistence.repository.userweatherpersonalitytype;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
@@ -53,4 +55,11 @@ public class UserWeatherPersonalityTypeRepositoryImpl implements UserWeatherPers
                 weatherPersonalityTypEntity
             ));
     };
+
+    @Override
+    public Optional<UserWeatherPersonalityType> findByUserId(UserId userId) {
+        return jpaUserWeatherPersonalityTypeRepository
+            .findByUserId(userId.value())
+            .map(UserWeatherPersonalityTypeMapper::toDomain);
+    }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
@@ -4,31 +4,41 @@ import org.springframework.stereotype.Service;
 
 import com.reimi.reimi_app.application.command.DiagnoseWeatherPersonalityCommand;
 import com.reimi.reimi_app.application.exception.client.DiagnoseResultAlreadyExistsException;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
 import com.reimi.reimi_app.application.service.ImageUrlResolver;
 import com.reimi.reimi_app.application.usecase.WeatherPersonalityUseCase;
+import com.reimi.reimi_app.domain.model.user.User;
 import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityDiagnosis;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityScore;
 import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityType;
+import com.reimi.reimi_app.domain.repository.UserRepository;
 import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 @Service
 public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase {
 
     private final UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository;
     private final ImageUrlResolver imageUrlResolver;
+    private final UserRepository userRepository;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
 
     public WeatherPersonalityUseCaseImpl(
         UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository,
-        ImageUrlResolver imageUrlResolver
+        ImageUrlResolver imageUrlResolver,
+        UserRepository userRepository,
+        AuthenticatedUserProvider authenticatedUserProvider
     ) {
         this.userWeatherPersonalityTypeRepository = userWeatherPersonalityTypeRepository;
         this.imageUrlResolver = imageUrlResolver;
+        this.userRepository = userRepository;
+        this.authenticatedUserProvider = authenticatedUserProvider;
     }
 
     @Override
-    public UserWeatherPersonalityType diagnose(DiagnoseWeatherPersonalityCommand command) {
+    public void diagnose(DiagnoseWeatherPersonalityCommand command) {
 
         // 既にユーザーが診断済みの場合は重複エラーとする
         if (userWeatherPersonalityTypeRepository.exists(command.userId())) {
@@ -53,8 +63,20 @@ public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase 
         );
 
         userWeatherPersonalityTypeRepository.save(result);
+    }
 
-        String typeImageUrl = imageUrlResolver.resolve(
+    @Override
+    public UserWeatherPersonalityType getUserResult() {
+
+    String firebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+    User user = userRepository.findMeByFirebaseUid(firebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+    UserWeatherPersonalityType result = userWeatherPersonalityTypeRepository.findByUserId(user.getId())
+        .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティ診断結果"));
+
+    String typeImageUrl = imageUrlResolver.resolve(
             result.getWeatherPersonalityType().getImagePath()
         );
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -47,7 +47,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
         this.userUseCase = userUseCase;
     }
 
-    @PostMapping("/diagnoses/score/user-weather-personality-type")
+    @PostMapping("/user-weather-personality-type")
     @DiagnoseWeatherPersonalityType
     public ResponseEntity<Void> diagnose(
         @Valid @RequestBody DiagnoseWeatherPersonalityRequest request
@@ -85,7 +85,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @GetMapping("/diagnoses/score/user-weather-personality-type")
+    @GetMapping("/user-weather-personality-type")
     @GetUserWeatherPersonalityType
     public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> getResult(
     ) {

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,7 +48,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
 
     @PostMapping("/diagnoses/score/user-weather-personality-type")
     @DiagnoseWeatherPersonalityType
-    public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> diagnose(
+    public ResponseEntity<Void> diagnose(
         @Valid @RequestBody DiagnoseWeatherPersonalityRequest request
     ) {
         List<AnswerChoice> answers = List.of(
@@ -73,12 +74,20 @@ public class WeatherPersonalityController extends ApiV1Controller {
         User user = userUseCase.getUser(myFirebaseUid)
             .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
 
-        var result = weatherPersonalityUseCase.diagnose(
+        weatherPersonalityUseCase.diagnose(
             new DiagnoseWeatherPersonalityCommand(
                 user.getId(),
                 answers
             )
         );
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/diagnoses/score/user-weather-personality-type")
+    public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> getResult(
+    ) {
+        var result = weatherPersonalityUseCase.getUserResult();
 
         Map<WeatherPersonalityAxis, Integer> userAxisScoreMap = new LinkedHashMap<>();
         userAxisScoreMap.put(WeatherPersonalityAxis.SENSITIVITY, result.getWeatherPersonalityScore().sensitivity());
@@ -99,6 +108,6 @@ public class WeatherPersonalityController extends ApiV1Controller {
                 result.getWeatherPersonalityType().getGodsMessage()
             );
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.ok(response);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -21,6 +21,7 @@ import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityAxi
 import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.DiagnoseWeatherPersonalityType;
+import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.GetUserWeatherPersonalityType;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -85,6 +86,7 @@ public class WeatherPersonalityController extends ApiV1Controller {
     }
 
     @GetMapping("/diagnoses/score/user-weather-personality-type")
+    @GetUserWeatherPersonalityType
     public ResponseEntity<DiagnoseResultWeatherPersonalityResponse> getResult(
     ) {
         var result = weatherPersonalityUseCase.getUserResult();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
@@ -7,7 +7,6 @@ import java.lang.annotation.RetentionPolicy;
 
 import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
 import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
-import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,7 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
     summary = "ウェザーパーソナリティ診断結果スコアリング",
-    description = "ユーザーのウェザーパーソナリティタイプの診断結果をスコアリングしてレスポンスするAPI",
+    description = "ユーザーのウェザーパーソナリティタイプの診断結果をスコアリングして保存するAPI",
     requestBody = @RequestBody(
         required = true,
         content = @Content(
@@ -35,8 +34,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
         responseCode = "201",
         description = "ユーザーのウェザーパーソナリティ診断が正常に行われました",
         content = @Content(
-            mediaType = "application/json",
-            schema = @Schema(implementation = DiagnoseResultWeatherPersonalityResponse.class)
+            mediaType = "application/json"
         )
     ),
     @ApiResponse(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/GetUserWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/GetUserWeatherPersonalityType.java
@@ -1,0 +1,83 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ウェザーパーソナリティ診断結果結果表示",
+    description = "ユーザーのウェザーパーソナリティタイプの診断結果をレスポンスするAPI"
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "ユーザーのウェザーパーソナリティ診断結果の取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = DiagnoseResultWeatherPersonalityResponse.class)
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ウェザーパーソナリティ診断結果が見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetUserWeatherPersonalityType {
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/GetUserWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/GetUserWeatherPersonalityType.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Operation(
-    summary = "ウェザーパーソナリティ診断結果結果表示",
+    summary = "ウェザーパーソナリティ診断結果表示",
     description = "ユーザーのウェザーパーソナリティタイプの診断結果をレスポンスするAPI"
 )
 @ApiResponses({


### PR DESCRIPTION
## 概要

API名：ウェザーパーソナリティ診断結果表示

種別：API開発

関連Issue：

- #147 

close #147 

## API設計

### 【やったこと・開発メモ】

### ドメイン層

---

- ユーザーウェザーパーソナリティタイプリポジトリのインターフェイスにメソッド定義
    - ユーザーIDからドメインモデルを取得してくるメソッド
- UserWeatherPersonalityTypeドメインモデルにメソッド追加
    - DBから取得してきたエンティティをドメインモデルに復元する
- WeatherPersonalityScoreにコンストラクタを作成
    - スコアリング用で使う初期値が設定されたコンストラクタ
    - エンティティからドメインモデルに変換する用で使う全引数コンストラクタ

### アプリケーション層

---

- ユーザーウェザーパーソナリティのユースケースインターフェイス変更
    - 診断業務を診断結果の保存だけにするため、型を返り値なし（Void）にする
    - ユーザーウェザーパーソナリティタイプの診断結果取得業務操作を定義

### インフラストラクチャ層

---

- ウェザーパーソナリティの実装ユースケースを変更
    - diagnoseメソッドで診断スコアリングと結果表示の２つの業務をしていたのを修正
    - 診断スコアリング（保存）：diagnoseメソッド
    - 結果表示：getUserResultメソッド
- ユーザーウェザーパーソナリティタイプの実装リポジトリにメソッド追加
    - オーバーライドメソッドを定義
        - ユーザーIDからエンティティを取得してMapperでドメインモデルに変換する
- ユーザーウェザーパーソナリティタイプJPA Repositoryメソッドを追加
    - ユーザIDからUserWeatherPersonalityTypeエンティティを取得
- UserWeatherPersonalityTypeMapperにメソッド追加
    - ドメインモデルへ変換メソッド
- Controllerの変更
    - 既存の診断スコアリングPOST APIを返り値なしメソッドにする
    - ウェザーパーソナリティ診断結果表示のGET APIメソッド追加
- 定義アノテーションの変更
    - ウェザーパーソナリティ診断結果スコアリング
        - レスポンススキーマの削除
        - 文言修正
    - ウェザーパーソナリティ診断結果表示用に新しく作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ウェザーパーソナリティ診断結果表示 |
| URL | /user-weather-personality-type |
| HTTPメソッド | GET |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
{
  "typeCode": string
  "typeName": string
  "typeCatchphrase": string
  "typeImageUrl": string
  "rulingStatement": string
  "axisFeatures": [
    {
      "axis": string
      "polarity": string
      "description": string
    }
  ]: array<object>
  "userAxisScore": {
    "SENSITIVITY": integer int32
    "PREPAREDNESS": integer int32
    "ACTIVITY": integer int32
    "MOTIVATION": integer int32
  }: object
  "behaviorTendencies": [
    {
      "summary": string
      "detail": string
    }
  ]: array<object>
  "godsMessage": string
}
```

### 【追加・変更した設定ファイル】

 - 追加したファイル
   - reimi_app/infrastructure/web/openapi/weatherpersonality/GetUserWeatherPersonalityType.java
 
 - 変更したファイル
   - reimi_app/application/usecase/WeatherPersonalityUseCase.java
   - reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
   - reimi_app/domain/model/weatherpersonality/WeatherPersonalityScore.java
   - reimi_app/domain/repository/UserWeatherPersonalityTypeRepository.java
   - reimi_app/infrastructure/persistence/mapper/UserWeatherPersonalityTypeMapper.java
   - reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/JpaUserWeatherPersonalityTypeRepository.java
   - reimi_app/infrastructure/persistence/repository/userweatherpersonalitytype/UserWeatherPersonalityTypeRepositoryImpl.java
   - reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
   - reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
   - reimi_app/infrastructure/web/openapi/weatherpersonality/DiagnoseWeatherPersonalityType.java
