### PR TITLE
【ロジック】レインボーいいね関連のロジック実装

### DIFF
--- a/reimi/frontend/reimi_app/lib/application/usecases/rainbow_like/get_rainbow_like_users_from_user_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/application/usecases/rainbow_like/get_rainbow_like_users_from_user_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:reimi_app/domain/read_models/rainbow_like_user_read_model.dart';
+import 'package:reimi_app/domain/repositories/rainbow_like_repository.dart';
+
+class GetRainbowLikeUsersFromUserUseCase {
+  const GetRainbowLikeUsersFromUserUseCase(this._repository);
+  final RainbowLikeRepository _repository;
+
+  Future<List<RainbowLikeUserReadModel>> call() {
+    final likeUsers = _repository.fetchRainbowLikeUsersFromUser();
+    return likeUsers;
+  }
+}

--- a/reimi/frontend/reimi_app/lib/application/usecases/rainbow_like/get_rainbow_like_users_to_user_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/application/usecases/rainbow_like/get_rainbow_like_users_to_user_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:reimi_app/domain/read_models/rainbow_like_user_read_model.dart';
+import 'package:reimi_app/domain/repositories/rainbow_like_repository.dart';
+
+class GetRainbowLikeUsersToUserUseCase {
+  const GetRainbowLikeUsersToUserUseCase(this._repository);
+  final RainbowLikeRepository _repository;
+
+  Future<List<RainbowLikeUserReadModel>> call() {
+    final likeUsers = _repository.fetchRainbowLikeUsersToUser();
+    return likeUsers;
+  }
+}

--- a/reimi/frontend/reimi_app/lib/core/di/usecase_providers.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/usecase_providers.dart
@@ -2,6 +2,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:reimi_app/application/usecases/like/like_user_usecase.dart';
 import 'package:reimi_app/application/usecases/notification/register_device_token_usecase.dart';
 import 'package:reimi_app/application/usecases/profile/update_user_profile_usecase.dart';
+import 'package:reimi_app/application/usecases/rainbow_like/get_rainbow_like_users_from_user_usecase.dart';
+import 'package:reimi_app/application/usecases/rainbow_like/get_rainbow_like_users_to_user_usecase.dart';
 import 'package:reimi_app/application/usecases/rainbow_like/rainbow_like_user_usecase.dart';
 import 'package:reimi_app/application/usecases/session/get_current_user_state_usecase.dart';
 import 'package:reimi_app/application/usecases/like/get_like_users_to_user_usecase.dart';
@@ -88,6 +90,18 @@ LikeUserUseCase likeUserUseCase(Ref ref) {
 RainbowLikeUserUseCase rainbowLikeUserUseCase(Ref ref) {
   return RainbowLikeUserUseCase(ref.watch(rainbowLikeRepositoryProvider));
 }
+
+@riverpod
+GetRainbowLikeUsersFromUserUseCase getRainbowLikeUsersFromUserUseCase(Ref ref) {
+  return GetRainbowLikeUsersFromUserUseCase(ref.watch(rainbowLikeRepositoryProvider));
+}
+
+
+@riverpod
+GetRainbowLikeUsersToUserUseCase getRainbowLikeUsersToUserUseCase(Ref ref) {
+  return GetRainbowLikeUsersToUserUseCase(ref.watch(rainbowLikeRepositoryProvider));
+}
+
 
 // chat_room関連
 @riverpod

--- a/reimi/frontend/reimi_app/lib/core/di/usecase_providers.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/usecase_providers.g.dart
@@ -221,6 +221,46 @@ final rainbowLikeUserUseCaseProvider =
 // ignore: unused_element
 typedef RainbowLikeUserUseCaseRef
     = AutoDisposeProviderRef<RainbowLikeUserUseCase>;
+String _$getRainbowLikeUsersFromUserUseCaseHash() =>
+    r'f91f285e2c62a22ef2fab4abfde9f1f3ab9b806f';
+
+/// See also [getRainbowLikeUsersFromUserUseCase].
+@ProviderFor(getRainbowLikeUsersFromUserUseCase)
+final getRainbowLikeUsersFromUserUseCaseProvider =
+    AutoDisposeProvider<GetRainbowLikeUsersFromUserUseCase>.internal(
+  getRainbowLikeUsersFromUserUseCase,
+  name: r'getRainbowLikeUsersFromUserUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getRainbowLikeUsersFromUserUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetRainbowLikeUsersFromUserUseCaseRef
+    = AutoDisposeProviderRef<GetRainbowLikeUsersFromUserUseCase>;
+String _$getRainbowLikeUsersToUserUseCaseHash() =>
+    r'8126957c886462e59fcb60843804f05555bdc859';
+
+/// See also [getRainbowLikeUsersToUserUseCase].
+@ProviderFor(getRainbowLikeUsersToUserUseCase)
+final getRainbowLikeUsersToUserUseCaseProvider =
+    AutoDisposeProvider<GetRainbowLikeUsersToUserUseCase>.internal(
+  getRainbowLikeUsersToUserUseCase,
+  name: r'getRainbowLikeUsersToUserUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getRainbowLikeUsersToUserUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetRainbowLikeUsersToUserUseCaseRef
+    = AutoDisposeProviderRef<GetRainbowLikeUsersToUserUseCase>;
 String _$getUnmessagedMatchUsersUseCaseHash() =>
     r'f19b364e5540940c6a4f04ed894ab18b2229c5e6';
 

--- a/reimi/frontend/reimi_app/lib/core/i18n/en.i18n.json
+++ b/reimi/frontend/reimi_app/lib/core/i18n/en.i18n.json
@@ -551,6 +551,10 @@
     "reTest":{
       "title": "Confirmation of Re-Test",
       "contentText": "If you run the test again, the current test results will be deleted. \nDo you really want to run the test again?"
+    },
+    "likeMessage":{
+      "title": "message received",
+      "nullCase": "There are no messages."
     }
   },
   "modalSheet": {

--- a/reimi/frontend/reimi_app/lib/core/i18n/ja.i18n.json
+++ b/reimi/frontend/reimi_app/lib/core/i18n/ja.i18n.json
@@ -551,6 +551,10 @@
     "reTest":{
       "title": "再診断の確認",
       "contentText": "診断をやり直すと、現在の診断結果は削除されます。\n本当に再診断しますか？"
+    },
+    "likeMessage":{
+      "title": "届いたメッセージ",
+      "nullCase": "メッセージがありません。"
     }
   },
   "modalSheet": {

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1226 (613 per locale)
+/// Strings: 1230 (615 per locale)
 ///
-/// Built on 2026-02-09 at 15:36 UTC
+/// Built on 2026-02-10 at 10:30 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings_en.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings_en.g.dart
@@ -554,6 +554,7 @@ class TranslationsDialogEn {
 	late final TranslationsDialogInterruptTestEn interruptTest = TranslationsDialogInterruptTestEn._(_root);
 	late final TranslationsDialogCompleteTestEn completeTest = TranslationsDialogCompleteTestEn._(_root);
 	late final TranslationsDialogReTestEn reTest = TranslationsDialogReTestEn._(_root);
+	late final TranslationsDialogLikeMessageEn likeMessage = TranslationsDialogLikeMessageEn._(_root);
 }
 
 // Path: modalSheet
@@ -1759,6 +1760,21 @@ class TranslationsDialogReTestEn {
 
 	/// en: 'If you run the test again, the current test results will be deleted. Do you really want to run the test again?'
 	String get contentText => 'If you run the test again, the current test results will be deleted. \nDo you really want to run the test again?';
+}
+
+// Path: dialog.likeMessage
+class TranslationsDialogLikeMessageEn {
+	TranslationsDialogLikeMessageEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'message received'
+	String get title => 'message received';
+
+	/// en: 'There are no messages.'
+	String get nullCase => 'There are no messages.';
 }
 
 // Path: modalSheet.sortUser
@@ -3886,6 +3902,8 @@ extension on Translations {
 			'dialog.completeTest.contentText' => 'Would you like to submit your answers and complete the test?',
 			'dialog.reTest.title' => 'Confirmation of Re-Test',
 			'dialog.reTest.contentText' => 'If you run the test again, the current test results will be deleted. \nDo you really want to run the test again?',
+			'dialog.likeMessage.title' => 'message received',
+			'dialog.likeMessage.nullCase' => 'There are no messages.',
 			'modalSheet.sortUser.title' => 'Sort',
 			'modalSheet.refineSearchUser.title' => 'Filter',
 			'modalSheet.refineSearchUser.section.age' => 'Age',
@@ -4102,10 +4120,10 @@ extension on Translations {
 			'kEnum.height.over200cm' => 'Over 200cm',
 			'kEnum.holiday.weekend' => 'Weekends',
 			'kEnum.holiday.weekday' => 'Weekdays',
-			'kEnum.holiday.irregular' => 'Irregular',
-			'kEnum.occupation.universityStudent' => 'University Student',
 			_ => null,
 		} ?? switch (path) {
+			'kEnum.holiday.irregular' => 'Irregular',
+			'kEnum.occupation.universityStudent' => 'University Student',
 			'kEnum.occupation.graduateStudent' => 'Graduate Student',
 			'kEnum.occupation.vocationalStudent' => 'Vocational Student',
 			'kEnum.occupation.juniorCollegeStudent' => 'Junior College Student',

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings_ja.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings_ja.g.dart
@@ -444,6 +444,7 @@ class _TranslationsDialogJa implements TranslationsDialogEn {
 	@override late final _TranslationsDialogInterruptTestJa interruptTest = _TranslationsDialogInterruptTestJa._(_root);
 	@override late final _TranslationsDialogCompleteTestJa completeTest = _TranslationsDialogCompleteTestJa._(_root);
 	@override late final _TranslationsDialogReTestJa reTest = _TranslationsDialogReTestJa._(_root);
+	@override late final _TranslationsDialogLikeMessageJa likeMessage = _TranslationsDialogLikeMessageJa._(_root);
 }
 
 // Path: modalSheet
@@ -1279,6 +1280,17 @@ class _TranslationsDialogReTestJa implements TranslationsDialogReTestEn {
 	// Translations
 	@override String get title => '再診断の確認';
 	@override String get contentText => '診断をやり直すと、現在の診断結果は削除されます。\n本当に再診断しますか？';
+}
+
+// Path: dialog.likeMessage
+class _TranslationsDialogLikeMessageJa implements TranslationsDialogLikeMessageEn {
+	_TranslationsDialogLikeMessageJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '届いたメッセージ';
+	@override String get nullCase => 'メッセージがありません。';
 }
 
 // Path: modalSheet.sortUser
@@ -2636,6 +2648,8 @@ extension on TranslationsJa {
 			'dialog.completeTest.contentText' => '回答した内容を送信し、診断を完了しますか？',
 			'dialog.reTest.title' => '再診断の確認',
 			'dialog.reTest.contentText' => '診断をやり直すと、現在の診断結果は削除されます。\n本当に再診断しますか？',
+			'dialog.likeMessage.title' => '届いたメッセージ',
+			'dialog.likeMessage.nullCase' => 'メッセージがありません。',
 			'modalSheet.sortUser.title' => '並び替え',
 			'modalSheet.refineSearchUser.title' => '絞り込み条件',
 			'modalSheet.refineSearchUser.section.age' => '年齢',
@@ -2852,10 +2866,10 @@ extension on TranslationsJa {
 			'kEnum.height.over200cm' => '200cm以上',
 			'kEnum.holiday.weekend' => '土日',
 			'kEnum.holiday.weekday' => '平日',
-			'kEnum.holiday.irregular' => '不定休',
-			'kEnum.occupation.universityStudent' => '大学生',
 			_ => null,
 		} ?? switch (path) {
+			'kEnum.holiday.irregular' => '不定休',
+			'kEnum.occupation.universityStudent' => '大学生',
 			'kEnum.occupation.graduateStudent' => '大学院生',
 			'kEnum.occupation.vocationalStudent' => '専門学生',
 			'kEnum.occupation.juniorCollegeStudent' => '短大生',

--- a/reimi/frontend/reimi_app/lib/data/datasources/mocks/rainbow_like_mock_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/mocks/rainbow_like_mock_datasource.dart
@@ -1,7 +1,20 @@
 import 'package:reimi_app/data/datasources/remote/rainbow_like_remote_datasource.dart';
+import 'package:reimi_app/data/dtos/rainbow_like_user_dto.dart';
+import 'package:reimi_app/domain/value_objects/address.dart';
+import 'package:reimi_app/gen/assets.gen.dart';
 
 class RainbowLikeMockDataSource implements RainbowLikeRemoteDataSource {
   const RainbowLikeMockDataSource();
+
+  @override
+  Future<List<RainbowLikeUserDto>> fetchRainbowLikeUsersFromUser() async {
+    return mockRainbowLikeUsersFromUser;
+  }
+
+  @override
+  Future<List<RainbowLikeUserDto>> fetchRainbowLikeUsersToUser() async {
+    return mockRainbowLikeUsersToUser;
+  }
 
   @override
   Future<void> rainbowlikeUser({
@@ -11,3 +24,57 @@ class RainbowLikeMockDataSource implements RainbowLikeRemoteDataSource {
     return;
   }
 }
+
+final List<RainbowLikeUserDto> mockRainbowLikeUsersFromUser = [
+  RainbowLikeUserDto(
+    id: 'user_001',
+    name: 'あおい',
+    birthDate: DateTime(2001, 5, 15),
+    address: Address.tokyo,
+    mainPhotoUrl: Assets.images.sample.user000SampleImage.path,
+    introduction: '都内でWebデザイナーをしています。休日はカフェ巡りや美術館に行くのが好きです。よろしくお願いします！',
+    message: "私もアウトドア派です！お出かけするとしたら、どこに行かれることが多いですか？",
+    isTodayReported: true,
+    typeImageUrl:
+        Assets.images.weatherPersonality.spoeTraineeSeaOtterImage.path,
+  ),
+  RainbowLikeUserDto(
+    id: 'user_004',
+    name: 'みさき',
+    birthDate: DateTime(1997, 7, 12),
+    address: Address.fukuoka,
+    mainPhotoUrl: Assets.images.sample.user004SampleImage.path,
+    introduction: 'フリーランスでイラストを描いています。のんびりした性格です。美味しいご飯とお酒が大好きです。',
+    message: '私も美味しいごはん屋さん開拓するのハマってます！よかったらお話ししませんか？',
+    isTodayReported: false,
+    typeImageUrl:
+        Assets.images.weatherPersonality.sforCrowsInTheGardenImage.path,
+  ),
+];
+
+final List<RainbowLikeUserDto> mockRainbowLikeUsersToUser = [
+  RainbowLikeUserDto(
+    id: 'user_002',
+    name: 'けん',
+    birthDate: DateTime(1992, 11, 3),
+    address: Address.osaka,
+    mainPhotoUrl: Assets.images.sample.user002SampleImage.path,
+    introduction: '大阪で経営をしています。仕事人間でしたが、最近は健康のためにゴルフを始めました。',
+    message: 'ゴルフいいですね！自分も最近ゴルフ始めたので、よかったら話しませんか？',
+    isTodayReported: true,
+    typeImageUrl:
+        Assets.images.weatherPersonality.spieSentimentalSquirrelImage.path,
+  ),
+  RainbowLikeUserDto(
+    id: 'user_006',
+    name: 'みゆき',
+    birthDate: DateTime(2002, 2, 28),
+    address: Address.tokyo,
+    mainPhotoUrl: Assets.images.sample.user003SampleImage.path,
+    introduction: '落ち着いたお付き合いができる方を探しています。ガーデニングと海外旅行が趣味です。',
+    message: '海外旅行よく行かれるんですね！どこの国がお好きなんですか？',
+    isTodayReported: true,
+    typeImageUrl:
+        Assets.images.weatherPersonality.sfoeStreetPerformingRedPandaImage.path,
+  ),
+];

--- a/reimi/frontend/reimi_app/lib/data/datasources/remote/rainbow_like_remote_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/remote/rainbow_like_remote_datasource.dart
@@ -1,7 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:reimi_app/core/error/api_exception.dart';
+import 'package:reimi_app/data/dtos/rainbow_like_user_dto.dart';
 
 abstract class RainbowLikeRemoteDataSource {
+  Future<List<RainbowLikeUserDto>> fetchRainbowLikeUsersFromUser();
+  Future<List<RainbowLikeUserDto>> fetchRainbowLikeUsersToUser();
   Future<void> rainbowlikeUser({
     required String userId,
     required String message,
@@ -11,6 +14,32 @@ abstract class RainbowLikeRemoteDataSource {
 class RainbowLikeRemoteDataSourceImpl implements RainbowLikeRemoteDataSource {
   const RainbowLikeRemoteDataSourceImpl(this._dio);
   final Dio _dio;
+
+  @override
+  Future<List<RainbowLikeUserDto>> fetchRainbowLikeUsersFromUser() async {
+    try {
+      final response = await _dio.get('/api/v1/rainbow-likes/users/received');
+      final List data = response.data as List;
+      return data
+          .map((e) => RainbowLikeUserDto.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<List<RainbowLikeUserDto>> fetchRainbowLikeUsersToUser() async {
+    try {
+      final response = await _dio.get('/api/v1/rainbow-likes/users/given');
+      final List data = response.data as List;
+      return data
+          .map((e) => RainbowLikeUserDto.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
 
   @override
   Future<void> rainbowlikeUser({

--- a/reimi/frontend/reimi_app/lib/data/dtos/rainbow_like_user_dto.dart
+++ b/reimi/frontend/reimi_app/lib/data/dtos/rainbow_like_user_dto.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/core/utils/yyyy_mm_dd_date_converter.dart';
+import 'package:reimi_app/domain/value_objects/address.dart';
+
+part 'rainbow_like_user_dto.freezed.dart';
+part 'rainbow_like_user_dto.g.dart';
+
+@freezed
+abstract class RainbowLikeUserDto with _$RainbowLikeUserDto {
+  const factory RainbowLikeUserDto({
+    required String id,
+    required String name,
+    @YyyyMmDdDateConverter() required DateTime birthDate,
+    required Address address,
+    required String mainPhotoUrl,
+    required String message,
+    String? introduction,
+    bool? isTodayReported,
+    String? typeImageUrl,
+  }) = _RainbowLikeUserDto;
+
+  factory RainbowLikeUserDto.fromJson(Map<String, dynamic> json) =>
+      _$RainbowLikeUserDtoFromJson(json);
+}

--- a/reimi/frontend/reimi_app/lib/data/dtos/rainbow_like_user_dto.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/data/dtos/rainbow_like_user_dto.freezed.dart
@@ -1,0 +1,534 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'rainbow_like_user_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RainbowLikeUserDto {
+  String get id;
+  String get name;
+  @YyyyMmDdDateConverter()
+  DateTime get birthDate;
+  Address get address;
+  String get mainPhotoUrl;
+  String get message;
+  String? get introduction;
+  bool? get isTodayReported;
+  String? get typeImageUrl;
+
+  /// Create a copy of RainbowLikeUserDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $RainbowLikeUserDtoCopyWith<RainbowLikeUserDto> get copyWith =>
+      _$RainbowLikeUserDtoCopyWithImpl<RainbowLikeUserDto>(
+          this as RainbowLikeUserDto, _$identity);
+
+  /// Serializes this RainbowLikeUserDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is RainbowLikeUserDto &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction) &&
+            (identical(other.isTodayReported, isTodayReported) ||
+                other.isTodayReported == isTodayReported) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, birthDate, address,
+      mainPhotoUrl, message, introduction, isTodayReported, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'RainbowLikeUserDto(id: $id, name: $name, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, message: $message, introduction: $introduction, isTodayReported: $isTodayReported, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $RainbowLikeUserDtoCopyWith<$Res> {
+  factory $RainbowLikeUserDtoCopyWith(
+          RainbowLikeUserDto value, $Res Function(RainbowLikeUserDto) _then) =
+      _$RainbowLikeUserDtoCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      @YyyyMmDdDateConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      String message,
+      String? introduction,
+      bool? isTodayReported,
+      String? typeImageUrl});
+}
+
+/// @nodoc
+class _$RainbowLikeUserDtoCopyWithImpl<$Res>
+    implements $RainbowLikeUserDtoCopyWith<$Res> {
+  _$RainbowLikeUserDtoCopyWithImpl(this._self, this._then);
+
+  final RainbowLikeUserDto _self;
+  final $Res Function(RainbowLikeUserDto) _then;
+
+  /// Create a copy of RainbowLikeUserDto
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? message = null,
+    Object? introduction = freezed,
+    Object? isTodayReported = freezed,
+    Object? typeImageUrl = freezed,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      introduction: freezed == introduction
+          ? _self.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isTodayReported: freezed == isTodayReported
+          ? _self.isTodayReported
+          : isTodayReported // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      typeImageUrl: freezed == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [RainbowLikeUserDto].
+extension RainbowLikeUserDtoPatterns on RainbowLikeUserDto {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_RainbowLikeUserDto value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserDto() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_RainbowLikeUserDto value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserDto():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_RainbowLikeUserDto value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserDto() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserDto() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserDto():
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserDto() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _RainbowLikeUserDto implements RainbowLikeUserDto {
+  const _RainbowLikeUserDto(
+      {required this.id,
+      required this.name,
+      @YyyyMmDdDateConverter() required this.birthDate,
+      required this.address,
+      required this.mainPhotoUrl,
+      required this.message,
+      this.introduction,
+      this.isTodayReported,
+      this.typeImageUrl});
+  factory _RainbowLikeUserDto.fromJson(Map<String, dynamic> json) =>
+      _$RainbowLikeUserDtoFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  @YyyyMmDdDateConverter()
+  final DateTime birthDate;
+  @override
+  final Address address;
+  @override
+  final String mainPhotoUrl;
+  @override
+  final String message;
+  @override
+  final String? introduction;
+  @override
+  final bool? isTodayReported;
+  @override
+  final String? typeImageUrl;
+
+  /// Create a copy of RainbowLikeUserDto
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$RainbowLikeUserDtoCopyWith<_RainbowLikeUserDto> get copyWith =>
+      __$RainbowLikeUserDtoCopyWithImpl<_RainbowLikeUserDto>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$RainbowLikeUserDtoToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _RainbowLikeUserDto &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction) &&
+            (identical(other.isTodayReported, isTodayReported) ||
+                other.isTodayReported == isTodayReported) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, birthDate, address,
+      mainPhotoUrl, message, introduction, isTodayReported, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'RainbowLikeUserDto(id: $id, name: $name, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, message: $message, introduction: $introduction, isTodayReported: $isTodayReported, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$RainbowLikeUserDtoCopyWith<$Res>
+    implements $RainbowLikeUserDtoCopyWith<$Res> {
+  factory _$RainbowLikeUserDtoCopyWith(
+          _RainbowLikeUserDto value, $Res Function(_RainbowLikeUserDto) _then) =
+      __$RainbowLikeUserDtoCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      @YyyyMmDdDateConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      String message,
+      String? introduction,
+      bool? isTodayReported,
+      String? typeImageUrl});
+}
+
+/// @nodoc
+class __$RainbowLikeUserDtoCopyWithImpl<$Res>
+    implements _$RainbowLikeUserDtoCopyWith<$Res> {
+  __$RainbowLikeUserDtoCopyWithImpl(this._self, this._then);
+
+  final _RainbowLikeUserDto _self;
+  final $Res Function(_RainbowLikeUserDto) _then;
+
+  /// Create a copy of RainbowLikeUserDto
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? message = null,
+    Object? introduction = freezed,
+    Object? isTodayReported = freezed,
+    Object? typeImageUrl = freezed,
+  }) {
+    return _then(_RainbowLikeUserDto(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      introduction: freezed == introduction
+          ? _self.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isTodayReported: freezed == isTodayReported
+          ? _self.isTodayReported
+          : isTodayReported // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      typeImageUrl: freezed == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/data/dtos/rainbow_like_user_dto.g.dart
+++ b/reimi/frontend/reimi_app/lib/data/dtos/rainbow_like_user_dto.g.dart
@@ -1,0 +1,84 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rainbow_like_user_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RainbowLikeUserDto _$RainbowLikeUserDtoFromJson(Map<String, dynamic> json) =>
+    _RainbowLikeUserDto(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      birthDate: DateTime.parse(json['birthDate'] as String),
+      address: $enumDecode(_$AddressEnumMap, json['address']),
+      mainPhotoUrl: json['mainPhotoUrl'] as String,
+      message: json['message'] as String,
+      introduction: json['introduction'] as String?,
+      isTodayReported: json['isTodayReported'] as bool?,
+      typeImageUrl: json['typeImageUrl'] as String?,
+    );
+
+Map<String, dynamic> _$RainbowLikeUserDtoToJson(_RainbowLikeUserDto instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'birthDate': instance.birthDate.toIso8601String(),
+      'address': _$AddressEnumMap[instance.address]!,
+      'mainPhotoUrl': instance.mainPhotoUrl,
+      'message': instance.message,
+      'introduction': instance.introduction,
+      'isTodayReported': instance.isTodayReported,
+      'typeImageUrl': instance.typeImageUrl,
+    };
+
+const _$AddressEnumMap = {
+  Address.hokkaido: 'HOKKAIDO',
+  Address.aomori: 'AOMORI',
+  Address.iwate: 'IWATE',
+  Address.miyagi: 'MIYAGI',
+  Address.akita: 'AKITA',
+  Address.yamagata: 'YAMAGATA',
+  Address.fukushima: 'FUKUSHIMA',
+  Address.ibaraki: 'IBARAKI',
+  Address.tochigi: 'TOCHIGI',
+  Address.gunma: 'GUNMA',
+  Address.saitama: 'SAITAMA',
+  Address.chiba: 'CHIBA',
+  Address.tokyo: 'TOKYO',
+  Address.kanagawa: 'KANAGAWA',
+  Address.niigata: 'NIIGATA',
+  Address.toyama: 'TOYAMA',
+  Address.ishikawa: 'ISHIKAWA',
+  Address.fukui: 'FUKUI',
+  Address.yamanashi: 'YAMANASHI',
+  Address.nagano: 'NAGANO',
+  Address.gifu: 'GIFU',
+  Address.shizuoka: 'SHIZUOKA',
+  Address.aichi: 'AICHI',
+  Address.mie: 'MIE',
+  Address.shiga: 'SHIGA',
+  Address.kyoto: 'KYOTO',
+  Address.osaka: 'OSAKA',
+  Address.hyogo: 'HYOGO',
+  Address.nara: 'NARA',
+  Address.wakayama: 'WAKAYAMA',
+  Address.tottori: 'TOTTORI',
+  Address.shimane: 'SHIMANE',
+  Address.okayama: 'OKAYAMA',
+  Address.hiroshima: 'HIROSHIMA',
+  Address.yamaguchi: 'YAMAGUCHI',
+  Address.tokushima: 'TOKUSHIMA',
+  Address.kagawa: 'KAGAWA',
+  Address.ehime: 'EHIME',
+  Address.kochi: 'KOCHI',
+  Address.fukuoka: 'FUKUOKA',
+  Address.saga: 'SAGA',
+  Address.nagasaki: 'NAGASAKI',
+  Address.kumamoto: 'KUMAMOTO',
+  Address.oita: 'OITA',
+  Address.miyazaki: 'MIYAZAKI',
+  Address.kagoshima: 'KAGOSHIMA',
+  Address.okinawa: 'OKINAWA',
+  Address.other: 'OTHER',
+};

--- a/reimi/frontend/reimi_app/lib/data/http/dio_client.dart
+++ b/reimi/frontend/reimi_app/lib/data/http/dio_client.dart
@@ -7,9 +7,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'dio_client.g.dart';
 
+const baseUrl = String.fromEnvironment('baseUrl');
+
 @Riverpod(keepAlive: true)
 Dio dioClient(Ref ref) {
-  const baseUrl = String.fromEnvironment('baseUrl');
   final logger = ref.watch(appLoggerProvider);
 
   final dio = Dio(

--- a/reimi/frontend/reimi_app/lib/data/http/dio_client.g.dart
+++ b/reimi/frontend/reimi_app/lib/data/http/dio_client.g.dart
@@ -6,7 +6,7 @@ part of 'dio_client.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$dioClientHash() => r'35ac150e9f28b8787165aef1ba8242a92ee29841';
+String _$dioClientHash() => r'0ba98110462dab80ebb4260892eee0d942a64ae8';
 
 /// See also [dioClient].
 @ProviderFor(dioClient)

--- a/reimi/frontend/reimi_app/lib/data/mapper/create_user_mapper.dart
+++ b/reimi/frontend/reimi_app/lib/data/mapper/create_user_mapper.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+// ignore: depend_on_referenced_packages
 import 'package:path/path.dart' as p;
 import 'package:reimi_app/core/utils/yyyy_mm_dd_date_converter.dart';
 import 'package:reimi_app/data/dtos/create_user_dto.dart';

--- a/reimi/frontend/reimi_app/lib/data/mapper/rainbow_like_user_mapper.dart
+++ b/reimi/frontend/reimi_app/lib/data/mapper/rainbow_like_user_mapper.dart
@@ -1,0 +1,24 @@
+import 'package:reimi_app/data/dtos/rainbow_like_user_dto.dart';
+import 'package:reimi_app/domain/read_models/rainbow_like_user_read_model.dart';
+
+extension RainbowLikeUserDtoMapper on RainbowLikeUserDto {
+  RainbowLikeUserReadModel toReadModel() {
+    return RainbowLikeUserReadModel(
+      id: id,
+      name: name,
+      birthDate: birthDate,
+      address: address,
+      mainPhotoUrl: mainPhotoUrl,
+      introduction: introduction,
+      message: message,
+      isTodayReported: isTodayReported,
+      typeImageUrl: typeImageUrl,
+    );
+  }
+}
+
+extension RainbowLikeUserDtoListMapper on List<RainbowLikeUserDto> {
+  List<RainbowLikeUserReadModel> toReadModels() {
+    return map((dto) => dto.toReadModel()).toList();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/data/mapper/update_profile_mapper.dart
+++ b/reimi/frontend/reimi_app/lib/data/mapper/update_profile_mapper.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+// ignore: depend_on_referenced_packages
 import 'package:path/path.dart' as p;
 import 'package:reimi_app/data/dtos/update_profile_dto.dart';
 import 'package:reimi_app/domain/params/update_profile_params.dart';

--- a/reimi/frontend/reimi_app/lib/data/repositories/rainbow_like_repository_impl.dart
+++ b/reimi/frontend/reimi_app/lib/data/repositories/rainbow_like_repository_impl.dart
@@ -1,9 +1,23 @@
 import 'package:reimi_app/data/datasources/remote/rainbow_like_remote_datasource.dart';
+import 'package:reimi_app/data/mapper/rainbow_like_user_mapper.dart';
+import 'package:reimi_app/domain/read_models/rainbow_like_user_read_model.dart';
 import 'package:reimi_app/domain/repositories/rainbow_like_repository.dart';
 
 class RainbowLikeRepositoryImpl implements RainbowLikeRepository {
   const RainbowLikeRepositoryImpl(this._remote);
   final RainbowLikeRemoteDataSource _remote;
+
+  @override
+  Future<List<RainbowLikeUserReadModel>> fetchRainbowLikeUsersFromUser() async {
+    final dtos = await _remote.fetchRainbowLikeUsersFromUser();
+    return dtos.toReadModels();
+  }
+
+  @override
+  Future<List<RainbowLikeUserReadModel>> fetchRainbowLikeUsersToUser() async {
+    final dtos = await _remote.fetchRainbowLikeUsersToUser();
+    return dtos.toReadModels();
+  }
 
   @override
   Future<void> rainbowlikeUser({

--- a/reimi/frontend/reimi_app/lib/domain/read_models/like_user_item.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/like_user_item.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/core/utils/yyyy_mm_dd_date_converter.dart';
+import 'package:reimi_app/domain/value_objects/address.dart';
+
+part 'like_user_item.freezed.dart';
+
+@freezed
+abstract class LikeUserItem with _$LikeUserItem {
+  const factory LikeUserItem({
+    required String id,
+    required String name,
+    @YyyyMmDdDateConverter() required DateTime birthDate,
+    required Address address,
+    required String mainPhotoUrl,
+    String? message,
+    String? introduction,
+    bool? isTodayReported,
+    String? typeImageUrl,
+  }) = _LikeUserItem;
+
+  const LikeUserItem._();
+  /// レインボーいいねかどうか
+  bool get isRainbowLike => message != null && message!.isNotEmpty;
+}

--- a/reimi/frontend/reimi_app/lib/domain/read_models/like_user_item.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/like_user_item.freezed.dart
@@ -1,0 +1,520 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'like_user_item.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$LikeUserItem {
+  String get id;
+  String get name;
+  @YyyyMmDdDateConverter()
+  DateTime get birthDate;
+  Address get address;
+  String get mainPhotoUrl;
+  String? get message;
+  String? get introduction;
+  bool? get isTodayReported;
+  String? get typeImageUrl;
+
+  /// Create a copy of LikeUserItem
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $LikeUserItemCopyWith<LikeUserItem> get copyWith =>
+      _$LikeUserItemCopyWithImpl<LikeUserItem>(
+          this as LikeUserItem, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is LikeUserItem &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction) &&
+            (identical(other.isTodayReported, isTodayReported) ||
+                other.isTodayReported == isTodayReported) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, birthDate, address,
+      mainPhotoUrl, message, introduction, isTodayReported, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'LikeUserItem(id: $id, name: $name, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, message: $message, introduction: $introduction, isTodayReported: $isTodayReported, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $LikeUserItemCopyWith<$Res> {
+  factory $LikeUserItemCopyWith(
+          LikeUserItem value, $Res Function(LikeUserItem) _then) =
+      _$LikeUserItemCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      @YyyyMmDdDateConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      String? message,
+      String? introduction,
+      bool? isTodayReported,
+      String? typeImageUrl});
+}
+
+/// @nodoc
+class _$LikeUserItemCopyWithImpl<$Res> implements $LikeUserItemCopyWith<$Res> {
+  _$LikeUserItemCopyWithImpl(this._self, this._then);
+
+  final LikeUserItem _self;
+  final $Res Function(LikeUserItem) _then;
+
+  /// Create a copy of LikeUserItem
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? message = freezed,
+    Object? introduction = freezed,
+    Object? isTodayReported = freezed,
+    Object? typeImageUrl = freezed,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: freezed == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      introduction: freezed == introduction
+          ? _self.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isTodayReported: freezed == isTodayReported
+          ? _self.isTodayReported
+          : isTodayReported // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      typeImageUrl: freezed == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [LikeUserItem].
+extension LikeUserItemPatterns on LikeUserItem {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_LikeUserItem value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserItem() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_LikeUserItem value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserItem():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_LikeUserItem value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserItem() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String? message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserItem() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String? message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserItem():
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String? message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LikeUserItem() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _LikeUserItem extends LikeUserItem {
+  const _LikeUserItem(
+      {required this.id,
+      required this.name,
+      @YyyyMmDdDateConverter() required this.birthDate,
+      required this.address,
+      required this.mainPhotoUrl,
+      this.message,
+      this.introduction,
+      this.isTodayReported,
+      this.typeImageUrl})
+      : super._();
+
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  @YyyyMmDdDateConverter()
+  final DateTime birthDate;
+  @override
+  final Address address;
+  @override
+  final String mainPhotoUrl;
+  @override
+  final String? message;
+  @override
+  final String? introduction;
+  @override
+  final bool? isTodayReported;
+  @override
+  final String? typeImageUrl;
+
+  /// Create a copy of LikeUserItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$LikeUserItemCopyWith<_LikeUserItem> get copyWith =>
+      __$LikeUserItemCopyWithImpl<_LikeUserItem>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LikeUserItem &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction) &&
+            (identical(other.isTodayReported, isTodayReported) ||
+                other.isTodayReported == isTodayReported) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, birthDate, address,
+      mainPhotoUrl, message, introduction, isTodayReported, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'LikeUserItem(id: $id, name: $name, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, message: $message, introduction: $introduction, isTodayReported: $isTodayReported, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$LikeUserItemCopyWith<$Res>
+    implements $LikeUserItemCopyWith<$Res> {
+  factory _$LikeUserItemCopyWith(
+          _LikeUserItem value, $Res Function(_LikeUserItem) _then) =
+      __$LikeUserItemCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      @YyyyMmDdDateConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      String? message,
+      String? introduction,
+      bool? isTodayReported,
+      String? typeImageUrl});
+}
+
+/// @nodoc
+class __$LikeUserItemCopyWithImpl<$Res>
+    implements _$LikeUserItemCopyWith<$Res> {
+  __$LikeUserItemCopyWithImpl(this._self, this._then);
+
+  final _LikeUserItem _self;
+  final $Res Function(_LikeUserItem) _then;
+
+  /// Create a copy of LikeUserItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? message = freezed,
+    Object? introduction = freezed,
+    Object? isTodayReported = freezed,
+    Object? typeImageUrl = freezed,
+  }) {
+    return _then(_LikeUserItem(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: freezed == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      introduction: freezed == introduction
+          ? _self.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isTodayReported: freezed == isTodayReported
+          ? _self.isTodayReported
+          : isTodayReported // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      typeImageUrl: freezed == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/domain/read_models/rainbow_like_user_read_model.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/rainbow_like_user_read_model.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/core/utils/yyyy_mm_dd_date_converter.dart';
+import 'package:reimi_app/domain/value_objects/address.dart';
+
+part 'rainbow_like_user_read_model.freezed.dart';
+
+@freezed
+abstract class RainbowLikeUserReadModel with _$RainbowLikeUserReadModel {
+  const factory RainbowLikeUserReadModel({
+    required String id,
+    required String name,
+    @YyyyMmDdDateConverter() required DateTime birthDate,
+    required Address address,
+    required String mainPhotoUrl,
+    required String message,
+    String? introduction,
+    bool? isTodayReported,
+    String? typeImageUrl,
+  }) = _RainbowLikeUserReadModel;
+}

--- a/reimi/frontend/reimi_app/lib/domain/read_models/rainbow_like_user_read_model.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/rainbow_like_user_read_model.freezed.dart
@@ -1,0 +1,521 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'rainbow_like_user_read_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RainbowLikeUserReadModel {
+  String get id;
+  String get name;
+  @YyyyMmDdDateConverter()
+  DateTime get birthDate;
+  Address get address;
+  String get mainPhotoUrl;
+  String get message;
+  String? get introduction;
+  bool? get isTodayReported;
+  String? get typeImageUrl;
+
+  /// Create a copy of RainbowLikeUserReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $RainbowLikeUserReadModelCopyWith<RainbowLikeUserReadModel> get copyWith =>
+      _$RainbowLikeUserReadModelCopyWithImpl<RainbowLikeUserReadModel>(
+          this as RainbowLikeUserReadModel, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is RainbowLikeUserReadModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction) &&
+            (identical(other.isTodayReported, isTodayReported) ||
+                other.isTodayReported == isTodayReported) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, birthDate, address,
+      mainPhotoUrl, message, introduction, isTodayReported, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'RainbowLikeUserReadModel(id: $id, name: $name, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, message: $message, introduction: $introduction, isTodayReported: $isTodayReported, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $RainbowLikeUserReadModelCopyWith<$Res> {
+  factory $RainbowLikeUserReadModelCopyWith(RainbowLikeUserReadModel value,
+          $Res Function(RainbowLikeUserReadModel) _then) =
+      _$RainbowLikeUserReadModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      @YyyyMmDdDateConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      String message,
+      String? introduction,
+      bool? isTodayReported,
+      String? typeImageUrl});
+}
+
+/// @nodoc
+class _$RainbowLikeUserReadModelCopyWithImpl<$Res>
+    implements $RainbowLikeUserReadModelCopyWith<$Res> {
+  _$RainbowLikeUserReadModelCopyWithImpl(this._self, this._then);
+
+  final RainbowLikeUserReadModel _self;
+  final $Res Function(RainbowLikeUserReadModel) _then;
+
+  /// Create a copy of RainbowLikeUserReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? message = null,
+    Object? introduction = freezed,
+    Object? isTodayReported = freezed,
+    Object? typeImageUrl = freezed,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      introduction: freezed == introduction
+          ? _self.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isTodayReported: freezed == isTodayReported
+          ? _self.isTodayReported
+          : isTodayReported // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      typeImageUrl: freezed == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [RainbowLikeUserReadModel].
+extension RainbowLikeUserReadModelPatterns on RainbowLikeUserReadModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_RainbowLikeUserReadModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_RainbowLikeUserReadModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserReadModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_RainbowLikeUserReadModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserReadModel() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserReadModel():
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            String id,
+            String name,
+            @YyyyMmDdDateConverter() DateTime birthDate,
+            Address address,
+            String mainPhotoUrl,
+            String message,
+            String? introduction,
+            bool? isTodayReported,
+            String? typeImageUrl)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _RainbowLikeUserReadModel() when $default != null:
+        return $default(
+            _that.id,
+            _that.name,
+            _that.birthDate,
+            _that.address,
+            _that.mainPhotoUrl,
+            _that.message,
+            _that.introduction,
+            _that.isTodayReported,
+            _that.typeImageUrl);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _RainbowLikeUserReadModel implements RainbowLikeUserReadModel {
+  const _RainbowLikeUserReadModel(
+      {required this.id,
+      required this.name,
+      @YyyyMmDdDateConverter() required this.birthDate,
+      required this.address,
+      required this.mainPhotoUrl,
+      required this.message,
+      this.introduction,
+      this.isTodayReported,
+      this.typeImageUrl});
+
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  @YyyyMmDdDateConverter()
+  final DateTime birthDate;
+  @override
+  final Address address;
+  @override
+  final String mainPhotoUrl;
+  @override
+  final String message;
+  @override
+  final String? introduction;
+  @override
+  final bool? isTodayReported;
+  @override
+  final String? typeImageUrl;
+
+  /// Create a copy of RainbowLikeUserReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$RainbowLikeUserReadModelCopyWith<_RainbowLikeUserReadModel> get copyWith =>
+      __$RainbowLikeUserReadModelCopyWithImpl<_RainbowLikeUserReadModel>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _RainbowLikeUserReadModel &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.birthDate, birthDate) ||
+                other.birthDate == birthDate) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.mainPhotoUrl, mainPhotoUrl) ||
+                other.mainPhotoUrl == mainPhotoUrl) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.introduction, introduction) ||
+                other.introduction == introduction) &&
+            (identical(other.isTodayReported, isTodayReported) ||
+                other.isTodayReported == isTodayReported) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, birthDate, address,
+      mainPhotoUrl, message, introduction, isTodayReported, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'RainbowLikeUserReadModel(id: $id, name: $name, birthDate: $birthDate, address: $address, mainPhotoUrl: $mainPhotoUrl, message: $message, introduction: $introduction, isTodayReported: $isTodayReported, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$RainbowLikeUserReadModelCopyWith<$Res>
+    implements $RainbowLikeUserReadModelCopyWith<$Res> {
+  factory _$RainbowLikeUserReadModelCopyWith(_RainbowLikeUserReadModel value,
+          $Res Function(_RainbowLikeUserReadModel) _then) =
+      __$RainbowLikeUserReadModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      @YyyyMmDdDateConverter() DateTime birthDate,
+      Address address,
+      String mainPhotoUrl,
+      String message,
+      String? introduction,
+      bool? isTodayReported,
+      String? typeImageUrl});
+}
+
+/// @nodoc
+class __$RainbowLikeUserReadModelCopyWithImpl<$Res>
+    implements _$RainbowLikeUserReadModelCopyWith<$Res> {
+  __$RainbowLikeUserReadModelCopyWithImpl(this._self, this._then);
+
+  final _RainbowLikeUserReadModel _self;
+  final $Res Function(_RainbowLikeUserReadModel) _then;
+
+  /// Create a copy of RainbowLikeUserReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? birthDate = null,
+    Object? address = null,
+    Object? mainPhotoUrl = null,
+    Object? message = null,
+    Object? introduction = freezed,
+    Object? isTodayReported = freezed,
+    Object? typeImageUrl = freezed,
+  }) {
+    return _then(_RainbowLikeUserReadModel(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      birthDate: null == birthDate
+          ? _self.birthDate
+          : birthDate // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Address,
+      mainPhotoUrl: null == mainPhotoUrl
+          ? _self.mainPhotoUrl
+          : mainPhotoUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      introduction: freezed == introduction
+          ? _self.introduction
+          : introduction // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isTodayReported: freezed == isTodayReported
+          ? _self.isTodayReported
+          : isTodayReported // ignore: cast_nullable_to_non_nullable
+              as bool?,
+      typeImageUrl: freezed == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/domain/repositories/rainbow_like_repository.dart
+++ b/reimi/frontend/reimi_app/lib/domain/repositories/rainbow_like_repository.dart
@@ -1,4 +1,8 @@
+import 'package:reimi_app/domain/read_models/rainbow_like_user_read_model.dart';
+
 abstract class RainbowLikeRepository {
+  Future<List<RainbowLikeUserReadModel>> fetchRainbowLikeUsersFromUser();
+  Future<List<RainbowLikeUserReadModel>> fetchRainbowLikeUsersToUser();
   Future<void> rainbowlikeUser({
     required String userId,
     required String message,

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/like_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/like_page.dart
@@ -6,7 +6,7 @@ import 'package:reimi_app/core/i18n/strings.g.dart';
 import 'package:reimi_app/presentation/features/like/notifiers/like_notifier.dart';
 import 'package:reimi_app/presentation/features/like/states/like_state.dart';
 import 'package:reimi_app/presentation/features/like/widgets/like_segment_switch.dart';
-import 'package:reimi_app/presentation/features/like/widgets/small_user_card.dart';
+import 'package:reimi_app/presentation/features/like/widgets/like_user_card.dart';
 import 'package:reimi_app/presentation/features/profile/pages/profile_detail_page.dart';
 import 'package:reimi_app/presentation/shared/widgets/app_snack_bar.dart';
 import 'package:reimi_app/presentation/shared/widgets/background_container_noon.dart';
@@ -100,7 +100,7 @@ class LikePage extends HookConsumerWidget {
                             ),
                             child: FadeTransition(
                               opacity: mainController,
-                              child: SmallUserCard(
+                              child: LikeUserCard(
                                 user: users[index],
                                 onTap: () {
                                   context.push(

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/mapper/like_user_mapper.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/mapper/like_user_mapper.dart
@@ -1,0 +1,17 @@
+import 'package:reimi_app/domain/read_models/like_user_item.dart';
+import 'package:reimi_app/domain/read_models/like_user_read_model.dart';
+
+extension LikeUserReadModelMapper on LikeUserReadModel {
+  LikeUserItem toLikeUserItem() {
+    return LikeUserItem(
+      id: id,
+      name: name,
+      birthDate: birthDate,
+      address: address,
+      mainPhotoUrl: mainPhotoUrl,
+      introduction: introduction,
+      isTodayReported: isTodayReported,
+      typeImageUrl: typeImageUrl,
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/mapper/rainbow_like_user_mapper.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/mapper/rainbow_like_user_mapper.dart
@@ -1,0 +1,18 @@
+import 'package:reimi_app/domain/read_models/like_user_item.dart';
+import 'package:reimi_app/domain/read_models/rainbow_like_user_read_model.dart';
+
+extension RainbowLikeUserReadModelMapper on RainbowLikeUserReadModel {
+  LikeUserItem toLikeUserItem() {
+    return LikeUserItem(
+      id: id,
+      name: name,
+      birthDate: birthDate,
+      address: address,
+      mainPhotoUrl: mainPhotoUrl,
+      message: message,
+      introduction: introduction,
+      isTodayReported: isTodayReported,
+      typeImageUrl: typeImageUrl,
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_notifier.dart
@@ -1,5 +1,8 @@
 import 'package:reimi_app/core/di/usecase_providers.dart';
+import 'package:reimi_app/domain/read_models/like_user_item.dart';
 import 'package:reimi_app/presentation/features/like/enum/like_segment.dart';
+import 'package:reimi_app/presentation/features/like/mapper/like_user_mapper.dart';
+import 'package:reimi_app/presentation/features/like/mapper/rainbow_like_user_mapper.dart';
 import 'package:reimi_app/presentation/features/like/states/like_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -31,11 +34,9 @@ class LikeNotifier extends _$LikeNotifier {
   Future<void> loadLikeUsers(LikeSegment segment) async {
     state = state.copyWith(isLoading: true, errorMessage: null);
     try {
-      final users = await switch (segment) {
-        LikeSegment.fromUser =>
-          ref.read(getLikeUsersFromUserUseCaseProvider).call(),
-        LikeSegment.toUser =>
-          ref.read(getLikeUsersToUserUseCaseProvider).call(),
+      final users = switch (segment) {
+        LikeSegment.fromUser => await _loadFromUserLikeUsers(),
+        LikeSegment.toUser => await _loadToUserLikeUsers(),
       };
       state = state.copyWith(
         users: users,
@@ -47,6 +48,39 @@ class LikeNotifier extends _$LikeNotifier {
         errorMessage: e.toString(),
       );
     }
+  }
+
+  Future<List<LikeUserItem>> _loadFromUserLikeUsers() async {
+    final likeUsers =
+        await ref.read(getLikeUsersFromUserUseCaseProvider).call();
+    final rainbowLikeUsers =
+        await ref.read(getRainbowLikeUsersFromUserUseCaseProvider).call();
+
+    final normalLikes = likeUsers.map((e) => e.toLikeUserItem()).toList();
+    final rainbowLikes =
+        rainbowLikeUsers.map((e) => e.toLikeUserItem()).toList();
+
+    final merged = <LikeUserItem>[
+      ...rainbowLikes,
+      ...normalLikes,
+    ];
+    return merged;
+  }
+
+  Future<List<LikeUserItem>> _loadToUserLikeUsers() async {
+    final likeUsers = await ref.read(getLikeUsersToUserUseCaseProvider).call();
+    final rainbowLikeUsers =
+        await ref.read(getRainbowLikeUsersToUserUseCaseProvider).call();
+
+    final normalLikes = likeUsers.map((e) => e.toLikeUserItem()).toList();
+    final rainbowLikes =
+        rainbowLikeUsers.map((e) => e.toLikeUserItem()).toList();
+
+    final merged = <LikeUserItem>[
+      ...rainbowLikes,
+      ...normalLikes,
+    ];
+    return merged;
   }
 
   Future<void> refresh() async {

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/notifiers/like_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'like_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$likeNotifierHash() => r'a4ec2d18f251978fd112cc8421397669e5d69e9c';
+String _$likeNotifierHash() => r'e72eae577cfabf470b5e40860580b82b290489a6';
 
 /// See also [LikeNotifier].
 @ProviderFor(LikeNotifier)

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/states/like_state.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/states/like_state.dart
@@ -1,5 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:reimi_app/domain/read_models/like_user_read_model.dart';
+import 'package:reimi_app/domain/read_models/like_user_item.dart';
 import 'package:reimi_app/presentation/features/like/enum/like_segment.dart';
 
 part 'like_state.freezed.dart';
@@ -7,7 +7,7 @@ part 'like_state.freezed.dart';
 @freezed
 abstract class LikeState with _$LikeState {
   const factory LikeState({
-    @Default(<LikeUserReadModel>[]) List<LikeUserReadModel> users,
+    @Default(<LikeUserItem>[]) List<LikeUserItem> users,
     @Default(LikeSegment.fromUser) LikeSegment segment,
     @Default(false) bool isLoading,
     String? errorMessage,

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/states/like_state.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/states/like_state.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$LikeState {
-  List<LikeUserReadModel> get users;
+  List<LikeUserItem> get users;
   LikeSegment get segment;
   bool get isLoading;
   String? get errorMessage;
@@ -59,7 +59,7 @@ abstract mixin class $LikeStateCopyWith<$Res> {
       _$LikeStateCopyWithImpl;
   @useResult
   $Res call(
-      {List<LikeUserReadModel> users,
+      {List<LikeUserItem> users,
       LikeSegment segment,
       bool isLoading,
       String? errorMessage});
@@ -86,7 +86,7 @@ class _$LikeStateCopyWithImpl<$Res> implements $LikeStateCopyWith<$Res> {
       users: null == users
           ? _self.users
           : users // ignore: cast_nullable_to_non_nullable
-              as List<LikeUserReadModel>,
+              as List<LikeUserItem>,
       segment: null == segment
           ? _self.segment
           : segment // ignore: cast_nullable_to_non_nullable
@@ -196,7 +196,7 @@ extension LikeStatePatterns on LikeState {
 
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>(
-    TResult Function(List<LikeUserReadModel> users, LikeSegment segment,
+    TResult Function(List<LikeUserItem> users, LikeSegment segment,
             bool isLoading, String? errorMessage)?
         $default, {
     required TResult orElse(),
@@ -226,7 +226,7 @@ extension LikeStatePatterns on LikeState {
 
   @optionalTypeArgs
   TResult when<TResult extends Object?>(
-    TResult Function(List<LikeUserReadModel> users, LikeSegment segment,
+    TResult Function(List<LikeUserItem> users, LikeSegment segment,
             bool isLoading, String? errorMessage)
         $default,
   ) {
@@ -254,7 +254,7 @@ extension LikeStatePatterns on LikeState {
 
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(List<LikeUserReadModel> users, LikeSegment segment,
+    TResult? Function(List<LikeUserItem> users, LikeSegment segment,
             bool isLoading, String? errorMessage)?
         $default,
   ) {
@@ -273,16 +273,16 @@ extension LikeStatePatterns on LikeState {
 
 class _LikeState implements LikeState {
   const _LikeState(
-      {final List<LikeUserReadModel> users = const <LikeUserReadModel>[],
+      {final List<LikeUserItem> users = const <LikeUserItem>[],
       this.segment = LikeSegment.fromUser,
       this.isLoading = false,
       this.errorMessage})
       : _users = users;
 
-  final List<LikeUserReadModel> _users;
+  final List<LikeUserItem> _users;
   @override
   @JsonKey()
-  List<LikeUserReadModel> get users {
+  List<LikeUserItem> get users {
     if (_users is EqualUnmodifiableListView) return _users;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_users);
@@ -341,7 +341,7 @@ abstract mixin class _$LikeStateCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {List<LikeUserReadModel> users,
+      {List<LikeUserItem> users,
       LikeSegment segment,
       bool isLoading,
       String? errorMessage});
@@ -368,7 +368,7 @@ class __$LikeStateCopyWithImpl<$Res> implements _$LikeStateCopyWith<$Res> {
       users: null == users
           ? _self._users
           : users // ignore: cast_nullable_to_non_nullable
-              as List<LikeUserReadModel>,
+              as List<LikeUserItem>,
       segment: null == segment
           ? _self.segment
           : segment // ignore: cast_nullable_to_non_nullable

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/like_user_card.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/like_user_card.dart
@@ -1,19 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:line_icons/line_icons.dart';
 import 'package:reimi_app/core/extensions/datetime_extensions.dart';
 import 'package:reimi_app/core/extensions/image_path_extension.dart';
 import 'package:reimi_app/core/extensions/value_objects/address_extension.dart';
-import 'package:reimi_app/domain/read_models/like_user_read_model.dart';
+import 'package:reimi_app/core/theme/custom_colors.dart';
+import 'package:reimi_app/domain/read_models/like_user_item.dart';
 import 'package:reimi_app/gen/assets.gen.dart';
 import 'package:reimi_app/presentation/features/home/widgets/circle_badge.dart';
+import 'package:reimi_app/presentation/features/like/widgets/show_message_dialog.dart';
 
-class SmallUserCard extends StatelessWidget {
-  const SmallUserCard({
+class LikeUserCard extends StatelessWidget {
+  const LikeUserCard({
     super.key,
     required this.user,
     required this.onTap,
   });
 
-  final LikeUserReadModel user;
+  final LikeUserItem user;
   final void Function()? onTap;
 
   @override
@@ -23,8 +26,11 @@ class SmallUserCard extends StatelessWidget {
       onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
-          color: const Color(0xFFDDF5FB),
+          color: user.isRainbowLike ? null : const Color(0xFFDDF5FB),
           borderRadius: BorderRadius.circular(20),
+          gradient: user.isRainbowLike
+              ? earthToneRainbowLinearGradient.withOpacity(0.6)
+              : null,
         ),
         padding: const EdgeInsets.all(12),
         child: Column(
@@ -48,9 +54,32 @@ class SmallUserCard extends StatelessWidget {
                         ),
                       ),
                     ),
+                    if (user.isRainbowLike) ...[
+                      Positioned(
+                        top: 5,
+                        right: 5,
+                        child: CircleBadge(
+                          color: Colors.white.withValues(alpha: 0.8),
+                          size: 40,
+                          child: GestureDetector(
+                            onTap: () async {
+                              await showMessageDialog(
+                                context: context,
+                                user: user,
+                              );
+                            },
+                            child: const Icon(
+                              LineIcons.envelope,
+                              size: 28,
+                              color: Colors.black87,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                     Positioned(
-                      top: 5,
-                      right: 5,
+                      bottom: 6,
+                      right: 6,
                       child: CircleBadge(
                         color: Colors.white.withValues(alpha: 0.8),
                         size: 48,
@@ -69,35 +98,6 @@ class SmallUserCard extends StatelessWidget {
                               fit: BoxFit.cover,
                             ),
                           ),
-                        ),
-                      ),
-                    ),
-                    Positioned(
-                      bottom: 7,
-                      right: 7,
-                      child: CircleBadge(
-                        color: theme.colorScheme.secondary,
-                        size: 40,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.end,
-                          children: [
-                            Text(
-                              '99',
-                              style: theme.textTheme.labelSmall!.copyWith(
-                                fontSize: 13,
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            Text(
-                              '%',
-                              style: theme.textTheme.labelSmall!.copyWith(
-                                fontSize: 10,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
                         ),
                       ),
                     ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/show_message_dialog.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/like/widgets/show_message_dialog.dart
@@ -1,0 +1,122 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:line_icons/line_icons.dart';
+import 'package:reimi_app/core/extensions/image_path_extension.dart';
+import 'package:reimi_app/core/i18n/strings.g.dart';
+import 'package:reimi_app/domain/read_models/like_user_item.dart';
+
+Future<void> showMessageDialog({
+  required BuildContext context,
+  required LikeUserItem user,
+}) async {
+  return showDialog(
+    context: context,
+    barrierDismissible: true,
+    barrierColor: Theme.of(context).colorScheme.primary.withValues(alpha: 0.55),
+    builder: (_) => MessageDialog(user: user),
+  );
+}
+
+class MessageDialog extends StatelessWidget {
+  const MessageDialog({
+    super.key,
+    required this.user,
+  });
+  final LikeUserItem user;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return BackdropFilter(
+      filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+      child: Center(
+        child: Stack(
+          clipBehavior: Clip.none,
+          alignment: Alignment.topCenter,
+          children: [
+            Container(
+              width: MediaQuery.of(context).size.width * 0.85,
+              padding: const EdgeInsets.fromLTRB(20, 56, 20, 20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    t.dialog.likeMessage.title,
+                    style: theme.textTheme.titleMedium!.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Divider(
+                          color:
+                              theme.colorScheme.primary.withValues(alpha: 0.6),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Icon(LineIcons.handPointingDown,
+                          color: theme.colorScheme.primary, size: 22),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Divider(
+                          color:
+                              theme.colorScheme.primary.withValues(alpha: 0.6),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    user.message ?? t.dialog.likeMessage.nullCase,
+                    style: theme.textTheme.bodyMedium!.copyWith(
+                      height: 1.6,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  GestureDetector(
+                    onTap: () => Navigator.of(context).pop(),
+                    child: Column(
+                      children: [
+                        const Icon(
+                          Icons.close,
+                          color: Colors.black87,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          t.button.close,
+                          style: theme.textTheme.bodySmall!
+                              .copyWith(color: Colors.black87),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              top: -36,
+              child: CircleAvatar(
+                radius: 36,
+                backgroundColor: Colors.white,
+                child: CircleAvatar(
+                  radius: 32,
+                  backgroundImage: user.mainPhotoUrl.toImageProvider(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/matching/notifiers/ai_matching_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/matching/notifiers/ai_matching_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'ai_matching_notifier.dart';
 // **************************************************************************
 
 String _$aIMatchingNotifierHash() =>
-    r'271b35d907e9ce5fafa810ff8147f397bab9ec08';
+    r'488fa88ad76114c1e5c97e452bac20a7aa98e666';
 
 /// See also [AIMatchingNotifier].
 @ProviderFor(AIMatchingNotifier)


### PR DESCRIPTION
## 対応Issue

- #162

close #162

## 対応したこと

<!-- このプルリクで何をしたのか記述する -->

- core
  - di
    - レインボーいいねユーザー一覧取得系のユースケースのdi追加
    
- data
  - datasource
    - レインボーいいねユーザー一覧取得系のメソッド追加、モックデータでテスト
    - レインボーいいねユーザー一覧取得系のapiを叩く処理を実装
  - dto
    - レインボーいいねユーザーを取得する時に使用するDto実装
  - mapper
    - レインボーいいねユーザー取得のDtoをReadモデルに変換するMapper作成 
  - repository
    - レインボーいいねユーザー一覧取得系のメソッド追加  
- domain
  - read_model
    - レインボーいいねユーザーを取得する時に使用するReadモデル実装
    - いいねユーザーとレインボーいいねユーザーをまとめて表示する時に使用するモデル実装 
  - repository
    - レインボーいいねユーザー一覧取得系のメソッド追加    
- application
  - usecase
    -レインボーいいねされたユーザー一覧取得のユースケース実装
    - レインボーいいねしたユーザー一覧取得のユースケース実装
 
- presentation
  - like
    - notifier
      - いいねユーザー一覧とレインボーいいねユーザー一覧をまとめて表示させる処理を実装、レインボーいいねユーザーの方が優先的に表示される
    - widget
      - いいねユーザーを表示するカードウィジェットであることがわかりやすいように、ファイル名修正、いいねとレインボーいいねでデザイン変更
      - レインボーいいねした・された場合のメッセージ内容を表示するダイアログ実装   
    - mapper
      - いいねユーザーとレインボーいいねユーザー一覧をまとめて表示させるモデルに変換するMapper作成


## 参考資料
<!-- 参考にした資料のリンクを貼る -->

## 対応しきれなかったこと

<!-- 修正が必要そうな部分や別チケットで解決したい部分をあげる -->

## 画面キャプチャ

<!-- 実装前と実装後でどう変わったかわかるキャプチャを貼る -->

| 動作確認 | いいねメッセージダイアログ |
| -- | -- |
| <img width="200" alt="Simulator Screenshot - iPhone 16e - 2026-02-11 at 00 54 56" src="https://github.com/user-attachments/assets/3d45afaf-04b5-43d1-b857-78bd5a09fdae" /> | <img width="200" alt="Simulator Screenshot - iPhone 16e - 2026-02-11 at 00 54 49" src="https://github.com/user-attachments/assets/06c11a03-2ae3-46b6-8f41-124afc15a291" /> |