### PR TITLE
【API設計】ユーザーのアカウント詳細情報取得のAPI設計（/users/me/account）

### DIFF
--- a/reimi/backend/reimi_app/.env.example
+++ b/reimi/backend/reimi_app/.env.example
@@ -28,6 +28,9 @@ FIREBASE_PROJECT_ID=your-project-id
 # Storageのバケット名
 FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
 
+GOOGLE_APPLICATION_CREDENTIALS=secrets/private-key.json
+
+
 # アプリケーションURL
 APP_URL=http://localhost:8080
 

--- a/reimi/backend/reimi_app/.env.example
+++ b/reimi/backend/reimi_app/.env.example
@@ -27,9 +27,8 @@ POSTGRES_PASSWORD=your_db_password
 FIREBASE_PROJECT_ID=your-project-id
 # Storageのバケット名
 FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
-
-GOOGLE_APPLICATION_CREDENTIALS=secrets/private-key.json
-
+# Firebase Admin SDK の認証情報（ローカル用）
+GOOGLE_APPLICATION_CREDENTIALS=secrets/your_service_account_key.json
 
 # アプリケーションURL
 APP_URL=http://localhost:8080

--- a/reimi/backend/reimi_app/.gitignore
+++ b/reimi/backend/reimi_app/.gitignore
@@ -8,6 +8,7 @@ src/main/resources/flyway.properties
 !**/src/main/**/target/
 !**/src/test/**/target/
 
+secrets/
 .env
 
 ### STS ###

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/dto/output/UserItemOutput.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/dto/output/UserItemOutput.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.application.dto.output;
+
+import java.util.Map;
+
+import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+
+public record UserItemOutput(
+    UserId userId,
+    String name,
+    String mainPhotoUrl,
+    UserWeatherPersonalityType userWeatherPersonalityType,
+    Map<ItemTypeCode, Integer> items
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/initializer/ItemTypeInitializer.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/initializer/ItemTypeInitializer.java
@@ -1,0 +1,24 @@
+package com.reimi.reimi_app.application.initializer;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.reimi.reimi_app.domain.model.item.ItemType;
+import com.reimi.reimi_app.domain.repository.ItemTypeRepository;
+
+@Configuration
+public class ItemTypeInitializer {
+    @Bean
+    ApplicationRunner initializeItemTypes(
+        ItemTypeRepository itemTypeRepository
+    ) {
+        return arg -> {
+            for(ItemType itemType : ItemType.values()) {
+                if (itemTypeRepository.findByCode(itemType.getCode()).isEmpty()) {
+                    itemTypeRepository.save(itemType);
+                }
+            }
+        };
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/ItemUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/ItemUseCase.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.application.usecase;
+
+import com.reimi.reimi_app.application.dto.UserItemOutput;
+
+public interface ItemUseCase {
+    UserItemOutput getUserItemList();
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/ItemUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/ItemUseCase.java
@@ -1,6 +1,6 @@
 package com.reimi.reimi_app.application.usecase;
 
-import com.reimi.reimi_app.application.dto.UserItemOutput;
+import com.reimi.reimi_app.application.dto.output.UserItemOutput;
 
 public interface ItemUseCase {
     UserItemOutput getUserItemList();

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemType.java
@@ -1,0 +1,52 @@
+package com.reimi.reimi_app.domain.model.item;
+
+public class ItemType {
+
+    private final ItemTypeId id;
+    private final ItemTypeCode code;
+    private final String name;
+    private final String description;
+
+    private ItemType (
+        ItemTypeId id,
+        ItemTypeCode code,
+        String name,
+        String description
+    ) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.description = description;
+    }
+
+    // アイテム
+    // レインボーいいね
+    public static final ItemType RAINBOW_LIKE =
+        new ItemType(
+            ItemTypeId.RAINBOW_LIKE,
+            ItemTypeCode.RAINBOW_LIKE,
+            "レインボーいいね",
+            "特別ないいね"
+        );
+
+    public static ItemType[] values() {
+        return new ItemType[] {
+            RAINBOW_LIKE,
+        };
+    }
+
+    public static ItemType from(ItemTypeCode code) {
+        for (ItemType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("存在しないアイテムコードです");
+    }
+
+    public ItemTypeId getId() { return id; }
+    public ItemTypeCode getCode() { return code; }
+    public String getName() { return name; }
+    public String getDescription() { return description; }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeCode.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeCode.java
@@ -1,0 +1,23 @@
+package com.reimi.reimi_app.domain.model.item;
+
+public enum ItemTypeCode {
+    RAINBOW_LIKE("rainbow_like");
+
+    private final String code;
+
+    ItemTypeCode(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public static ItemTypeCode from(String code) {
+        try {
+            return ItemTypeCode.valueOf(code);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new IllegalArgumentException("存在しないアイテムコードです");
+        }
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeCode.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeCode.java
@@ -20,4 +20,11 @@ public enum ItemTypeCode {
             throw new IllegalArgumentException("存在しないアイテムコードです");
         }
     }
+
+    public static ItemTypeCode fromItemTypeId(ItemTypeId id) {
+        return switch (id) {
+            case RAINBOW_LIKE -> RAINBOW_LIKE;
+        };
+    }
+
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeId.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeId.java
@@ -1,0 +1,15 @@
+package com.reimi.reimi_app.domain.model.item;
+
+public enum ItemTypeId {
+    RAINBOW_LIKE(1);
+
+    private final int value;
+
+    ItemTypeId(int value) {
+        this.value = value;
+    }
+
+    public int value() {
+        return value;
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeId.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/ItemTypeId.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.domain.model.item;
 
+import java.util.Arrays;
+
 public enum ItemTypeId {
     RAINBOW_LIKE(1);
 
@@ -12,4 +14,14 @@ public enum ItemTypeId {
     public int value() {
         return value;
     }
+
+    public static ItemTypeId fromValue(int value) {
+        return Arrays.stream(values())
+            .filter(type -> type.value() == value)
+            .findFirst()
+            .orElseThrow(() ->
+                new IllegalArgumentException("不正なアイテムIDです")
+            );
+    }
+
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/UserItem.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/UserItem.java
@@ -1,24 +1,31 @@
 package com.reimi.reimi_app.domain.model.item;
 
-import com.reimi.reimi_app.domain.model.user.UserId;
-
 public class UserItem {
 
-    private final UserId userId;
-    private final ItemTypeId itemTypeId;
+    private final UserItemId id;
     private int quantity;
 
     private UserItem(
-        UserId userId,
-        ItemTypeId itemTypeId,
+        UserItemId id,
         int quantity
     ) {
-        this.userId = userId;
-        this.itemTypeId = itemTypeId;
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("アイテムの数量は1以上である必要があります");
+        }
+        this.id = id;
         this.quantity = quantity;
     }
 
-    public UserId getUserId() { return userId; }
-    public ItemTypeId getItemTypeId() { return itemTypeId; }
+    public static UserItem reconstruct(
+        UserItemId id,
+        int count
+    ) {
+        return new UserItem(
+            id,
+            count
+        );
+    }
+
+    public UserItemId getId() { return id; }
     public int getQuantity() { return quantity; }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/UserItem.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/UserItem.java
@@ -1,0 +1,24 @@
+package com.reimi.reimi_app.domain.model.item;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+
+public class UserItem {
+
+    private final UserId userId;
+    private final ItemTypeId itemTypeId;
+    private int quantity;
+
+    private UserItem(
+        UserId userId,
+        ItemTypeId itemTypeId,
+        int quantity
+    ) {
+        this.userId = userId;
+        this.itemTypeId = itemTypeId;
+        this.quantity = quantity;
+    }
+
+    public UserId getUserId() { return userId; }
+    public ItemTypeId getItemTypeId() { return itemTypeId; }
+    public int getQuantity() { return quantity; }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/UserItemId.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/item/UserItemId.java
@@ -1,0 +1,14 @@
+package com.reimi.reimi_app.domain.model.item;
+
+import com.reimi.reimi_app.domain.model.user.UserId;
+import java.util.Objects;
+
+public record UserItemId(
+    UserId userId,
+    ItemTypeId itemTypeId
+) {
+    public UserItemId {
+        Objects.requireNonNull(userId, "ユーザーIDは必須です");
+        Objects.requireNonNull(itemTypeId, "アイテムIDは必須です");
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/ItemTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/ItemTypeRepository.java
@@ -1,0 +1,12 @@
+package com.reimi.reimi_app.domain.repository;
+
+import java.util.Optional;
+
+import com.reimi.reimi_app.domain.model.item.ItemType;
+import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
+
+public interface ItemTypeRepository {
+    Optional<ItemType> findByCode(ItemTypeCode code);
+
+    void save(ItemType itemType);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserItemRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserItemRepository.java
@@ -1,0 +1,7 @@
+package com.reimi.reimi_app.domain.repository;
+
+import com.reimi.reimi_app.domain.model.item.UserItem;
+
+public interface UserItemRepository {
+    void save(UserItem userItem);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserItemRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/repository/UserItemRepository.java
@@ -1,7 +1,13 @@
 package com.reimi.reimi_app.domain.repository;
 
+import java.util.List;
+
 import com.reimi.reimi_app.domain.model.item.UserItem;
+import com.reimi.reimi_app.domain.model.user.UserId;
 
 public interface UserItemRepository {
+
     void save(UserItem userItem);
+
+    List<UserItem> findByUserId(UserId userId);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/ItemTypeEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/ItemTypeEntity.java
@@ -1,0 +1,48 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+    name = "item_types",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_item_types_code", columnNames = "code")
+    }
+)
+public class ItemTypeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private int id;
+
+    @Column(name = "code", nullable = false, updatable = false, unique = true)
+    private String code;
+
+    @Column(name = "name", nullable = false, updatable = false)
+    private String name;
+
+    @Column(name = "description", nullable = false, updatable = false)
+    private String description;
+
+    public ItemTypeEntity(
+        int id,
+        String code,
+        String name,
+        String description
+    ) {
+        this.id = id;
+        this.code = code;
+        this.name = name;
+        this.description = description;
+    }
+
+    public ItemTypeEntity() {}
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserItemEntity.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/entity/UserItemEntity.java
@@ -1,0 +1,43 @@
+package com.reimi.reimi_app.infrastructure.persistence.entity;
+
+import java.util.UUID;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(
+    name = "user_items",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "item_type_id"})
+    }
+)
+public class UserItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Column(name = "item_type_id", nullable = false, updatable = false)
+    private int itemTypeId;
+
+    @Min(1)
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    public UserItemEntity() {}
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ItemTypeMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/ItemTypeMapper.java
@@ -1,0 +1,22 @@
+package com.reimi.reimi_app.infrastructure.persistence.mapper;
+
+import com.reimi.reimi_app.domain.model.item.ItemType;
+import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
+import com.reimi.reimi_app.infrastructure.persistence.entity.ItemTypeEntity;
+
+public class ItemTypeMapper {
+
+    public static ItemType toDomain(ItemTypeEntity entity) {
+        ItemTypeCode code = ItemTypeCode.from(entity.getCode());
+        return ItemType.from(code);
+    }
+
+    public static ItemTypeEntity toEntity(ItemType type) {
+        return new ItemTypeEntity(
+            type.getId().value(),
+            type.getCode().name(),
+            type.getName(),
+            type.getDescription()
+        );
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserItemMapper.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/mapper/UserItemMapper.java
@@ -1,0 +1,30 @@
+package com.reimi.reimi_app.infrastructure.persistence.mapper;
+
+import com.reimi.reimi_app.domain.model.item.ItemTypeId;
+import com.reimi.reimi_app.domain.model.item.UserItem;
+import com.reimi.reimi_app.domain.model.item.UserItemId;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.infrastructure.persistence.entity.UserItemEntity;
+
+public class UserItemMapper {
+
+    public static UserItem toDomain(UserItemEntity entity) {
+        return UserItem.reconstruct(
+            new UserItemId(
+                new UserId(entity.getUserId()),
+                ItemTypeId.fromValue(entity.getItemTypeId())
+            ),
+            entity.getQuantity()
+        );
+    }
+
+    public static UserItemEntity toEntity(UserItem userItem) {
+        UserItemEntity entity = new UserItemEntity();
+        entity.setUserId(userItem.getId().userId().value());
+        entity.setItemTypeId(userItem.getId().itemTypeId().value());
+        entity.setQuantity(userItem.getQuantity());
+
+        return entity;
+    }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/item/ItemTypeRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/item/ItemTypeRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.item;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.reimi.reimi_app.domain.model.item.ItemType;
+import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
+import com.reimi.reimi_app.domain.repository.ItemTypeRepository;
+import com.reimi.reimi_app.infrastructure.persistence.mapper.ItemTypeMapper;
+
+@Repository
+public class ItemTypeRepositoryImpl implements ItemTypeRepository {
+
+    private final JpaItemTypeRepository jpaItemTypeRepository;
+
+    public ItemTypeRepositoryImpl(
+        JpaItemTypeRepository jpaItemTypeRepository
+    ) {
+        this.jpaItemTypeRepository = jpaItemTypeRepository;
+    }
+
+    @Override
+    public Optional<ItemType> findByCode(ItemTypeCode itemTypeCode) {
+        return jpaItemTypeRepository
+            .findByCode(itemTypeCode.name())
+            .map(ItemTypeMapper::toDomain);
+    }
+
+    @Override
+    public void save(ItemType itemType) {
+        jpaItemTypeRepository.save(ItemTypeMapper.toEntity(itemType));
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/item/JpaItemTypeRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/item/JpaItemTypeRepository.java
@@ -1,0 +1,11 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.item;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.ItemTypeEntity;
+
+public interface JpaItemTypeRepository extends JpaRepository<ItemTypeEntity, Integer> {
+    Optional<ItemTypeEntity> findByCode(String code);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/useritem/JpaUserItemRepository.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/useritem/JpaUserItemRepository.java
@@ -1,0 +1,12 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.useritem;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reimi.reimi_app.infrastructure.persistence.entity.UserItemEntity;
+
+public interface JpaUserItemRepository extends JpaRepository<UserItemEntity, Long>  {
+    List<UserItemEntity> findByUserId(UUID userId);
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/useritem/UserItemRepositoryImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/persistence/repository/useritem/UserItemRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.reimi.reimi_app.infrastructure.persistence.repository.useritem;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.reimi.reimi_app.domain.model.item.UserItem;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.repository.UserItemRepository;
+import com.reimi.reimi_app.infrastructure.persistence.mapper.UserItemMapper;
+
+@Repository
+public class UserItemRepositoryImpl implements UserItemRepository {
+
+    private final JpaUserItemRepository jpaUserItemRepository;
+
+    public UserItemRepositoryImpl(
+        JpaUserItemRepository jpaUserItemRepository
+    ) {
+        this.jpaUserItemRepository = jpaUserItemRepository;
+    }
+
+    @Override
+    public void save(UserItem userItem) {
+        jpaUserItemRepository.save(UserItemMapper.toEntity(userItem));
+    }
+
+    @Override
+    public List<UserItem> findByUserId(UserId userId) {
+        return jpaUserItemRepository.findByUserId(userId.value())
+            .stream()
+            .map(UserItemMapper::toDomain)
+            .toList();
+    }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/ItemUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/ItemUseCaseImpl.java
@@ -1,0 +1,90 @@
+package com.reimi.reimi_app.infrastructure.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.reimi.reimi_app.application.dto.output.UserItemOutput;
+import com.reimi.reimi_app.application.exception.client.ResourceNotFoundException;
+import com.reimi.reimi_app.application.service.ImageUrlResolver;
+import com.reimi.reimi_app.application.usecase.ItemUseCase;
+import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
+import com.reimi.reimi_app.domain.model.item.UserItem;
+import com.reimi.reimi_app.domain.model.user.User;
+import com.reimi.reimi_app.domain.model.user.UserId;
+import com.reimi.reimi_app.domain.model.weatherpersonality.UserWeatherPersonalityType;
+import com.reimi.reimi_app.domain.repository.UserItemRepository;
+import com.reimi.reimi_app.domain.repository.UserRepository;
+import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
+import com.reimi.reimi_app.infrastructure.storage.image.ImageStorageComponent;
+import com.reimi.reimi_app.security.AuthenticatedUserProvider;
+
+@Service
+public class ItemUseCaseImpl implements ItemUseCase {
+
+    private final UserItemRepository userItemRepository;
+    private final UserRepository userRepository;
+    private final AuthenticatedUserProvider authenticatedUserProvider;
+    private final ImageStorageComponent imageStorage;
+    private final UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository;
+    private final ImageUrlResolver imageUrlResolver;
+
+
+    public ItemUseCaseImpl(
+        UserItemRepository userItemRepository,
+        UserRepository userRepository,
+        AuthenticatedUserProvider authenticatedUserProvider,
+        ImageStorageComponent imageStorage,
+        UserWeatherPersonalityTypeRepository userWeatherPersonalityTypeRepository,
+        ImageUrlResolver imageUrlResolver
+    ) {
+        this.userItemRepository = userItemRepository;
+        this.userRepository = userRepository;
+        this.authenticatedUserProvider = authenticatedUserProvider;
+        this.imageStorage = imageStorage;
+        this.userWeatherPersonalityTypeRepository = userWeatherPersonalityTypeRepository;
+        this.imageUrlResolver = imageUrlResolver;
+    }
+
+    @Override
+    public UserItemOutput getUserItemList() {
+
+        String firebaseUid = authenticatedUserProvider.getFirebaseUid();
+
+        User user = userRepository.findMeByFirebaseUid(firebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        UserId userId = user.getId();
+
+        List<UserItem> userItems = userItemRepository.findByUserId(userId);
+
+        Map<ItemTypeCode, Integer> items =
+            userItems.stream()
+                .collect(Collectors.toMap(
+                    userItem -> ItemTypeCode.fromItemTypeId(userItem.getId().itemTypeId()),
+                    userItem -> userItem.getQuantity()
+                ));
+
+        UserWeatherPersonalityType userType = userWeatherPersonalityTypeRepository.findByUserId(userId)
+            .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティ診断結果"));
+
+        String typeImageUrl = imageUrlResolver.resolve(
+                userType.getWeatherPersonalityType().getImagePath()
+            );
+
+        userType.getWeatherPersonalityType().setTypeImageUrl(typeImageUrl);
+
+        user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));
+
+        return new UserItemOutput(
+            user.getId(),
+            user.getName(),
+            user.getSignedMainPhotoUrl(),
+            userType,
+            items
+        );
+    }
+
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/ItemUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/ItemUseCaseImpl.java
@@ -1,7 +1,9 @@
 package com.reimi.reimi_app.infrastructure.service;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -60,12 +62,20 @@ public class ItemUseCaseImpl implements ItemUseCase {
 
         List<UserItem> userItems = userItemRepository.findByUserId(userId);
 
+        // すべてのItemTypeCodeを0個として初期化
         Map<ItemTypeCode, Integer> items =
-            userItems.stream()
+            Arrays.stream(ItemTypeCode.values())
                 .collect(Collectors.toMap(
-                    userItem -> ItemTypeCode.fromItemTypeId(userItem.getId().itemTypeId()),
-                    userItem -> userItem.getQuantity()
+                    Function.identity(),
+                    item -> 0
                 ));
+        // 存在しているユーザーアイテムの個数をputする
+        userItems.forEach(userItem -> {
+            ItemTypeCode code =
+                ItemTypeCode.fromItemTypeId(userItem.getId().itemTypeId());
+
+            items.put(code, userItem.getQuantity());
+        });
 
         UserWeatherPersonalityType userType = userWeatherPersonalityTypeRepository.findByUserId(userId)
             .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティ診断結果"));

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/ItemController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/ItemController.java
@@ -1,0 +1,48 @@
+package com.reimi.reimi_app.infrastructure.web.controller.v1;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reimi.reimi_app.application.dto.output.UserItemOutput;
+import com.reimi.reimi_app.application.usecase.ItemUseCase;
+import com.reimi.reimi_app.infrastructure.web.dto.response.UserAccountDetailResponse;
+import com.reimi.reimi_app.infrastructure.web.openapi.item.GetUserAccountDetailApi;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "User", description = "ユーザー関連のAPI")
+public class ItemController {
+
+    private final ItemUseCase itemUseCase;
+
+    public ItemController(
+        ItemUseCase itemUseCase
+    ) {
+        this.itemUseCase = itemUseCase;
+    }
+
+    @GetMapping("/users/me/account")
+    @GetUserAccountDetailApi
+    public ResponseEntity<UserAccountDetailResponse> getUserAccountDetail() {
+
+        UserItemOutput output = itemUseCase.getUserItemList();
+
+        var userType =
+            output.userWeatherPersonalityType().getWeatherPersonalityType();
+
+        UserAccountDetailResponse response =
+            new UserAccountDetailResponse(
+                output.userId().value(),
+                output.name(),
+                output.mainPhotoUrl(),
+                userType.getCode(),
+                userType.getName(),
+                userType.getTypeImageUrl(),
+                output.items()
+            );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/UserAccountDetailResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/UserAccountDetailResponse.java
@@ -1,0 +1,41 @@
+package com.reimi.reimi_app.infrastructure.web.dto.response;
+
+import java.util.Map;
+import java.util.UUID;
+
+import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
+import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "ユーザーのアカウント詳細情報取得用レスポンス")
+public record UserAccountDetailResponse (
+
+        @Schema(description = "ユーザーID", example = "5bf5eb52-c5fb-4a4c-b6e3-25e53c28bf93")
+        UUID id,
+
+        @Schema(description = "名前", example = "山田 太郎")
+        String name,
+
+        @Schema(description = "メイン写真URL")
+        String mainPhotoUrl,
+
+        @Schema(description = "タイプコード", example = "SPOE")
+        WeatherPersonalityCode typeCode,
+
+        @Schema(description = "タイプ名", example = "トレーニーラッコ")
+        String typeName,
+
+        @Schema(description = "タイプイメージ画像URL", example = "http://localhost:8080/images/weather-personalities/トレーニーラッコ_イメージ画像.png")
+        String typeImageUrl,
+
+        @Schema(
+            description = "ユーザーのアイテム所持数",
+            example = """
+            {
+                "RAINBOW_LIKE": 3
+            }
+            """
+        )
+        Map<ItemTypeCode, Integer> items
+) {}

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/item/GetUserAccountDetailApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/item/GetUserAccountDetailApi.java
@@ -1,0 +1,83 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.item;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+import com.reimi.reimi_app.infrastructure.web.dto.response.UserAccountDetailResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ユーザーのアカウント詳細情報取得",
+    description = "ログインユーザーのアカウント詳細情報を取得できるAPI"
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "ユーザーのアカウント詳細情報取得成功",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = UserAccountDetailResponse.class)
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ユーザーが見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface GetUserAccountDetailApi {
+}


### PR DESCRIPTION
## 概要

API名：ユーザーのアカウント詳細情報取得

種別：API開発

関連Issue：

- #152 

close #152

## API設計

### 【やったこと・開発メモ】

### ドメイン層

---

- ItemTypeドメインモデルを作成
    - 不変オブジェクトとして定義
    - レインボーライクの固定インスタンスを作成
    - ItemTypeCode型のコードからドメインモデルを返すメソッドを定義
    - Getterの定義
- UserItemドメインモデルを作成
    - UserItemIdを別で定義
    - アイテムの数量は1以上であるようにする
    - reconstructメソッドを作成
    - Getterの定義
- UserItemIdを値オブジェクトとして作成
    - 不変オブジェクトとして定義
    - ユーザーIDとアイテムID必須
- アイテムのコードとIDをenum（列挙型）で定義
    - アイテムコード：
        - 文字列のコードをItemTypeCode型に変換するメソッドを定義
        - ItemTypeId型をItemTypeCode型に変換するメソッドを定義
    - アイテムID：数値をItemTypeId型に変換するメソッドを定義
- アイテムタイプリポジトリのインターフェイス作成
    - コードによりドメインモデルを取得してくるメソッド
    - アイテムタイプが登録（保存）されるメソッド
- ユーザーアイテムリポジトリのインターフェイス作成
    - ユーザーアイテムが登録（保存）されるメソッド
    - ユーザーIDよりユーザーアイテムをリストで取得するメソッド

### アプリケーション層

---

- アプリケーション起動時にアイテムタイプを自動生成させるイニシャライザを作成
    - アプリ起動時にItemTypeがDBに存在しなければ、ドメインモデルに定義済みのアイテムタイプを登録する
    - 今回はレインボーいいねのみ
- アイテムユースケースのインターフェイスに業務を追加
    - ユーザーのアイテム所持情報取得メソッド
- アウトプットDTOを作成

### インフラストラクチャ層

---

- エンティティの作成
    - ItemType
        - 必要なアノテーションとカラム定義
            - codeにユニーク制約を貼る
        - Mapperでエンティティに変換するための引数ありコンストラクタを定義
    - UserItem
        - 必要なアノテーションとカラム定義
            - ユーザーIDとアイテムIDの複合ユニーク制約を貼る
            - quantityカラムは1以上
- Mapperの作成
    - ItemTypeとUserItem
        - エンティティへの変換メソッド
        - ドメインモデルへの変換メソッド
- JPA Repositoryを使うためのインターフェイス作成
    - ItemType
        - 主キーはInteger型
        - コードからエンティティを取得してくるメソッド
    - UserItem
        - 主キーはLong型
        - ユーザーIDからエンティティのリストを取得してくるメソッド
- アイテムのユースケースを実装
    - ログインユーザーが存在しているか確認
    - ユーザーIDからユーザーアイテムをリストで取得
    - アイテムコードと数量のMap型変数を作成
        - アイテムにコードに対して
            - ユーザーアイテムが存在していなかったら、数量を0にする
            - ユーザーアイテムが存在していたら、そのまま数量を入れる
    - ユーザーのウェザーパーソナリティタイプを取得
    - 作成したアウトプットDTOに必要な値をセット
- アイテムタイプのリポジトリを実装
    - オーバーライドメソッドを定義
        - 主キー（コード）からウェザーパーソナリティタイプドメインモデルを取得する
        - ドメインモデルからエンティティに変換されて保存される
- ユーザーアイテムタイプのリポジトリを実装
    - オーバーライドメソッドを定義
        - ドメインモデルからエンティティに変換されて保存される
        - ユーザーIDからUserItemエンティティリストを取得してきてドメインモデルに変換する
- レスポンスDTOを作成
- Controllerの作成
    - ユーザーのアカウント詳細情報取得のGET APIを定義
- 定義アノテーションを作成

### その他

---

- ローカルではGOOGLE_APPLICATION_CREDENTIALSにサービスアカウントキーのJSONファイルパスを入れて認証情報を取得する
    - envファイルにもう一度追加
    - secretsフォルダを作成してサービスアカウントキーを入れる
    - ↑.gitignoreでgit管理外のファイルにする

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ユーザーのアカウント詳細情報取得 |
| URL | /api/v1/users/me/account |
| HTTPメソッド | GET |
| ステータスコード | 200 / 401 / 404 / 500 |

### 【リクエスト】

特になし

### 【レスポンス】

```json
{
  "id": string uuid
  "name": string
  "mainPhotoUrl": string
  "typeCode": string
  "typeName": string
  "typeImageUrl": string
  "items": {
    "RAINBOW_LIKE": integer int32
  }: object
}
```

### 【追加・変更したエンティティ】

- エンティティ名①：ItemType
  - 役割：アイテムに関する情報を格納する
  - ドメインルール：

- エンティティ名②：UserItem
  - 役割：ユーザーアイテムに関する情報を格納する
  - ドメインルール：
    - ユーザーアイテムはユーザーと多対１で紐づく
    - 数量は1以上
    - 0=所持していないものという認識

### 【追加・変更した設定ファイル】

- 追加したファイル
```
 ├── application
│   ├── dto
│   │   └── output
│   │       └── UserItemOutput.java
│   │
│   ├── initializer
│   │   └── ItemTypeInitializer.java
│   │
│   └── usecase
│       └── ItemUseCase.java
│
├── domain
│   ├── model
│   │   └── item
│   │       ├── ItemType.java
│   │       ├── ItemTypeCode.java
│   │       ├── ItemTypeId.java
│   │       ├── UserItem.java
│   │       └── UserItemId.java
│   │
│   └── repository
│       ├── ItemTypeRepository.java
│       └── UserItemRepository.java
│
├── infrastructure
│   ├── persistence
│   │   ├── entity
│   │   │   ├── ItemTypeEntity.java
│   │   │   └── UserItemEntity.java
│   │   │
│   │   ├── mapper
│   │   │   ├── ItemTypeMapper.java
│   │   │   └── UserItemMapper.java
│   │   │
│   │   └── repository
│   │       ├── item
│   │       │   ├── ItemTypeRepositoryImpl.java
│   │       │   └── JpaItemTypeRepository.java
│   │       │
│   │       └── useritem
│   │           ├── JpaUserItemRepository.java
│   │           └── UserItemRepositoryImpl.java
│   │
│   ├── service
│   │   └── ItemUseCaseImpl.java
│   │
│   └── web
│       ├── controller
│       │   └── v1
│       │       └── ItemController.java
│       │
│       └── dto
│           └── response
│               └── UserAccountDetailResponse.java

```
- 変更したファイル
  - reimi/backend/reimi_app/.env.example
  - reimi/backend/reimi_app/.gitignore
 