### PR TITLE
【API修正】未診断ユーザーのアカウント設定表示（/users/me/account）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/ItemUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/ItemUseCaseImpl.java
@@ -77,14 +77,16 @@ public class ItemUseCaseImpl implements ItemUseCase {
             items.put(code, userItem.getQuantity());
         });
 
-        UserWeatherPersonalityType userType = userWeatherPersonalityTypeRepository.findByUserId(userId)
-            .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティ診断結果"));
-
-        String typeImageUrl = imageUrlResolver.resolve(
-                userType.getWeatherPersonalityType().getImagePath()
-            );
-
-        userType.getWeatherPersonalityType().setTypeImageUrl(typeImageUrl);
+        UserWeatherPersonalityType userType =
+            userWeatherPersonalityTypeRepository.findByUserId(userId)
+                .map(type -> {
+                    String typeImageUrl = imageUrlResolver.resolve(
+                        type.getWeatherPersonalityType().getImagePath()
+                    );
+                    type.getWeatherPersonalityType().setTypeImageUrl(typeImageUrl);
+                    return type;
+                })
+                .orElse(null);
 
         user.setSignedMainPhotoUrl(imageStorage.getSignedUrl(user.getMainPhotoUrl()));
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/ItemController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/ItemController.java
@@ -1,5 +1,7 @@
 package com.reimi.reimi_app.infrastructure.web.controller.v1;
 
+import java.util.Optional;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,17 +31,22 @@ public class ItemController {
 
         UserItemOutput output = itemUseCase.getUserItemList();
 
-        var userType =
-            output.userWeatherPersonalityType().getWeatherPersonalityType();
+        var optionalUserType =
+            Optional.ofNullable(output.userWeatherPersonalityType())
+                .map(type -> type.getWeatherPersonalityType());
+
+        String typeCode = optionalUserType.map(type -> type.getCode().name()).orElse(null);
+        String typeName = optionalUserType.map(type -> type.getName()).orElse(null);
+        String typeImageUrl = optionalUserType.map(type -> type.getTypeImageUrl()).orElse(null);
 
         UserAccountDetailResponse response =
             new UserAccountDetailResponse(
                 output.userId().value(),
                 output.name(),
                 output.mainPhotoUrl(),
-                userType.getCode(),
-                userType.getName(),
-                userType.getTypeImageUrl(),
+                typeCode,
+                typeName,
+                typeImageUrl,
                 output.items()
             );
 

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/UserAccountDetailResponse.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/dto/response/UserAccountDetailResponse.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.reimi.reimi_app.domain.model.item.ItemTypeCode;
-import com.reimi.reimi_app.domain.model.weatherpersonality.WeatherPersonalityCode;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -21,7 +20,7 @@ public record UserAccountDetailResponse (
         String mainPhotoUrl,
 
         @Schema(description = "タイプコード", example = "SPOE")
-        WeatherPersonalityCode typeCode,
+        String typeCode,
 
         @Schema(description = "タイプ名", example = "トレーニーラッコ")
         String typeName,


### PR DESCRIPTION
## 概要

修正するAPI名：ユーザーのアカウント詳細情報取得

種別：API修正

関連Issue：

- #176 

close #176 


## 修正内容

### 【修正理由】

- まだウェザーパーソナリティ診断をしていないユーザーがアカウント設定画面を表示できるようにするため

### 【やったこと・開発メモ】

- 未診断のユーザーの場合、表示するウェザーパーソナリティタイプの値をnullにする
  - タイプ名
  - タイプコード
  - タイプイメージ画像

### 【追加・変更した設定ファイル】

- 変更したファイル
  - reimi_app/infrastructure/service/ItemUseCaseImpl.java
  - reimi_app/infrastructure/web/controller/v1/ItemController.java
  - reimi_app/infrastructure/web/dto/response/UserAccountDetailResponse.java