### PR TITLE
GCPのCloud Runにデプロイするために諸々修正

### DIFF
--- a/reimi/backend/reimi_app/.env.example
+++ b/reimi/backend/reimi_app/.env.example
@@ -23,11 +23,10 @@ POSTGRES_USER=your_db_username
 POSTGRES_PASSWORD=your_db_password
 
 # Firebase
-# Firebase Storageのバケット名
+# プロジェクトID
+FIREBASE_PROJECT_ID=your-project-id
+# Storageのバケット名
 FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
-
-# Firebase Admin SDK の認証情報（ローカル用）
-GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/firebase-service-account.json
 
 # アプリケーションURL
 APP_URL=http://localhost:8080

--- a/reimi/backend/reimi_app/.gitignore
+++ b/reimi/backend/reimi_app/.gitignore
@@ -9,7 +9,6 @@ src/main/resources/flyway.properties
 !**/src/test/**/target/
 
 .env
-secrets/
 
 ### STS ###
 .apt_generated

--- a/reimi/backend/reimi_app/infra/docker/Dockerfile.prod
+++ b/reimi/backend/reimi_app/infra/docker/Dockerfile.prod
@@ -10,7 +10,7 @@ COPY src ./src
 RUN ./mvnw dependency:go-offline -B
 RUN ./mvnw clean package -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
@@ -1,7 +1,5 @@
 package com.reimi.reimi_app.config;
 
-
-import java.io.FileInputStream;
 import java.io.IOException;
 
 import org.springframework.context.annotation.Bean;
@@ -32,13 +30,12 @@ public class FirebaseConfig {
             return FirebaseApp.getInstance();
         }
 
-        String credentialsPath = dotenv.get("GOOGLE_APPLICATION_CREDENTIALS");
+        String projectId = dotenv.get("FIREBASE_PROJECT_ID");
         String bucket = dotenv.get("FIREBASE_STORAGE_BUCKET");
 
-        FileInputStream serviceAccount = new FileInputStream(credentialsPath);
-
         FirebaseOptions firebaseOptions = FirebaseOptions.builder()
-            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+            .setCredentials(GoogleCredentials.getApplicationDefault())
+            .setProjectId(projectId)
             .setStorageBucket(bucket)
             .build();
 

--- a/reimi/backend/reimi_app/src/main/resources/application-example.yml
+++ b/reimi/backend/reimi_app/src/main/resources/application-example.yml
@@ -53,6 +53,8 @@ springdoc:
 firebase:
     storage:
         bucket: ${FIREBASE_STORAGE_BUCKET}
+    project:
+        id: ${FIREBASE_PROJECT_ID}
 
 # アプリケーションベースURL
 app:


### PR DESCRIPTION
## 概要

種別：バックエンド開発

関連Issue：

- #156 

close #156 


## PR内容

### 【やったこと・開発メモ】

- Cloud Run × Cloud SQLにデプロイ
  - [手順まとめ](https://www.notion.so/Cloud-Run-2f88a732ffd4804d9799cbc6b70796d2?source=copy_link)
 
- GCPのADC（Application Default Credentials） によって認証情報を取得
    - サービスアカウンキー（JSONファイル）直読みの方法をやめる
    - 環境によって認証情報の取得方法が変わらない様にする
    - プロジェクトIDを明示的に指定
    - Cloud Runのサービスアカウントに必要なロールの設定を行う

### 【追加・変更した設定ファイル】

- 変更したファイル
  - reimi_app/.env.example
  - reimi_app/.gitignore
  - reimi_app/infra/docker/Dockerfile.prod
  - reimi_app/src/main/java/com/reimi/reimi_app/config/FirebaseConfig.java
  - reimi_app/src/main/resources/application-example.yml

## 参考資料

- Google Runデプロイ方法
  - https://docs.cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-java-service?hl=ja
- Dockerエラー
  - https://qiita.com/nasuB7373/items/9d841f2bd46ec9fc10d5
- Google Cloud CLI をインストール
  - https://docs.cloud.google.com/sdk/docs/install-sdk?hl=ja
- IAM権限不足によるエラー解消
  - https://blog.g-gen.co.jp/entry/permission-downloadartifacts-denied-403
  - https://stackoverflow.com/questions/79183567/my-gcp-service-account-with-artifact-registry-admin-account-was-not-able-to-pu
  - https://stackoverflow.com/questions/41215667/google-cloud-sql-proxy-couldnt-find-default-credentials
- Cloud RunのADC（Application Default Credentials）を使う
  - https://firebase.google.com/docs/admin/setup?hl=ja&utm_source=chatgpt.com
  - https://qiita.com/ktdatascience/items/9472699d7b3cf6ac667f
