### PR TITLE
【UI】ウェザーパーソナリティタイプ一覧が見れる画面のUI実装

### DIFF
--- a/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_character_detail_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_character_detail_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:reimi_app/domain/read_models/weather_personality_character_detail_read_model.dart';
+import 'package:reimi_app/domain/repositories/weather_personality_repository.dart';
+
+class GetWeatherPersonalityCharacterDetailUseCase {
+  const GetWeatherPersonalityCharacterDetailUseCase(this._repository);
+  final WeatherPersonalityRepository _repository;
+
+  Future<WeatherPersonalityCharacterDetailReadModel> call() {
+    return _repository.fetchWeatherPersonalityCharacter();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_characters_usecase.dart
+++ b/reimi/frontend/reimi_app/lib/application/usecases/weather_personality/get_weather_personality_characters_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:reimi_app/domain/read_models/weather_personality_character_read_model.dart';
+import 'package:reimi_app/domain/repositories/weather_personality_repository.dart';
+
+class GetWeatherPersonalityCharactersUseCase {
+  const GetWeatherPersonalityCharactersUseCase(this._repository);
+  final WeatherPersonalityRepository _repository;
+
+  Future<List<WeatherPersonalityCharacterReadModel>> call() {
+    return _repository.fetchWeatherPersonalityCharacters();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/core/di/usecase_providers.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/usecase_providers.dart
@@ -11,6 +11,8 @@ import 'package:reimi_app/application/usecases/rainbow_like/rainbow_like_user_us
 import 'package:reimi_app/application/usecases/session/get_current_user_state_usecase.dart';
 import 'package:reimi_app/application/usecases/like/get_like_users_to_user_usecase.dart';
 import 'package:reimi_app/application/usecases/user/get_user_account_usecase.dart';
+import 'package:reimi_app/application/usecases/weather_personality/get_weather_personality_character_detail_usecase.dart';
+import 'package:reimi_app/application/usecases/weather_personality/get_weather_personality_characters_usecase.dart';
 import 'package:reimi_app/application/usecases/weather_personality/get_weather_personality_detail_usecase.dart';
 import 'package:reimi_app/application/usecases/weather_personality/get_weather_personality_result_usecase.dart';
 import 'package:reimi_app/application/usecases/weather_personality/test_weather_personality_usecase.dart';
@@ -180,6 +182,25 @@ GetWeatherPersonalityResultUseCase getWeatherPersonalityResultUseCase(Ref ref) {
 GetWeatherPersonalityDetailUseCase getWeatherPersonalityDetailUseCase(Ref ref) {
   return GetWeatherPersonalityDetailUseCase(
       ref.watch(weatherPersonalityRepositoryProvider));
+}
+
+@riverpod
+GetWeatherPersonalityCharactersUseCase getWeatherPersonalityCharactersUseCase(
+  Ref ref,
+) {
+  return GetWeatherPersonalityCharactersUseCase(
+    ref.watch(weatherPersonalityRepositoryProvider),
+  );
+}
+
+@riverpod
+GetWeatherPersonalityCharacterDetailUseCase
+    getWeatherPersonalityCharacterDetailUseCase(
+  Ref ref,
+) {
+  return GetWeatherPersonalityCharacterDetailUseCase(
+    ref.watch(weatherPersonalityRepositoryProvider),
+  );
 }
 
 // notification関連

--- a/reimi/frontend/reimi_app/lib/core/di/usecase_providers.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/di/usecase_providers.g.dart
@@ -518,6 +518,46 @@ final getWeatherPersonalityDetailUseCaseProvider =
 // ignore: unused_element
 typedef GetWeatherPersonalityDetailUseCaseRef
     = AutoDisposeProviderRef<GetWeatherPersonalityDetailUseCase>;
+String _$getWeatherPersonalityCharactersUseCaseHash() =>
+    r'2246e48d5ec53191bbd4dc47bcfabcff1955dbb7';
+
+/// See also [getWeatherPersonalityCharactersUseCase].
+@ProviderFor(getWeatherPersonalityCharactersUseCase)
+final getWeatherPersonalityCharactersUseCaseProvider =
+    AutoDisposeProvider<GetWeatherPersonalityCharactersUseCase>.internal(
+  getWeatherPersonalityCharactersUseCase,
+  name: r'getWeatherPersonalityCharactersUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getWeatherPersonalityCharactersUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetWeatherPersonalityCharactersUseCaseRef
+    = AutoDisposeProviderRef<GetWeatherPersonalityCharactersUseCase>;
+String _$getWeatherPersonalityCharacterDetailUseCaseHash() =>
+    r'7af9c4534ed195f7c0aabdc83fafc3b1d6b26a43';
+
+/// See also [getWeatherPersonalityCharacterDetailUseCase].
+@ProviderFor(getWeatherPersonalityCharacterDetailUseCase)
+final getWeatherPersonalityCharacterDetailUseCaseProvider =
+    AutoDisposeProvider<GetWeatherPersonalityCharacterDetailUseCase>.internal(
+  getWeatherPersonalityCharacterDetailUseCase,
+  name: r'getWeatherPersonalityCharacterDetailUseCaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getWeatherPersonalityCharacterDetailUseCaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef GetWeatherPersonalityCharacterDetailUseCaseRef
+    = AutoDisposeProviderRef<GetWeatherPersonalityCharacterDetailUseCase>;
 String _$registerDeviceTokenUseCaseHash() =>
     r'cab4f58254f0ad029a5a990eef104ee3a82e5c87';
 

--- a/reimi/frontend/reimi_app/lib/core/i18n/en.i18n.json
+++ b/reimi/frontend/reimi_app/lib/core/i18n/en.i18n.json
@@ -203,7 +203,11 @@
     }
   },
   "accountPage": {
-    "nullCase": "User information could not be obtained."
+    "nullCase": "User information could not be obtained.",
+    "items": {
+      "aboutTest": "What is the Weather Personality Test?",
+      "seeAllCharacters": "See all characters"
+    }
   },
   "profilePage": {
     "title": "Edit Profile",
@@ -279,6 +283,14 @@
   "profileDetailPage": {
     "title": "Profile Details",
     "nullCase": "Profile information could not be retrieved."
+  },
+  "weatherPersonalityCharactersIntroductionPage": {
+    "title": "Character Introduction",
+    "isEmptyCase": "Character information could not be obtained."
+  },
+    "weatherPersonalityCharacterDetailPage": {
+    "title": "Character Details",
+    "nullCase": "Character details could not be obtained."
   },
   "weatherPersonalityConceptPage": {
     "title": "Weather Personality Assessment",
@@ -651,7 +663,8 @@
     "retest": "Re-test",
     "suggestGoOut": "Suggest An Outing",
     "return": "Return",
-    "confirmWeatherNews": "Confirm Weather News"
+    "confirmWeatherNews": "Confirm Weather News",
+    "seeDetails": "See Details"
   },
   "segmentedSwitch": {
     "like": {

--- a/reimi/frontend/reimi_app/lib/core/i18n/ja.i18n.json
+++ b/reimi/frontend/reimi_app/lib/core/i18n/ja.i18n.json
@@ -203,7 +203,11 @@
     }
   },
   "accountPage": {
-    "nullCase": "ユーザー情報が取得できませんでした。"
+    "nullCase": "ユーザー情報が取得できませんでした。",
+    "items": {
+      "aboutTest": "ウェザーパーソナリティ診断とは？",
+      "seeAllCharacters": "すべてのキャラクターを見る"
+    }
   },
   "profilePage": {
     "title": "プロフィール編集",
@@ -279,6 +283,14 @@
   "profileDetailPage": {
     "title": "プロフィール詳細",
     "nullCase": "プロフィール情報が取得できませんでした。"
+  },
+  "weatherPersonalityCharactersIntroductionPage": {
+    "title": "キャラクター紹介",
+    "isEmptyCase": "キャラクター情報が取得できませんでした。"
+  },
+    "weatherPersonalityCharacterDetailPage": {
+    "title": "キャラクター詳細",
+    "nullCase": "キャラクター詳細情報が取得できませんでした。"
   },
   "weatherPersonalityConceptPage": {
     "title": "ウェザーパーソナリティ診断",
@@ -651,7 +663,8 @@
     "retest": "再診断",
     "suggestGoOut": "この内容でおでかけ提案する",
     "return": "戻る",
-    "confirmWeatherNews": "ウェザーニュースで詳しく見る"
+    "confirmWeatherNews": "ウェザーニュースで詳しく見る",
+    "seeDetails": "詳しく見る"
   },
   "segmentedSwitch": {
     "like": {

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 1278 (639 per locale)
+/// Strings: 1292 (646 per locale)
 ///
-/// Built on 2026-02-15 at 07:46 UTC
+/// Built on 2026-02-15 at 13:15 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings_en.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings_en.g.dart
@@ -67,6 +67,8 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsAccountPageEn accountPage = TranslationsAccountPageEn._(_root);
 	late final TranslationsProfilePageEn profilePage = TranslationsProfilePageEn._(_root);
 	late final TranslationsProfileDetailPageEn profileDetailPage = TranslationsProfileDetailPageEn._(_root);
+	late final TranslationsWeatherPersonalityCharactersIntroductionPageEn weatherPersonalityCharactersIntroductionPage = TranslationsWeatherPersonalityCharactersIntroductionPageEn._(_root);
+	late final TranslationsWeatherPersonalityCharacterDetailPageEn weatherPersonalityCharacterDetailPage = TranslationsWeatherPersonalityCharacterDetailPageEn._(_root);
 	late final TranslationsWeatherPersonalityConceptPageEn weatherPersonalityConceptPage = TranslationsWeatherPersonalityConceptPageEn._(_root);
 	late final TranslationsWeatherPersonalityDetailPageEn weatherPersonalityDetailPage = TranslationsWeatherPersonalityDetailPageEn._(_root);
 	late final TranslationsWeatherPersonalityTestJudgingPageEn weatherPersonalityTestJudgingPage = TranslationsWeatherPersonalityTestJudgingPageEn._(_root);
@@ -422,6 +424,8 @@ class TranslationsAccountPageEn {
 
 	/// en: 'User information could not be obtained.'
 	String get nullCase => 'User information could not be obtained.';
+
+	late final TranslationsAccountPageItemsEn items = TranslationsAccountPageItemsEn._(_root);
 }
 
 // Path: profilePage
@@ -456,6 +460,36 @@ class TranslationsProfileDetailPageEn {
 
 	/// en: 'Profile information could not be retrieved.'
 	String get nullCase => 'Profile information could not be retrieved.';
+}
+
+// Path: weatherPersonalityCharactersIntroductionPage
+class TranslationsWeatherPersonalityCharactersIntroductionPageEn {
+	TranslationsWeatherPersonalityCharactersIntroductionPageEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Character Introduction'
+	String get title => 'Character Introduction';
+
+	/// en: 'Character information could not be obtained.'
+	String get isEmptyCase => 'Character information could not be obtained.';
+}
+
+// Path: weatherPersonalityCharacterDetailPage
+class TranslationsWeatherPersonalityCharacterDetailPageEn {
+	TranslationsWeatherPersonalityCharacterDetailPageEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Character Details'
+	String get title => 'Character Details';
+
+	/// en: 'Character details could not be obtained.'
+	String get nullCase => 'Character details could not be obtained.';
 }
 
 // Path: weatherPersonalityConceptPage
@@ -696,6 +730,9 @@ class TranslationsButtonEn {
 
 	/// en: 'Confirm Weather News'
 	String get confirmWeatherNews => 'Confirm Weather News';
+
+	/// en: 'See Details'
+	String get seeDetails => 'See Details';
 }
 
 // Path: segmentedSwitch
@@ -1073,6 +1110,21 @@ class TranslationsWeatherReportDetailPageLabelEn {
 
 	/// en: 'Sensory Forecast'
 	String get forecast => 'Sensory Forecast';
+}
+
+// Path: accountPage.items
+class TranslationsAccountPageItemsEn {
+	TranslationsAccountPageItemsEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'What is the Weather Personality Test?'
+	String get aboutTest => 'What is the Weather Personality Test?';
+
+	/// en: 'See all characters'
+	String get seeAllCharacters => 'See all characters';
 }
 
 // Path: profilePage.section
@@ -3894,6 +3946,8 @@ extension on Translations {
 			'weatherReportDetailPage.label.feeling' => 'Feeling',
 			'weatherReportDetailPage.label.forecast' => 'Sensory Forecast',
 			'accountPage.nullCase' => 'User information could not be obtained.',
+			'accountPage.items.aboutTest' => 'What is the Weather Personality Test?',
+			'accountPage.items.seeAllCharacters' => 'See all characters',
 			'profilePage.title' => 'Edit Profile',
 			'profilePage.nullCase' => 'Profile information could not be retrieved.',
 			'profilePage.section.mainPhoto' => 'Main Photo',
@@ -3941,6 +3995,10 @@ extension on Translations {
 			'profilePage.placeholder.basicInformation.toolTip' => 'This field cannot be changed.',
 			'profileDetailPage.title' => 'Profile Details',
 			'profileDetailPage.nullCase' => 'Profile information could not be retrieved.',
+			'weatherPersonalityCharactersIntroductionPage.title' => 'Character Introduction',
+			'weatherPersonalityCharactersIntroductionPage.isEmptyCase' => 'Character information could not be obtained.',
+			'weatherPersonalityCharacterDetailPage.title' => 'Character Details',
+			'weatherPersonalityCharacterDetailPage.nullCase' => 'Character details could not be obtained.',
 			'weatherPersonalityConceptPage.title' => 'Weather Personality Assessment',
 			'weatherPersonalityConceptPage.contentText.contentTitle' => 'About the Assessment',
 			'weatherPersonalityConceptPage.contentText.contentText1' => 'If you were to be reborn as an animal,\n\n',
@@ -4146,6 +4204,7 @@ extension on Translations {
 			'button.suggestGoOut' => 'Suggest An Outing',
 			'button.kReturn' => 'Return',
 			'button.confirmWeatherNews' => 'Confirm Weather News',
+			'button.seeDetails' => 'See Details',
 			'segmentedSwitch.like.fromUser' => 'From Them',
 			'segmentedSwitch.like.toUser' => 'From Me',
 			'segmentedSwitch.chat.message' => 'Message',
@@ -4297,6 +4356,8 @@ extension on Translations {
 			'kEnum.height.just169cm' => '169cm',
 			'kEnum.height.just170cm' => '170cm',
 			'kEnum.height.just171cm' => '171cm',
+			_ => null,
+		} ?? switch (path) {
 			'kEnum.height.just172cm' => '172cm',
 			'kEnum.height.just173cm' => '173cm',
 			'kEnum.height.just174cm' => '174cm',
@@ -4304,8 +4365,6 @@ extension on Translations {
 			'kEnum.height.just176cm' => '176cm',
 			'kEnum.height.just177cm' => '177cm',
 			'kEnum.height.just178cm' => '178cm',
-			_ => null,
-		} ?? switch (path) {
 			'kEnum.height.just179cm' => '179cm',
 			'kEnum.height.just180cm' => '180cm',
 			'kEnum.height.just181cm' => '181cm',

--- a/reimi/frontend/reimi_app/lib/core/i18n/strings_ja.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/i18n/strings_ja.g.dart
@@ -64,6 +64,8 @@ class TranslationsJa with BaseTranslations<AppLocale, Translations> implements T
 	@override late final _TranslationsAccountPageJa accountPage = _TranslationsAccountPageJa._(_root);
 	@override late final _TranslationsProfilePageJa profilePage = _TranslationsProfilePageJa._(_root);
 	@override late final _TranslationsProfileDetailPageJa profileDetailPage = _TranslationsProfileDetailPageJa._(_root);
+	@override late final _TranslationsWeatherPersonalityCharactersIntroductionPageJa weatherPersonalityCharactersIntroductionPage = _TranslationsWeatherPersonalityCharactersIntroductionPageJa._(_root);
+	@override late final _TranslationsWeatherPersonalityCharacterDetailPageJa weatherPersonalityCharacterDetailPage = _TranslationsWeatherPersonalityCharacterDetailPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityConceptPageJa weatherPersonalityConceptPage = _TranslationsWeatherPersonalityConceptPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityDetailPageJa weatherPersonalityDetailPage = _TranslationsWeatherPersonalityDetailPageJa._(_root);
 	@override late final _TranslationsWeatherPersonalityTestJudgingPageJa weatherPersonalityTestJudgingPage = _TranslationsWeatherPersonalityTestJudgingPageJa._(_root);
@@ -328,6 +330,7 @@ class _TranslationsAccountPageJa implements TranslationsAccountPageEn {
 
 	// Translations
 	@override String get nullCase => 'ユーザー情報が取得できませんでした。';
+	@override late final _TranslationsAccountPageItemsJa items = _TranslationsAccountPageItemsJa._(_root);
 }
 
 // Path: profilePage
@@ -353,6 +356,28 @@ class _TranslationsProfileDetailPageJa implements TranslationsProfileDetailPageE
 	// Translations
 	@override String get title => 'プロフィール詳細';
 	@override String get nullCase => 'プロフィール情報が取得できませんでした。';
+}
+
+// Path: weatherPersonalityCharactersIntroductionPage
+class _TranslationsWeatherPersonalityCharactersIntroductionPageJa implements TranslationsWeatherPersonalityCharactersIntroductionPageEn {
+	_TranslationsWeatherPersonalityCharactersIntroductionPageJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'キャラクター紹介';
+	@override String get isEmptyCase => 'キャラクター情報が取得できませんでした。';
+}
+
+// Path: weatherPersonalityCharacterDetailPage
+class _TranslationsWeatherPersonalityCharacterDetailPageJa implements TranslationsWeatherPersonalityCharacterDetailPageEn {
+	_TranslationsWeatherPersonalityCharacterDetailPageJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'キャラクター詳細';
+	@override String get nullCase => 'キャラクター詳細情報が取得できませんでした。';
 }
 
 // Path: weatherPersonalityConceptPage
@@ -522,6 +547,7 @@ class _TranslationsButtonJa implements TranslationsButtonEn {
 	@override String get suggestGoOut => 'この内容でおでかけ提案する';
 	@override String get kReturn => '戻る';
 	@override String get confirmWeatherNews => 'ウェザーニュースで詳しく見る';
+	@override String get seeDetails => '詳しく見る';
 }
 
 // Path: segmentedSwitch
@@ -814,6 +840,17 @@ class _TranslationsWeatherReportDetailPageLabelJa implements TranslationsWeather
 	@override String get weather => '天気';
 	@override String get feeling => '体感';
 	@override String get forecast => '五感予想';
+}
+
+// Path: accountPage.items
+class _TranslationsAccountPageItemsJa implements TranslationsAccountPageItemsEn {
+	_TranslationsAccountPageItemsJa._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get aboutTest => 'ウェザーパーソナリティ診断とは？';
+	@override String get seeAllCharacters => 'すべてのキャラクターを見る';
 }
 
 // Path: profilePage.section
@@ -2590,6 +2627,8 @@ extension on TranslationsJa {
 			'weatherReportDetailPage.label.feeling' => '体感',
 			'weatherReportDetailPage.label.forecast' => '五感予想',
 			'accountPage.nullCase' => 'ユーザー情報が取得できませんでした。',
+			'accountPage.items.aboutTest' => 'ウェザーパーソナリティ診断とは？',
+			'accountPage.items.seeAllCharacters' => 'すべてのキャラクターを見る',
 			'profilePage.title' => 'プロフィール編集',
 			'profilePage.nullCase' => 'プロフィール情報が取得できませんでした。',
 			'profilePage.section.mainPhoto' => 'メイン写真',
@@ -2637,6 +2676,10 @@ extension on TranslationsJa {
 			'profilePage.placeholder.basicInformation.toolTip' => 'この項目は変更できません。',
 			'profileDetailPage.title' => 'プロフィール詳細',
 			'profileDetailPage.nullCase' => 'プロフィール情報が取得できませんでした。',
+			'weatherPersonalityCharactersIntroductionPage.title' => 'キャラクター紹介',
+			'weatherPersonalityCharactersIntroductionPage.isEmptyCase' => 'キャラクター情報が取得できませんでした。',
+			'weatherPersonalityCharacterDetailPage.title' => 'キャラクター詳細',
+			'weatherPersonalityCharacterDetailPage.nullCase' => 'キャラクター詳細情報が取得できませんでした。',
 			'weatherPersonalityConceptPage.title' => 'ウェザーパーソナリティ診断',
 			'weatherPersonalityConceptPage.contentText.contentTitle' => '診断について',
 			'weatherPersonalityConceptPage.contentText.contentText1' => 'あなたが動物に生まれ変わるとして、\n\n',
@@ -2842,6 +2885,7 @@ extension on TranslationsJa {
 			'button.suggestGoOut' => 'この内容でおでかけ提案する',
 			'button.kReturn' => '戻る',
 			'button.confirmWeatherNews' => 'ウェザーニュースで詳しく見る',
+			'button.seeDetails' => '詳しく見る',
 			'segmentedSwitch.like.fromUser' => '相手から',
 			'segmentedSwitch.like.toUser' => '自分から',
 			'segmentedSwitch.chat.message' => 'メッセージ',
@@ -2993,6 +3037,8 @@ extension on TranslationsJa {
 			'kEnum.height.just169cm' => '169cm',
 			'kEnum.height.just170cm' => '170cm',
 			'kEnum.height.just171cm' => '171cm',
+			_ => null,
+		} ?? switch (path) {
 			'kEnum.height.just172cm' => '172cm',
 			'kEnum.height.just173cm' => '173cm',
 			'kEnum.height.just174cm' => '174cm',
@@ -3000,8 +3046,6 @@ extension on TranslationsJa {
 			'kEnum.height.just176cm' => '176cm',
 			'kEnum.height.just177cm' => '177cm',
 			'kEnum.height.just178cm' => '178cm',
-			_ => null,
-		} ?? switch (path) {
 			'kEnum.height.just179cm' => '179cm',
 			'kEnum.height.just180cm' => '180cm',
 			'kEnum.height.just181cm' => '181cm',

--- a/reimi/frontend/reimi_app/lib/core/router/app_router.dart
+++ b/reimi/frontend/reimi_app/lib/core/router/app_router.dart
@@ -24,6 +24,8 @@ import 'package:reimi_app/presentation/features/user_registration/pages/user_gen
 import 'package:reimi_app/presentation/features/user_registration/pages/user_introduction_page.dart';
 import 'package:reimi_app/presentation/features/user_registration/pages/user_main_photo_page.dart';
 import 'package:reimi_app/presentation/features/user_registration/pages/user_name_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_character_detail_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_characters_introduction_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_concept_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_test_judging_page.dart';
@@ -301,7 +303,25 @@ GoRouter goRouter(Ref ref) {
         path: WeatherPersonalityConceptPage.routeLocation,
         name: WeatherPersonalityConceptPage.routeName,
         builder: (context, state) {
-          return const WeatherPersonalityConceptPage();
+          final extra = state.extra! as Map<String, Object?>;
+          final isPreTest = extra['isPreTest'] as bool;
+          return WeatherPersonalityConceptPage(isPreTest: isPreTest);
+        },
+      ),
+      GoRoute(
+        path: WeatherPersonalityCharactersIntroductionPage.routeLocation,
+        name: WeatherPersonalityCharactersIntroductionPage.routeName,
+        builder: (context, state) {
+          return const WeatherPersonalityCharactersIntroductionPage();
+        },
+      ),
+      GoRoute(
+        path: WeatherPersonalityCharacterDetailPage.routeLocation,
+        name: WeatherPersonalityCharacterDetailPage.routeName,
+        builder: (context, state) {
+          final extra = state.extra! as Map<String, Object?>;
+          final typeCode = extra['typeCode'] as String?;
+          return WeatherPersonalityCharacterDetailPage(typeCode: typeCode);
         },
       ),
       GoRoute(

--- a/reimi/frontend/reimi_app/lib/core/router/app_router.g.dart
+++ b/reimi/frontend/reimi_app/lib/core/router/app_router.g.dart
@@ -6,7 +6,7 @@ part of 'app_router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'019e804f7a4f0381db7b0cd51f91607d74842261';
+String _$goRouterHash() => r'a86e1171ddbdd8057d4e0f8519ab2c393382385c';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_personality_mock_datasource.dart
+++ b/reimi/frontend/reimi_app/lib/data/datasources/mocks/weather_personality_mock_datasource.dart
@@ -60,9 +60,9 @@ final mockWeatherPersonalityResult = WeatherPersonalityResultDto(
   ],
   userAxisScore: {
     WeatherPersonalityAxis.sensitivity: 8,
-    WeatherPersonalityAxis.preparedness: 0,
+    WeatherPersonalityAxis.preparedness: 1,
     WeatherPersonalityAxis.activity: 7,
-    WeatherPersonalityAxis.motivation: -5,
+    WeatherPersonalityAxis.motivation: 5,
   },
   behaviorTendencies: [
     const BehaviorTendencyDto(
@@ -125,9 +125,9 @@ final mockWeatherPersonalityDetail = WeatherPersonalityDetailDto(
   ],
   userAxisScore: {
     WeatherPersonalityAxis.sensitivity: 8,
-    WeatherPersonalityAxis.preparedness: 0,
+    WeatherPersonalityAxis.preparedness: 1,
     WeatherPersonalityAxis.activity: 7,
-    WeatherPersonalityAxis.motivation: -5,
+    WeatherPersonalityAxis.motivation: 5,
   },
   behaviorTendencies: [
     const BehaviorTendencyDto(

--- a/reimi/frontend/reimi_app/lib/data/repositories/weather_personality_repository_impl.dart
+++ b/reimi/frontend/reimi_app/lib/data/repositories/weather_personality_repository_impl.dart
@@ -3,6 +3,8 @@ import 'package:reimi_app/data/mapper/test_weather_personality_mapper.dart';
 import 'package:reimi_app/data/mapper/weather_personality_detail_mapper.dart';
 import 'package:reimi_app/data/mapper/weather_personality_result_mapper.dart';
 import 'package:reimi_app/domain/params/test_weather_personality_params.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_detail_read_model.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_result_read_model.dart';
 import 'package:reimi_app/domain/repositories/weather_personality_repository.dart';
@@ -30,5 +32,17 @@ class WeatherPersonalityRepositoryImpl implements WeatherPersonalityRepository {
   ) async {
     final dto = await _remote.fetchWeatherPersonalityDetail(userId);
     return dto.toReadModel();
+  }
+
+  @override
+  Future<WeatherPersonalityCharacterDetailReadModel> fetchWeatherPersonalityCharacter() {
+    // TODO: implement fetchWeatherPersonalityCharacter
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<WeatherPersonalityCharacterReadModel>> fetchWeatherPersonalityCharacters() {
+    // TODO: implement fetchWeatherPersonalityCharacters
+    throw UnimplementedError();
   }
 }

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_detail_read_model.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_detail_read_model.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/domain/read_models/axis_feature_read_model.dart';
+import 'package:reimi_app/domain/read_models/behavior_tendency_read_model.dart';
+import 'package:reimi_app/domain/read_models/type_compatibility_read_model.dart';
+import 'package:reimi_app/domain/value_objects/weather_personality_code.dart';
+
+part 'weather_personality_character_detail_read_model.freezed.dart';
+
+@freezed
+abstract class WeatherPersonalityCharacterDetailReadModel
+    with _$WeatherPersonalityCharacterDetailReadModel {
+  const factory WeatherPersonalityCharacterDetailReadModel({
+    required WeatherPersonalityCode typeCode,
+    required String typeName,
+    required String typeCatchphrase,
+    required String typeImageUrl,
+    required String rulingStatement,
+    required List<AxisFeatureReadModel> axisFeatures,
+    required List<BehaviorTendencyReadModel> behaviorTendencies,
+    required List<TypeCompatibilityReadModel> compatibleTypes,
+    required List<TypeCompatibilityReadModel> incompatibleTypes,
+    required String godsMessage,
+  }) = _WeatherPersonalityCharacterDetailReadModel;
+}

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_detail_read_model.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_detail_read_model.freezed.dart
@@ -1,0 +1,615 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_personality_character_detail_read_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WeatherPersonalityCharacterDetailReadModel {
+  WeatherPersonalityCode get typeCode;
+  String get typeName;
+  String get typeCatchphrase;
+  String get typeImageUrl;
+  String get rulingStatement;
+  List<AxisFeatureReadModel> get axisFeatures;
+  List<BehaviorTendencyReadModel> get behaviorTendencies;
+  List<TypeCompatibilityReadModel> get compatibleTypes;
+  List<TypeCompatibilityReadModel> get incompatibleTypes;
+  String get godsMessage;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityCharacterDetailReadModelCopyWith<
+          WeatherPersonalityCharacterDetailReadModel>
+      get copyWith => _$WeatherPersonalityCharacterDetailReadModelCopyWithImpl<
+              WeatherPersonalityCharacterDetailReadModel>(
+          this as WeatherPersonalityCharacterDetailReadModel, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WeatherPersonalityCharacterDetailReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCatchphrase, typeCatchphrase) ||
+                other.typeCatchphrase == typeCatchphrase) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl) &&
+            (identical(other.rulingStatement, rulingStatement) ||
+                other.rulingStatement == rulingStatement) &&
+            const DeepCollectionEquality()
+                .equals(other.axisFeatures, axisFeatures) &&
+            const DeepCollectionEquality()
+                .equals(other.behaviorTendencies, behaviorTendencies) &&
+            const DeepCollectionEquality()
+                .equals(other.compatibleTypes, compatibleTypes) &&
+            const DeepCollectionEquality()
+                .equals(other.incompatibleTypes, incompatibleTypes) &&
+            (identical(other.godsMessage, godsMessage) ||
+                other.godsMessage == godsMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      typeCode,
+      typeName,
+      typeCatchphrase,
+      typeImageUrl,
+      rulingStatement,
+      const DeepCollectionEquality().hash(axisFeatures),
+      const DeepCollectionEquality().hash(behaviorTendencies),
+      const DeepCollectionEquality().hash(compatibleTypes),
+      const DeepCollectionEquality().hash(incompatibleTypes),
+      godsMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharacterDetailReadModel(typeCode: $typeCode, typeName: $typeName, typeCatchphrase: $typeCatchphrase, typeImageUrl: $typeImageUrl, rulingStatement: $rulingStatement, axisFeatures: $axisFeatures, behaviorTendencies: $behaviorTendencies, compatibleTypes: $compatibleTypes, incompatibleTypes: $incompatibleTypes, godsMessage: $godsMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res> {
+  factory $WeatherPersonalityCharacterDetailReadModelCopyWith(
+          WeatherPersonalityCharacterDetailReadModel value,
+          $Res Function(WeatherPersonalityCharacterDetailReadModel) _then) =
+      _$WeatherPersonalityCharacterDetailReadModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {WeatherPersonalityCode typeCode,
+      String typeName,
+      String typeCatchphrase,
+      String typeImageUrl,
+      String rulingStatement,
+      List<AxisFeatureReadModel> axisFeatures,
+      List<BehaviorTendencyReadModel> behaviorTendencies,
+      List<TypeCompatibilityReadModel> compatibleTypes,
+      List<TypeCompatibilityReadModel> incompatibleTypes,
+      String godsMessage});
+}
+
+/// @nodoc
+class _$WeatherPersonalityCharacterDetailReadModelCopyWithImpl<$Res>
+    implements $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res> {
+  _$WeatherPersonalityCharacterDetailReadModelCopyWithImpl(
+      this._self, this._then);
+
+  final WeatherPersonalityCharacterDetailReadModel _self;
+  final $Res Function(WeatherPersonalityCharacterDetailReadModel) _then;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCatchphrase = null,
+    Object? typeImageUrl = null,
+    Object? rulingStatement = null,
+    Object? axisFeatures = null,
+    Object? behaviorTendencies = null,
+    Object? compatibleTypes = null,
+    Object? incompatibleTypes = null,
+    Object? godsMessage = null,
+  }) {
+    return _then(_self.copyWith(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityCode,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCatchphrase: null == typeCatchphrase
+          ? _self.typeCatchphrase
+          : typeCatchphrase // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeImageUrl: null == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      rulingStatement: null == rulingStatement
+          ? _self.rulingStatement
+          : rulingStatement // ignore: cast_nullable_to_non_nullable
+              as String,
+      axisFeatures: null == axisFeatures
+          ? _self.axisFeatures
+          : axisFeatures // ignore: cast_nullable_to_non_nullable
+              as List<AxisFeatureReadModel>,
+      behaviorTendencies: null == behaviorTendencies
+          ? _self.behaviorTendencies
+          : behaviorTendencies // ignore: cast_nullable_to_non_nullable
+              as List<BehaviorTendencyReadModel>,
+      compatibleTypes: null == compatibleTypes
+          ? _self.compatibleTypes
+          : compatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      incompatibleTypes: null == incompatibleTypes
+          ? _self.incompatibleTypes
+          : incompatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      godsMessage: null == godsMessage
+          ? _self.godsMessage
+          : godsMessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [WeatherPersonalityCharacterDetailReadModel].
+extension WeatherPersonalityCharacterDetailReadModelPatterns
+    on WeatherPersonalityCharacterDetailReadModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharacterDetailReadModel value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharacterDetailReadModel value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailReadModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_WeatherPersonalityCharacterDetailReadModel value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            WeatherPersonalityCode typeCode,
+            String typeName,
+            String typeCatchphrase,
+            String typeImageUrl,
+            String rulingStatement,
+            List<AxisFeatureReadModel> axisFeatures,
+            List<BehaviorTendencyReadModel> behaviorTendencies,
+            List<TypeCompatibilityReadModel> compatibleTypes,
+            List<TypeCompatibilityReadModel> incompatibleTypes,
+            String godsMessage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailReadModel() when $default != null:
+        return $default(
+            _that.typeCode,
+            _that.typeName,
+            _that.typeCatchphrase,
+            _that.typeImageUrl,
+            _that.rulingStatement,
+            _that.axisFeatures,
+            _that.behaviorTendencies,
+            _that.compatibleTypes,
+            _that.incompatibleTypes,
+            _that.godsMessage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            WeatherPersonalityCode typeCode,
+            String typeName,
+            String typeCatchphrase,
+            String typeImageUrl,
+            String rulingStatement,
+            List<AxisFeatureReadModel> axisFeatures,
+            List<BehaviorTendencyReadModel> behaviorTendencies,
+            List<TypeCompatibilityReadModel> compatibleTypes,
+            List<TypeCompatibilityReadModel> incompatibleTypes,
+            String godsMessage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailReadModel():
+        return $default(
+            _that.typeCode,
+            _that.typeName,
+            _that.typeCatchphrase,
+            _that.typeImageUrl,
+            _that.rulingStatement,
+            _that.axisFeatures,
+            _that.behaviorTendencies,
+            _that.compatibleTypes,
+            _that.incompatibleTypes,
+            _that.godsMessage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            WeatherPersonalityCode typeCode,
+            String typeName,
+            String typeCatchphrase,
+            String typeImageUrl,
+            String rulingStatement,
+            List<AxisFeatureReadModel> axisFeatures,
+            List<BehaviorTendencyReadModel> behaviorTendencies,
+            List<TypeCompatibilityReadModel> compatibleTypes,
+            List<TypeCompatibilityReadModel> incompatibleTypes,
+            String godsMessage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailReadModel() when $default != null:
+        return $default(
+            _that.typeCode,
+            _that.typeName,
+            _that.typeCatchphrase,
+            _that.typeImageUrl,
+            _that.rulingStatement,
+            _that.axisFeatures,
+            _that.behaviorTendencies,
+            _that.compatibleTypes,
+            _that.incompatibleTypes,
+            _that.godsMessage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _WeatherPersonalityCharacterDetailReadModel
+    implements WeatherPersonalityCharacterDetailReadModel {
+  const _WeatherPersonalityCharacterDetailReadModel(
+      {required this.typeCode,
+      required this.typeName,
+      required this.typeCatchphrase,
+      required this.typeImageUrl,
+      required this.rulingStatement,
+      required final List<AxisFeatureReadModel> axisFeatures,
+      required final List<BehaviorTendencyReadModel> behaviorTendencies,
+      required final List<TypeCompatibilityReadModel> compatibleTypes,
+      required final List<TypeCompatibilityReadModel> incompatibleTypes,
+      required this.godsMessage})
+      : _axisFeatures = axisFeatures,
+        _behaviorTendencies = behaviorTendencies,
+        _compatibleTypes = compatibleTypes,
+        _incompatibleTypes = incompatibleTypes;
+
+  @override
+  final WeatherPersonalityCode typeCode;
+  @override
+  final String typeName;
+  @override
+  final String typeCatchphrase;
+  @override
+  final String typeImageUrl;
+  @override
+  final String rulingStatement;
+  final List<AxisFeatureReadModel> _axisFeatures;
+  @override
+  List<AxisFeatureReadModel> get axisFeatures {
+    if (_axisFeatures is EqualUnmodifiableListView) return _axisFeatures;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_axisFeatures);
+  }
+
+  final List<BehaviorTendencyReadModel> _behaviorTendencies;
+  @override
+  List<BehaviorTendencyReadModel> get behaviorTendencies {
+    if (_behaviorTendencies is EqualUnmodifiableListView)
+      return _behaviorTendencies;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_behaviorTendencies);
+  }
+
+  final List<TypeCompatibilityReadModel> _compatibleTypes;
+  @override
+  List<TypeCompatibilityReadModel> get compatibleTypes {
+    if (_compatibleTypes is EqualUnmodifiableListView) return _compatibleTypes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_compatibleTypes);
+  }
+
+  final List<TypeCompatibilityReadModel> _incompatibleTypes;
+  @override
+  List<TypeCompatibilityReadModel> get incompatibleTypes {
+    if (_incompatibleTypes is EqualUnmodifiableListView)
+      return _incompatibleTypes;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_incompatibleTypes);
+  }
+
+  @override
+  final String godsMessage;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$WeatherPersonalityCharacterDetailReadModelCopyWith<
+          _WeatherPersonalityCharacterDetailReadModel>
+      get copyWith => __$WeatherPersonalityCharacterDetailReadModelCopyWithImpl<
+          _WeatherPersonalityCharacterDetailReadModel>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WeatherPersonalityCharacterDetailReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCatchphrase, typeCatchphrase) ||
+                other.typeCatchphrase == typeCatchphrase) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl) &&
+            (identical(other.rulingStatement, rulingStatement) ||
+                other.rulingStatement == rulingStatement) &&
+            const DeepCollectionEquality()
+                .equals(other._axisFeatures, _axisFeatures) &&
+            const DeepCollectionEquality()
+                .equals(other._behaviorTendencies, _behaviorTendencies) &&
+            const DeepCollectionEquality()
+                .equals(other._compatibleTypes, _compatibleTypes) &&
+            const DeepCollectionEquality()
+                .equals(other._incompatibleTypes, _incompatibleTypes) &&
+            (identical(other.godsMessage, godsMessage) ||
+                other.godsMessage == godsMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      typeCode,
+      typeName,
+      typeCatchphrase,
+      typeImageUrl,
+      rulingStatement,
+      const DeepCollectionEquality().hash(_axisFeatures),
+      const DeepCollectionEquality().hash(_behaviorTendencies),
+      const DeepCollectionEquality().hash(_compatibleTypes),
+      const DeepCollectionEquality().hash(_incompatibleTypes),
+      godsMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharacterDetailReadModel(typeCode: $typeCode, typeName: $typeName, typeCatchphrase: $typeCatchphrase, typeImageUrl: $typeImageUrl, rulingStatement: $rulingStatement, axisFeatures: $axisFeatures, behaviorTendencies: $behaviorTendencies, compatibleTypes: $compatibleTypes, incompatibleTypes: $incompatibleTypes, godsMessage: $godsMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>
+    implements $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res> {
+  factory _$WeatherPersonalityCharacterDetailReadModelCopyWith(
+          _WeatherPersonalityCharacterDetailReadModel value,
+          $Res Function(_WeatherPersonalityCharacterDetailReadModel) _then) =
+      __$WeatherPersonalityCharacterDetailReadModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {WeatherPersonalityCode typeCode,
+      String typeName,
+      String typeCatchphrase,
+      String typeImageUrl,
+      String rulingStatement,
+      List<AxisFeatureReadModel> axisFeatures,
+      List<BehaviorTendencyReadModel> behaviorTendencies,
+      List<TypeCompatibilityReadModel> compatibleTypes,
+      List<TypeCompatibilityReadModel> incompatibleTypes,
+      String godsMessage});
+}
+
+/// @nodoc
+class __$WeatherPersonalityCharacterDetailReadModelCopyWithImpl<$Res>
+    implements _$WeatherPersonalityCharacterDetailReadModelCopyWith<$Res> {
+  __$WeatherPersonalityCharacterDetailReadModelCopyWithImpl(
+      this._self, this._then);
+
+  final _WeatherPersonalityCharacterDetailReadModel _self;
+  final $Res Function(_WeatherPersonalityCharacterDetailReadModel) _then;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCatchphrase = null,
+    Object? typeImageUrl = null,
+    Object? rulingStatement = null,
+    Object? axisFeatures = null,
+    Object? behaviorTendencies = null,
+    Object? compatibleTypes = null,
+    Object? incompatibleTypes = null,
+    Object? godsMessage = null,
+  }) {
+    return _then(_WeatherPersonalityCharacterDetailReadModel(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityCode,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCatchphrase: null == typeCatchphrase
+          ? _self.typeCatchphrase
+          : typeCatchphrase // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeImageUrl: null == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      rulingStatement: null == rulingStatement
+          ? _self.rulingStatement
+          : rulingStatement // ignore: cast_nullable_to_non_nullable
+              as String,
+      axisFeatures: null == axisFeatures
+          ? _self._axisFeatures
+          : axisFeatures // ignore: cast_nullable_to_non_nullable
+              as List<AxisFeatureReadModel>,
+      behaviorTendencies: null == behaviorTendencies
+          ? _self._behaviorTendencies
+          : behaviorTendencies // ignore: cast_nullable_to_non_nullable
+              as List<BehaviorTendencyReadModel>,
+      compatibleTypes: null == compatibleTypes
+          ? _self._compatibleTypes
+          : compatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      incompatibleTypes: null == incompatibleTypes
+          ? _self._incompatibleTypes
+          : incompatibleTypes // ignore: cast_nullable_to_non_nullable
+              as List<TypeCompatibilityReadModel>,
+      godsMessage: null == godsMessage
+          ? _self.godsMessage
+          : godsMessage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_read_model.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_read_model.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/domain/value_objects/weather_personality_code.dart';
+
+part 'weather_personality_character_read_model.freezed.dart';
+
+@freezed
+abstract class WeatherPersonalityCharacterReadModel
+    with _$WeatherPersonalityCharacterReadModel {
+  const factory WeatherPersonalityCharacterReadModel({
+    required WeatherPersonalityCode typeCode,
+    required String typeName,
+    required String typeCatchphrase,
+    required String typeImageUrl,
+  }) = _WeatherPersonalityCharacterReadModel;
+}

--- a/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_read_model.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/domain/read_models/weather_personality_character_read_model.freezed.dart
@@ -1,0 +1,386 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_personality_character_read_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WeatherPersonalityCharacterReadModel {
+  WeatherPersonalityCode get typeCode;
+  String get typeName;
+  String get typeCatchphrase;
+  String get typeImageUrl;
+
+  /// Create a copy of WeatherPersonalityCharacterReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityCharacterReadModelCopyWith<
+          WeatherPersonalityCharacterReadModel>
+      get copyWith => _$WeatherPersonalityCharacterReadModelCopyWithImpl<
+              WeatherPersonalityCharacterReadModel>(
+          this as WeatherPersonalityCharacterReadModel, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WeatherPersonalityCharacterReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCatchphrase, typeCatchphrase) ||
+                other.typeCatchphrase == typeCatchphrase) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, typeCode, typeName, typeCatchphrase, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharacterReadModel(typeCode: $typeCode, typeName: $typeName, typeCatchphrase: $typeCatchphrase, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WeatherPersonalityCharacterReadModelCopyWith<$Res> {
+  factory $WeatherPersonalityCharacterReadModelCopyWith(
+          WeatherPersonalityCharacterReadModel value,
+          $Res Function(WeatherPersonalityCharacterReadModel) _then) =
+      _$WeatherPersonalityCharacterReadModelCopyWithImpl;
+  @useResult
+  $Res call(
+      {WeatherPersonalityCode typeCode,
+      String typeName,
+      String typeCatchphrase,
+      String typeImageUrl});
+}
+
+/// @nodoc
+class _$WeatherPersonalityCharacterReadModelCopyWithImpl<$Res>
+    implements $WeatherPersonalityCharacterReadModelCopyWith<$Res> {
+  _$WeatherPersonalityCharacterReadModelCopyWithImpl(this._self, this._then);
+
+  final WeatherPersonalityCharacterReadModel _self;
+  final $Res Function(WeatherPersonalityCharacterReadModel) _then;
+
+  /// Create a copy of WeatherPersonalityCharacterReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCatchphrase = null,
+    Object? typeImageUrl = null,
+  }) {
+    return _then(_self.copyWith(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityCode,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCatchphrase: null == typeCatchphrase
+          ? _self.typeCatchphrase
+          : typeCatchphrase // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeImageUrl: null == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [WeatherPersonalityCharacterReadModel].
+extension WeatherPersonalityCharacterReadModelPatterns
+    on WeatherPersonalityCharacterReadModel {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharacterReadModel value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharacterReadModel value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterReadModel():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_WeatherPersonalityCharacterReadModel value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterReadModel() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(WeatherPersonalityCode typeCode, String typeName,
+            String typeCatchphrase, String typeImageUrl)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterReadModel() when $default != null:
+        return $default(_that.typeCode, _that.typeName, _that.typeCatchphrase,
+            _that.typeImageUrl);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(WeatherPersonalityCode typeCode, String typeName,
+            String typeCatchphrase, String typeImageUrl)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterReadModel():
+        return $default(_that.typeCode, _that.typeName, _that.typeCatchphrase,
+            _that.typeImageUrl);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(WeatherPersonalityCode typeCode, String typeName,
+            String typeCatchphrase, String typeImageUrl)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterReadModel() when $default != null:
+        return $default(_that.typeCode, _that.typeName, _that.typeCatchphrase,
+            _that.typeImageUrl);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _WeatherPersonalityCharacterReadModel
+    implements WeatherPersonalityCharacterReadModel {
+  const _WeatherPersonalityCharacterReadModel(
+      {required this.typeCode,
+      required this.typeName,
+      required this.typeCatchphrase,
+      required this.typeImageUrl});
+
+  @override
+  final WeatherPersonalityCode typeCode;
+  @override
+  final String typeName;
+  @override
+  final String typeCatchphrase;
+  @override
+  final String typeImageUrl;
+
+  /// Create a copy of WeatherPersonalityCharacterReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$WeatherPersonalityCharacterReadModelCopyWith<
+          _WeatherPersonalityCharacterReadModel>
+      get copyWith => __$WeatherPersonalityCharacterReadModelCopyWithImpl<
+          _WeatherPersonalityCharacterReadModel>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WeatherPersonalityCharacterReadModel &&
+            (identical(other.typeCode, typeCode) ||
+                other.typeCode == typeCode) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeCatchphrase, typeCatchphrase) ||
+                other.typeCatchphrase == typeCatchphrase) &&
+            (identical(other.typeImageUrl, typeImageUrl) ||
+                other.typeImageUrl == typeImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, typeCode, typeName, typeCatchphrase, typeImageUrl);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharacterReadModel(typeCode: $typeCode, typeName: $typeName, typeCatchphrase: $typeCatchphrase, typeImageUrl: $typeImageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$WeatherPersonalityCharacterReadModelCopyWith<$Res>
+    implements $WeatherPersonalityCharacterReadModelCopyWith<$Res> {
+  factory _$WeatherPersonalityCharacterReadModelCopyWith(
+          _WeatherPersonalityCharacterReadModel value,
+          $Res Function(_WeatherPersonalityCharacterReadModel) _then) =
+      __$WeatherPersonalityCharacterReadModelCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {WeatherPersonalityCode typeCode,
+      String typeName,
+      String typeCatchphrase,
+      String typeImageUrl});
+}
+
+/// @nodoc
+class __$WeatherPersonalityCharacterReadModelCopyWithImpl<$Res>
+    implements _$WeatherPersonalityCharacterReadModelCopyWith<$Res> {
+  __$WeatherPersonalityCharacterReadModelCopyWithImpl(this._self, this._then);
+
+  final _WeatherPersonalityCharacterReadModel _self;
+  final $Res Function(_WeatherPersonalityCharacterReadModel) _then;
+
+  /// Create a copy of WeatherPersonalityCharacterReadModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? typeCode = null,
+    Object? typeName = null,
+    Object? typeCatchphrase = null,
+    Object? typeImageUrl = null,
+  }) {
+    return _then(_WeatherPersonalityCharacterReadModel(
+      typeCode: null == typeCode
+          ? _self.typeCode
+          : typeCode // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityCode,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeCatchphrase: null == typeCatchphrase
+          ? _self.typeCatchphrase
+          : typeCatchphrase // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeImageUrl: null == typeImageUrl
+          ? _self.typeImageUrl
+          : typeImageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/domain/repositories/weather_personality_repository.dart
+++ b/reimi/frontend/reimi_app/lib/domain/repositories/weather_personality_repository.dart
@@ -1,9 +1,17 @@
 import 'package:reimi_app/domain/params/test_weather_personality_params.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_detail_read_model.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_detail_read_model.dart';
 import 'package:reimi_app/domain/read_models/weather_personality_result_read_model.dart';
 
 abstract class WeatherPersonalityRepository {
   Future<void> testWeatherPersonality(TestWeatherPersonalityParams params);
   Future<WeatherPersonalityResultReadModel> fetchWeatherPersonalityResult();
-  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(String userId);
+  Future<WeatherPersonalityDetailReadModel> fetchWeatherPersonalityDetail(
+    String userId,
+  );
+  Future<List<WeatherPersonalityCharacterReadModel>>
+      fetchWeatherPersonalityCharacters();
+  Future<WeatherPersonalityCharacterDetailReadModel>
+      fetchWeatherPersonalityCharacter();
 }

--- a/reimi/frontend/reimi_app/lib/presentation/features/account/account_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/account/account_page.dart
@@ -9,6 +9,8 @@ import 'package:reimi_app/gen/assets.gen.dart';
 import 'package:reimi_app/core/i18n/strings.g.dart';
 import 'package:reimi_app/presentation/features/account/notifiers/account_notifier.dart';
 import 'package:reimi_app/presentation/features/account/states/account_state.dart';
+import 'package:reimi_app/presentation/features/account/widgets/info_tile.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_characters_introduction_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_concept_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_detail_page.dart';
 import 'package:reimi_app/presentation/features/weather_personality/widgets/weather_personality_button.dart';
@@ -234,10 +236,39 @@ class AccountPage extends HookConsumerWidget {
                             onPressed: () {
                               context.push(
                                 WeatherPersonalityConceptPage.routeLocation,
+                                extra: {
+                                  'isPreTest': true,
+                                },
                               );
                             },
                           ),
                           const Spacer(flex: 1),
+                        ] else ...[
+                          const SizedBox(height: 40),
+                          InfoTile(
+                            onTap: () {
+                              context.push(
+                                WeatherPersonalityConceptPage.routeLocation,
+                                extra: {
+                                  'isPreTest': false,
+                                },
+                              );
+                            },
+                            icon: LineIcons.clipboardList,
+                            title: t.accountPage.items.aboutTest,
+                          ),
+                          const SizedBox(height: 8),
+                          InfoTile(
+                            onTap: () {
+                              context.push(
+                                WeatherPersonalityCharactersIntroductionPage
+                                    .routeLocation,
+                              );
+                            },
+                            icon: LineIcons.paw,
+                            title: t.accountPage.items.seeAllCharacters,
+                          ),
+                          const Spacer(),
                         ]
                       ],
                     ),

--- a/reimi/frontend/reimi_app/lib/presentation/features/account/widgets/info_tile.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/account/widgets/info_tile.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+class InfoTile extends StatelessWidget {
+  const InfoTile({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.onTap,
+  });
+  final IconData icon;
+  final String title;
+  final void Function()? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      onTap: onTap,
+      contentPadding: EdgeInsets.zero,
+      leading: Container(
+        padding: const EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.7),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Icon(
+          icon,
+          color: Colors.black87,
+        ),
+      ),
+      title: Text(
+        title,
+        style: theme.textTheme.titleSmall,
+      ),
+      trailing: const Icon(
+        Icons.chevron_right,
+        color: Colors.black87,
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_character_detail_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_character_detail_notifier.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:reimi_app/core/di/usecase_providers.dart';
+import 'package:reimi_app/presentation/features/weather_personality/states/weather_personality_character_detail_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'weather_personality_character_detail_notifier.g.dart';
+
+@riverpod
+class WeatherPersonalityCharacterDetailNotifier
+    extends _$WeatherPersonalityCharacterDetailNotifier {
+  @override
+  WeatherPersonalityCharacterDetailState build() {
+    return const WeatherPersonalityCharacterDetailState();
+  }
+
+  Future<void> init(String? typeCode) async {
+    await loadWeatherPersonalityCharacter(typeCode);
+  }
+
+  Future<void> loadWeatherPersonalityCharacter(String? typeCode) async {
+    if (typeCode == null) return;
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final character = await ref
+          .read(getWeatherPersonalityCharacterDetailUseCaseProvider)
+          .call();
+      state = state.copyWith(
+        character: character,
+        isLoading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: e.toString(),
+      );
+    }
+  }
+
+  Future<void> refresh(String? typeCode) async {
+    if (typeCode == null) return;
+    await loadWeatherPersonalityCharacter(typeCode);
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_character_detail_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_character_detail_notifier.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_personality_character_detail_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$weatherPersonalityCharacterDetailNotifierHash() =>
+    r'46e868b571bd465c6c99677595f2caa9cd5c08d9';
+
+/// See also [WeatherPersonalityCharacterDetailNotifier].
+@ProviderFor(WeatherPersonalityCharacterDetailNotifier)
+final weatherPersonalityCharacterDetailNotifierProvider =
+    AutoDisposeNotifierProvider<WeatherPersonalityCharacterDetailNotifier,
+        WeatherPersonalityCharacterDetailState>.internal(
+  WeatherPersonalityCharacterDetailNotifier.new,
+  name: r'weatherPersonalityCharacterDetailNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$weatherPersonalityCharacterDetailNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WeatherPersonalityCharacterDetailNotifier
+    = AutoDisposeNotifier<WeatherPersonalityCharacterDetailState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_characters_introduction_notifier.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_characters_introduction_notifier.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:reimi_app/core/di/usecase_providers.dart';
+import 'package:reimi_app/presentation/features/weather_personality/states/weather_personality_characters_introduction_state.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'weather_personality_characters_introduction_notifier.g.dart';
+
+@riverpod
+class WeatherPersonalityCharactersIntroductionNotifier
+    extends _$WeatherPersonalityCharactersIntroductionNotifier {
+  @override
+  WeatherPersonalityCharactersIntroductionState build() {
+    return const WeatherPersonalityCharactersIntroductionState();
+  }
+
+  Future<void> init() async {
+    await loadWeatherPersonalityCharacters();
+  }
+
+  Future<void> loadWeatherPersonalityCharacters() async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final characters =
+          await ref.read(getWeatherPersonalityCharactersUseCaseProvider).call();
+      state = state.copyWith(
+        characters: characters,
+        isLoading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: e.toString(),
+      );
+    }
+  }
+
+  Future<void> refresh() async {
+    await loadWeatherPersonalityCharacters();
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_characters_introduction_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/notifiers/weather_personality_characters_introduction_notifier.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_personality_characters_introduction_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$weatherPersonalityCharactersIntroductionNotifierHash() =>
+    r'4f27224d7a34c4caa257a13a33bf4ed9ce57d691';
+
+/// See also [WeatherPersonalityCharactersIntroductionNotifier].
+@ProviderFor(WeatherPersonalityCharactersIntroductionNotifier)
+final weatherPersonalityCharactersIntroductionNotifierProvider =
+    AutoDisposeNotifierProvider<
+        WeatherPersonalityCharactersIntroductionNotifier,
+        WeatherPersonalityCharactersIntroductionState>.internal(
+  WeatherPersonalityCharactersIntroductionNotifier.new,
+  name: r'weatherPersonalityCharactersIntroductionNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$weatherPersonalityCharactersIntroductionNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WeatherPersonalityCharactersIntroductionNotifier
+    = AutoDisposeNotifier<WeatherPersonalityCharactersIntroductionState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_character_detail_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_character_detail_page.dart
@@ -1,0 +1,709 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:reimi_app/core/extensions/image_path_extension.dart';
+import 'package:reimi_app/domain/read_models/behavior_tendency_read_model.dart';
+import 'package:reimi_app/domain/read_models/type_compatibility_read_model.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_detail_read_model.dart';
+import 'package:reimi_app/gen/assets.gen.dart';
+import 'package:reimi_app/core/i18n/strings.g.dart';
+import 'package:reimi_app/presentation/features/account/account_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/notifiers/weather_personality_character_detail_notifier.dart';
+import 'package:reimi_app/presentation/features/weather_personality/states/weather_personality_character_detail_state.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/action_button.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/axis_feature_card.dart';
+import 'package:reimi_app/presentation/shared/widgets/text_card.dart';
+import 'package:reimi_app/presentation/shared/widgets/app_snack_bar.dart';
+import 'package:reimi_app/presentation/shared/widgets/background_container_noon.dart';
+import 'package:reimi_app/presentation/shared/widgets/section_title.dart';
+import 'package:reimi_app/presentation/shared/widgets/sliver_widgets.dart';
+
+class WeatherPersonalityCharacterDetailPage extends HookConsumerWidget {
+  static String get routeName => 'weather_personality_character_detail';
+  static String get routeLocation => '/$routeName';
+  const WeatherPersonalityCharacterDetailPage({
+    super.key,
+    required this.typeCode,
+  });
+  final String? typeCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+    final notifier =
+        ref.read(weatherPersonalityCharacterDetailNotifierProvider.notifier);
+    final character = ref.watch(
+        weatherPersonalityCharacterDetailNotifierProvider
+            .select((state) => state.character));
+    final isLoading = ref.watch(
+        weatherPersonalityCharacterDetailNotifierProvider
+            .select((state) => state.isLoading));
+
+    final mainController = useAnimationController(
+      duration: const Duration(milliseconds: 600),
+    )..forward();
+
+    final subController = useAnimationController(
+      duration: const Duration(milliseconds: 500),
+    );
+
+    useEffect(() {
+      Future.microtask(() {
+        notifier.init(typeCode);
+      });
+      final timer = Timer(
+        const Duration(milliseconds: 400),
+        () => subController.forward(),
+      );
+
+      final subscription =
+          ref.listenManual<WeatherPersonalityCharacterDetailState>(
+        weatherPersonalityCharacterDetailNotifierProvider,
+        (prev, next) {
+          if (next.errorMessage == null) return;
+          AppSnackBar.error(context, next.errorMessage!);
+        },
+      );
+
+      return () {
+        timer.cancel;
+        subscription.close;
+      };
+    }, []);
+
+    return Scaffold(
+      body: BackgroundContainerNoon(
+        child: SafeArea(
+          child: RefreshIndicator(
+            onRefresh: () async {
+              notifier.refresh(typeCode);
+            },
+            child: CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: [
+                SliverAppBar(
+                  floating: true,
+                  snap: true,
+                  centerTitle: true,
+                  title: Text(
+                    t.weatherPersonalityCharacterDetailPage.title,
+                    style: theme.textTheme.titleMedium!.copyWith(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  backgroundColor: Colors.transparent,
+                  elevation: 0,
+                ),
+                if (isLoading) ...[
+                  const SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                ] else if (character == null) ...[
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                    ),
+                    sliver: SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: Center(
+                        child: Text(
+                          t.weatherPersonalityCharacterDetailPage.nullCase,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ),
+                    ),
+                  ),
+                ] else ...[
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: ScaleTransition(
+                        scale: Tween(begin: 0.9, end: 1.0).animate(
+                          CurvedAnimation(
+                            parent: mainController,
+                            curve: Curves.easeOutBack,
+                          ),
+                        ),
+                        child: FadeTransition(
+                          opacity: mainController,
+                          child: _MainResultCard(
+                            character: character,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 32),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: SlideTransition(
+                        position: Tween(
+                          begin: const Offset(0, 0.15),
+                          end: Offset.zero,
+                        ).animate(
+                          CurvedAnimation(
+                            parent: subController,
+                            curve: Curves.easeOut,
+                          ),
+                        ),
+                        child: FadeTransition(
+                          opacity: subController,
+                          child: _GodsRulingCard(
+                            ruling: character.rulingStatement,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 32),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: Column(
+                        children: [
+                          SectionTitle(
+                            title: t.weatherPersonalityDetailPage.section
+                                .axisFeature.title,
+                          ),
+                          const SizedBox(height: 16),
+                          for (final axisFeature in character.axisFeatures) ...[
+                            AxisFeatureCard(
+                              axisFeature: axisFeature,
+                            ),
+                            const SizedBox(height: 12),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 20),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: BehaviorTendencyCard(
+                        behaviorTendencies: character.behaviorTendencies,
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 32),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: CompatibleTypeCard(
+                        compatibleTypes: character.compatibleTypes,
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 32),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: IncompatibleTypeCard(
+                        incompatibleTypes: character.incompatibleTypes,
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 32),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: GodsMessageCard(
+                        godsMessage: character.godsMessage,
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 32),
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverToBoxAdapter(
+                      child: ActionButton(
+                        label: Text(
+                          t.button.returnToAccountPage,
+                          style: theme.textTheme.labelLarge!.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: theme.colorScheme.primary,
+                          ),
+                        ),
+                        foregroundColor: theme.colorScheme.primary,
+                        backgroundColor: Colors.white,
+                        onPressed: () {
+                          context.go(AccountPage.routeLocation);
+                        },
+                      ),
+                    ),
+                  ),
+                  const Gap(height: 40),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MainResultCard extends StatelessWidget {
+  const _MainResultCard({
+    required this.character,
+  });
+  final WeatherPersonalityCharacterDetailReadModel character;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        color: const Color(0xFFE9F7FB),
+        borderRadius: BorderRadius.circular(32),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Text(
+            t.weatherPersonalityDetailPage.section.mainResult.typeCode,
+            style: theme.textTheme.titleSmall!.copyWith(
+              color: Colors.black54,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            character.typeCode.displayCode,
+            style: theme.textTheme.titleLarge!.copyWith(
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Container(
+            width: 140,
+            height: 140,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  theme.colorScheme.secondary.withValues(alpha: 0.7),
+                  theme.colorScheme.tertiary.withValues(alpha: 0.7),
+                  theme.colorScheme.primary.withValues(alpha: 0.7),
+                ],
+              ),
+            ),
+            alignment: Alignment.center,
+            child: Image(
+              image: character.typeImageUrl.toImageProvider(),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            character.typeName,
+            style: theme.textTheme.titleLarge!.copyWith(
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+                colors: [
+                  theme.colorScheme.secondary.withValues(alpha: 0.15),
+                  theme.colorScheme.tertiary.withValues(alpha: 0.15),
+                  theme.colorScheme.primary.withValues(alpha: 0.15),
+                ],
+              ),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              character.typeCatchphrase,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium!.copyWith(
+                fontSize: 13,
+                height: 1.6,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GodsRulingCard extends StatelessWidget {
+  const _GodsRulingCard({
+    required this.ruling,
+  });
+  final String ruling;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.godsRuling.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            ruling,
+            style: theme.textTheme.bodyMedium!.copyWith(height: 1.6),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class BehaviorTendencyCard extends StatelessWidget {
+  const BehaviorTendencyCard({
+    super.key,
+    required this.behaviorTendencies,
+  });
+  final List<BehaviorTendencyReadModel> behaviorTendencies;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.behaviorTendency.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Column(
+            children: behaviorTendencies
+                .map((behaviorTendency) =>
+                    _BehaviorTendencieListTile(behaviorTendency))
+                .toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BehaviorTendencieListTile extends StatelessWidget {
+  const _BehaviorTendencieListTile(this.behaviorTendency);
+
+  final BehaviorTendencyReadModel behaviorTendency;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 8.0),
+            child: Icon(Icons.circle, size: 6),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              behaviorTendency.summary,
+              style: theme.textTheme.titleSmall!.copyWith(
+                color: const Color(0xFF4A5F72),
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+      subtitle: Row(
+        children: [
+          const SizedBox(width: 10),
+          Flexible(
+            child: Text(
+              behaviorTendency.detail,
+              style: theme.textTheme.bodyMedium!.copyWith(
+                color: const Color(0xFF4A5F72),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CompatibleTypeCard extends StatelessWidget {
+  const CompatibleTypeCard({
+    super.key,
+    required this.compatibleTypes,
+  });
+  final List<TypeCompatibilityReadModel> compatibleTypes;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      padding: const EdgeInsets.symmetric(
+        vertical: 24,
+        horizontal: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.compatibleType.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children:
+                compatibleTypes.map((type) => TypeCard(type: type)).toList(),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class IncompatibleTypeCard extends StatelessWidget {
+  const IncompatibleTypeCard({
+    super.key,
+    required this.incompatibleTypes,
+  });
+  final List<TypeCompatibilityReadModel> incompatibleTypes;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      padding: const EdgeInsets.symmetric(
+        vertical: 24,
+        horizontal: 16,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Center(
+            child: Text(
+              t.weatherPersonalityDetailPage.section.incompatibleType.title,
+              style: theme.textTheme.titleSmall!.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children:
+                incompatibleTypes.map((type) => TypeCard(type: type)).toList(),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class TypeCard extends StatelessWidget {
+  const TypeCard({
+    super.key,
+    required this.type,
+  });
+  final TypeCompatibilityReadModel type;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            theme.colorScheme.secondary.withValues(alpha: 0.1),
+            theme.colorScheme.tertiary.withValues(alpha: 0.1),
+            theme.colorScheme.primary.withValues(alpha: 0.1),
+          ],
+        ),
+      ),
+      width: 150,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Container(
+            width: 140,
+            height: 140,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(16),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  theme.colorScheme.secondary.withValues(alpha: 0.7),
+                  theme.colorScheme.tertiary.withValues(alpha: 0.7),
+                  theme.colorScheme.primary.withValues(alpha: 0.7),
+                ],
+              ),
+            ),
+            alignment: Alignment.center,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: Image(
+                  image: type.typeImageUrl.toImageProvider(),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  type.typeCode.displayCode,
+                  softWrap: true,
+                  style: theme.textTheme.bodyMedium!.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                Text(
+                  '(${type.typeName})',
+                  softWrap: true,
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  'Point:',
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  type.compatibilityPoint,
+                  softWrap: true,
+                  style: theme.textTheme.bodySmall!.copyWith(
+                    decoration: TextDecoration.underline,
+                  ),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class GodsMessageCard extends StatelessWidget {
+  const GodsMessageCard({
+    super.key,
+    required this.godsMessage,
+  });
+  final String godsMessage;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return TextCard(
+      colors: const [
+        Color(0xFFCDDCD7),
+        Color(0xFFB7E3DB),
+      ],
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 32,
+                backgroundColor: Colors.transparent,
+                backgroundImage: Assets
+                    .images.weatherPersonality.reimiGodIcon.path
+                    .toImageProvider(),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                t.weatherPersonalityDetailPage.section.godsMessage.title,
+                style: theme.textTheme.titleSmall!.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            godsMessage,
+            style: theme.textTheme.bodyMedium!.copyWith(
+              height: 1.6,
+              color: const Color(0xFF334155),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_characters_introduction_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_characters_introduction_page.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:reimi_app/core/i18n/strings.g.dart';
+import 'package:reimi_app/presentation/features/weather_personality/notifiers/weather_personality_characters_introduction_notifier.dart';
+import 'package:reimi_app/presentation/features/weather_personality/pages/weather_personality_character_detail_page.dart';
+import 'package:reimi_app/presentation/features/weather_personality/states/weather_personality_characters_introduction_state.dart';
+import 'package:reimi_app/presentation/features/weather_personality/widgets/character_card.dart';
+import 'package:reimi_app/presentation/shared/widgets/app_snack_bar.dart';
+import 'package:reimi_app/presentation/shared/widgets/background_container_noon.dart';
+
+class WeatherPersonalityCharactersIntroductionPage extends HookConsumerWidget {
+  const WeatherPersonalityCharactersIntroductionPage({super.key});
+  static String get routeName => 'weather_personality_characters_introduction';
+  static String get routeLocation => '/$routeName';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final t = Translations.of(context);
+    final theme = Theme.of(context);
+    final scrollController = useScrollController();
+    final notifier = ref.read(
+        weatherPersonalityCharactersIntroductionNotifierProvider.notifier);
+    final isLoading = ref.watch(
+        weatherPersonalityCharactersIntroductionNotifierProvider
+            .select((state) => state.isLoading));
+    final characters = ref.watch(
+        weatherPersonalityCharactersIntroductionNotifierProvider
+            .select((state) => state.characters));
+
+    final mainController = useAnimationController(
+      duration: const Duration(milliseconds: 600),
+    )..forward();
+
+    useEffect(() {
+      Future.microtask(() {
+        notifier.init();
+      });
+
+      final subscription =
+          ref.listenManual<WeatherPersonalityCharactersIntroductionState>(
+        weatherPersonalityCharactersIntroductionNotifierProvider,
+        (prev, next) {
+          if (next.errorMessage == null) return;
+          AppSnackBar.error(context, next.errorMessage!);
+        },
+      );
+
+      return subscription.close;
+    }, []);
+
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      body: BackgroundContainerNoon(
+        child: SafeArea(
+          child: RefreshIndicator(
+            onRefresh: () async {
+              notifier.refresh();
+            },
+            child: CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              controller: scrollController,
+              slivers: [
+                SliverAppBar(
+                  floating: true,
+                  snap: true,
+                  title: Text(
+                    t.weatherPersonalityCharactersIntroductionPage.title,
+                    style: theme.textTheme.titleMedium!.copyWith(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.black87,
+                    ),
+                  ),
+                  backgroundColor: Colors.transparent,
+                  elevation: 0,
+                ),
+                if (isLoading) ...[
+                  const SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                ] else if (characters.isEmpty) ...[
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    sliver: SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: Center(
+                        child: Text(
+                          t.weatherPersonalityCharactersIntroductionPage
+                              .isEmptyCase,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ),
+                    ),
+                  )
+                ] else ...[
+                  SliverPadding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 20,
+                      vertical: 16,
+                    ),
+                    sliver: SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        (context, index) {
+                          final character = characters[index];
+                          return Padding(
+                            padding: const EdgeInsets.only(bottom: 32),
+                            child: ScaleTransition(
+                              scale: Tween(begin: 0.9, end: 1.0).animate(
+                                CurvedAnimation(
+                                  parent: mainController,
+                                  curve: Curves.easeOutBack,
+                                ),
+                              ),
+                              child: FadeTransition(
+                                opacity: mainController,
+                                child: CharacterCard(
+                                  character: character,
+                                  onTap: () {
+                                    context.push(
+                                      WeatherPersonalityCharacterDetailPage
+                                          .routeLocation,
+                                      extra: {
+                                        'typeCode':
+                                            character.typeCode.displayCode,
+                                      },
+                                    );
+                                  },
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                        childCount: characters.length,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_concept_page.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/pages/weather_personality_concept_page.dart
@@ -7,9 +7,13 @@ import 'package:reimi_app/presentation/features/weather_personality/widgets/weat
 import 'package:reimi_app/presentation/shared/widgets/background_container_noon.dart';
 
 class WeatherPersonalityConceptPage extends StatelessWidget {
-  const WeatherPersonalityConceptPage({super.key});
   static String get routeName => 'weather_personality_concept';
   static String get routeLocation => '/$routeName';
+  const WeatherPersonalityConceptPage({
+    super.key,
+    required this.isPreTest,
+  });
+  final bool isPreTest;
 
   @override
   Widget build(BuildContext context) {
@@ -49,10 +53,11 @@ class WeatherPersonalityConceptPage extends StatelessWidget {
               Positioned(
                 child: Column(
                   children: [
-                    const SizedBox(height: 210),
+                    SizedBox(height: isPreTest ? 210 : 280),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: Container(
+                        width: double.infinity,
                         padding: const EdgeInsets.fromLTRB(40, 24, 40, 28),
                         decoration: BoxDecoration(
                           color: Colors.white.withValues(alpha: 0.8),
@@ -112,14 +117,17 @@ class WeatherPersonalityConceptPage extends StatelessWidget {
                         ),
                       ),
                     ),
-                    const Spacer(),
-                    WeatherPersonalityButton(
-                      label: t.button.startTest,
-                      onPressed: () {
-                        context.go(WeatherPersonalityTestQ1Page.routeLocation);
-                      },
-                    ),
-                    const SizedBox(height: 32),
+                    if (isPreTest) ...[
+                      const Spacer(),
+                      WeatherPersonalityButton(
+                        label: t.button.startTest,
+                        onPressed: () {
+                          context
+                              .go(WeatherPersonalityTestQ1Page.routeLocation);
+                        },
+                      ),
+                      const SizedBox(height: 32),
+                    ],
                   ],
                 ),
               )

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_character_detail_state.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_character_detail_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_detail_read_model.dart';
+
+part 'weather_personality_character_detail_state.freezed.dart';
+
+@freezed
+abstract class WeatherPersonalityCharacterDetailState
+    with _$WeatherPersonalityCharacterDetailState {
+  const factory WeatherPersonalityCharacterDetailState({
+    WeatherPersonalityCharacterDetailReadModel? character,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _WeatherPersonalityCharacterDetailState;
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_character_detail_state.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_character_detail_state.freezed.dart
@@ -1,0 +1,397 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_personality_character_detail_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WeatherPersonalityCharacterDetailState {
+  WeatherPersonalityCharacterDetailReadModel? get character;
+  bool get isLoading;
+  String? get errorMessage;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityCharacterDetailStateCopyWith<
+          WeatherPersonalityCharacterDetailState>
+      get copyWith => _$WeatherPersonalityCharacterDetailStateCopyWithImpl<
+              WeatherPersonalityCharacterDetailState>(
+          this as WeatherPersonalityCharacterDetailState, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WeatherPersonalityCharacterDetailState &&
+            (identical(other.character, character) ||
+                other.character == character) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, character, isLoading, errorMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharacterDetailState(character: $character, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WeatherPersonalityCharacterDetailStateCopyWith<$Res> {
+  factory $WeatherPersonalityCharacterDetailStateCopyWith(
+          WeatherPersonalityCharacterDetailState value,
+          $Res Function(WeatherPersonalityCharacterDetailState) _then) =
+      _$WeatherPersonalityCharacterDetailStateCopyWithImpl;
+  @useResult
+  $Res call(
+      {WeatherPersonalityCharacterDetailReadModel? character,
+      bool isLoading,
+      String? errorMessage});
+
+  $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>? get character;
+}
+
+/// @nodoc
+class _$WeatherPersonalityCharacterDetailStateCopyWithImpl<$Res>
+    implements $WeatherPersonalityCharacterDetailStateCopyWith<$Res> {
+  _$WeatherPersonalityCharacterDetailStateCopyWithImpl(this._self, this._then);
+
+  final WeatherPersonalityCharacterDetailState _self;
+  final $Res Function(WeatherPersonalityCharacterDetailState) _then;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? character = freezed,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(_self.copyWith(
+      character: freezed == character
+          ? _self.character
+          : character // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityCharacterDetailReadModel?,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+
+  /// Create a copy of WeatherPersonalityCharacterDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>? get character {
+    if (_self.character == null) {
+      return null;
+    }
+
+    return $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>(
+        _self.character!, (value) {
+      return _then(_self.copyWith(character: value));
+    });
+  }
+}
+
+/// Adds pattern-matching-related methods to [WeatherPersonalityCharacterDetailState].
+extension WeatherPersonalityCharacterDetailStatePatterns
+    on WeatherPersonalityCharacterDetailState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharacterDetailState value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailState() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharacterDetailState value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailState():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_WeatherPersonalityCharacterDetailState value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailState() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(WeatherPersonalityCharacterDetailReadModel? character,
+            bool isLoading, String? errorMessage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailState() when $default != null:
+        return $default(_that.character, _that.isLoading, _that.errorMessage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(WeatherPersonalityCharacterDetailReadModel? character,
+            bool isLoading, String? errorMessage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailState():
+        return $default(_that.character, _that.isLoading, _that.errorMessage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(WeatherPersonalityCharacterDetailReadModel? character,
+            bool isLoading, String? errorMessage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharacterDetailState() when $default != null:
+        return $default(_that.character, _that.isLoading, _that.errorMessage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _WeatherPersonalityCharacterDetailState
+    implements WeatherPersonalityCharacterDetailState {
+  const _WeatherPersonalityCharacterDetailState(
+      {this.character, this.isLoading = false, this.errorMessage});
+
+  @override
+  final WeatherPersonalityCharacterDetailReadModel? character;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$WeatherPersonalityCharacterDetailStateCopyWith<
+          _WeatherPersonalityCharacterDetailState>
+      get copyWith => __$WeatherPersonalityCharacterDetailStateCopyWithImpl<
+          _WeatherPersonalityCharacterDetailState>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WeatherPersonalityCharacterDetailState &&
+            (identical(other.character, character) ||
+                other.character == character) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, character, isLoading, errorMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharacterDetailState(character: $character, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$WeatherPersonalityCharacterDetailStateCopyWith<$Res>
+    implements $WeatherPersonalityCharacterDetailStateCopyWith<$Res> {
+  factory _$WeatherPersonalityCharacterDetailStateCopyWith(
+          _WeatherPersonalityCharacterDetailState value,
+          $Res Function(_WeatherPersonalityCharacterDetailState) _then) =
+      __$WeatherPersonalityCharacterDetailStateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {WeatherPersonalityCharacterDetailReadModel? character,
+      bool isLoading,
+      String? errorMessage});
+
+  @override
+  $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>? get character;
+}
+
+/// @nodoc
+class __$WeatherPersonalityCharacterDetailStateCopyWithImpl<$Res>
+    implements _$WeatherPersonalityCharacterDetailStateCopyWith<$Res> {
+  __$WeatherPersonalityCharacterDetailStateCopyWithImpl(this._self, this._then);
+
+  final _WeatherPersonalityCharacterDetailState _self;
+  final $Res Function(_WeatherPersonalityCharacterDetailState) _then;
+
+  /// Create a copy of WeatherPersonalityCharacterDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? character = freezed,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(_WeatherPersonalityCharacterDetailState(
+      character: freezed == character
+          ? _self.character
+          : character // ignore: cast_nullable_to_non_nullable
+              as WeatherPersonalityCharacterDetailReadModel?,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+
+  /// Create a copy of WeatherPersonalityCharacterDetailState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>? get character {
+    if (_self.character == null) {
+      return null;
+    }
+
+    return $WeatherPersonalityCharacterDetailReadModelCopyWith<$Res>(
+        _self.character!, (value) {
+      return _then(_self.copyWith(character: value));
+    });
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_characters_introduction_state.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_characters_introduction_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_read_model.dart';
+
+part 'weather_personality_characters_introduction_state.freezed.dart';
+
+@freezed
+abstract class WeatherPersonalityCharactersIntroductionState
+    with _$WeatherPersonalityCharactersIntroductionState {
+  const factory WeatherPersonalityCharactersIntroductionState({
+    @Default(<WeatherPersonalityCharacterReadModel>[])
+    List<WeatherPersonalityCharacterReadModel> characters,
+    @Default(false) bool isLoading,
+    String? errorMessage,
+  }) = _WeatherPersonalityCharactersIntroductionState;
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_characters_introduction_state.freezed.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/states/weather_personality_characters_introduction_state.freezed.dart
@@ -1,0 +1,390 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_personality_characters_introduction_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WeatherPersonalityCharactersIntroductionState {
+  List<WeatherPersonalityCharacterReadModel> get characters;
+  bool get isLoading;
+  String? get errorMessage;
+
+  /// Create a copy of WeatherPersonalityCharactersIntroductionState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $WeatherPersonalityCharactersIntroductionStateCopyWith<
+          WeatherPersonalityCharactersIntroductionState>
+      get copyWith =>
+          _$WeatherPersonalityCharactersIntroductionStateCopyWithImpl<
+                  WeatherPersonalityCharactersIntroductionState>(
+              this as WeatherPersonalityCharactersIntroductionState,
+              _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is WeatherPersonalityCharactersIntroductionState &&
+            const DeepCollectionEquality()
+                .equals(other.characters, characters) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(characters), isLoading, errorMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharactersIntroductionState(characters: $characters, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $WeatherPersonalityCharactersIntroductionStateCopyWith<
+    $Res> {
+  factory $WeatherPersonalityCharactersIntroductionStateCopyWith(
+          WeatherPersonalityCharactersIntroductionState value,
+          $Res Function(WeatherPersonalityCharactersIntroductionState) _then) =
+      _$WeatherPersonalityCharactersIntroductionStateCopyWithImpl;
+  @useResult
+  $Res call(
+      {List<WeatherPersonalityCharacterReadModel> characters,
+      bool isLoading,
+      String? errorMessage});
+}
+
+/// @nodoc
+class _$WeatherPersonalityCharactersIntroductionStateCopyWithImpl<$Res>
+    implements $WeatherPersonalityCharactersIntroductionStateCopyWith<$Res> {
+  _$WeatherPersonalityCharactersIntroductionStateCopyWithImpl(
+      this._self, this._then);
+
+  final WeatherPersonalityCharactersIntroductionState _self;
+  final $Res Function(WeatherPersonalityCharactersIntroductionState) _then;
+
+  /// Create a copy of WeatherPersonalityCharactersIntroductionState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? characters = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(_self.copyWith(
+      characters: null == characters
+          ? _self.characters
+          : characters // ignore: cast_nullable_to_non_nullable
+              as List<WeatherPersonalityCharacterReadModel>,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [WeatherPersonalityCharactersIntroductionState].
+extension WeatherPersonalityCharactersIntroductionStatePatterns
+    on WeatherPersonalityCharactersIntroductionState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharactersIntroductionState value)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharactersIntroductionState()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_WeatherPersonalityCharactersIntroductionState value)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharactersIntroductionState():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_WeatherPersonalityCharactersIntroductionState value)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharactersIntroductionState()
+          when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(List<WeatherPersonalityCharacterReadModel> characters,
+            bool isLoading, String? errorMessage)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharactersIntroductionState()
+          when $default != null:
+        return $default(_that.characters, _that.isLoading, _that.errorMessage);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(List<WeatherPersonalityCharacterReadModel> characters,
+            bool isLoading, String? errorMessage)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharactersIntroductionState():
+        return $default(_that.characters, _that.isLoading, _that.errorMessage);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(List<WeatherPersonalityCharacterReadModel> characters,
+            bool isLoading, String? errorMessage)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _WeatherPersonalityCharactersIntroductionState()
+          when $default != null:
+        return $default(_that.characters, _that.isLoading, _that.errorMessage);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _WeatherPersonalityCharactersIntroductionState
+    implements WeatherPersonalityCharactersIntroductionState {
+  const _WeatherPersonalityCharactersIntroductionState(
+      {final List<WeatherPersonalityCharacterReadModel> characters =
+          const <WeatherPersonalityCharacterReadModel>[],
+      this.isLoading = false,
+      this.errorMessage})
+      : _characters = characters;
+
+  final List<WeatherPersonalityCharacterReadModel> _characters;
+  @override
+  @JsonKey()
+  List<WeatherPersonalityCharacterReadModel> get characters {
+    if (_characters is EqualUnmodifiableListView) return _characters;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_characters);
+  }
+
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  final String? errorMessage;
+
+  /// Create a copy of WeatherPersonalityCharactersIntroductionState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$WeatherPersonalityCharactersIntroductionStateCopyWith<
+          _WeatherPersonalityCharactersIntroductionState>
+      get copyWith =>
+          __$WeatherPersonalityCharactersIntroductionStateCopyWithImpl<
+              _WeatherPersonalityCharactersIntroductionState>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WeatherPersonalityCharactersIntroductionState &&
+            const DeepCollectionEquality()
+                .equals(other._characters, _characters) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_characters),
+      isLoading,
+      errorMessage);
+
+  @override
+  String toString() {
+    return 'WeatherPersonalityCharactersIntroductionState(characters: $characters, isLoading: $isLoading, errorMessage: $errorMessage)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$WeatherPersonalityCharactersIntroductionStateCopyWith<
+        $Res>
+    implements $WeatherPersonalityCharactersIntroductionStateCopyWith<$Res> {
+  factory _$WeatherPersonalityCharactersIntroductionStateCopyWith(
+          _WeatherPersonalityCharactersIntroductionState value,
+          $Res Function(_WeatherPersonalityCharactersIntroductionState) _then) =
+      __$WeatherPersonalityCharactersIntroductionStateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<WeatherPersonalityCharacterReadModel> characters,
+      bool isLoading,
+      String? errorMessage});
+}
+
+/// @nodoc
+class __$WeatherPersonalityCharactersIntroductionStateCopyWithImpl<$Res>
+    implements _$WeatherPersonalityCharactersIntroductionStateCopyWith<$Res> {
+  __$WeatherPersonalityCharactersIntroductionStateCopyWithImpl(
+      this._self, this._then);
+
+  final _WeatherPersonalityCharactersIntroductionState _self;
+  final $Res Function(_WeatherPersonalityCharactersIntroductionState) _then;
+
+  /// Create a copy of WeatherPersonalityCharactersIntroductionState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? characters = null,
+    Object? isLoading = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(_WeatherPersonalityCharactersIntroductionState(
+      characters: null == characters
+          ? _self._characters
+          : characters // ignore: cast_nullable_to_non_nullable
+              as List<WeatherPersonalityCharacterReadModel>,
+      isLoading: null == isLoading
+          ? _self.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _self.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/widgets/character_card.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_personality/widgets/character_card.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:reimi_app/core/extensions/image_path_extension.dart';
+import 'package:reimi_app/core/i18n/strings.g.dart';
+import 'package:reimi_app/domain/read_models/weather_personality_character_read_model.dart';
+
+class CharacterCard extends StatelessWidget {
+  const CharacterCard({
+    super.key,
+    required this.character,
+    required this.onTap,
+  });
+  final WeatherPersonalityCharacterReadModel character;
+  final void Function()? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final t = Translations.of(context);
+
+    return Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFDDE6ED),
+            borderRadius: BorderRadius.circular(28),
+          ),
+          child: Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.9),
+              borderRadius: BorderRadius.circular(24),
+            ),
+            child: Column(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(16),
+                  child: Image(
+                    image: character.typeImageUrl.toImageProvider(),
+                    height: 200,
+                    fit: BoxFit.contain,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  character.typeCode.displayCode,
+                  style: theme.textTheme.headlineMedium!.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  character.typeName,
+                  style: theme.textTheme.titleLarge!.copyWith(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.centerLeft,
+                      end: Alignment.centerRight,
+                      colors: [
+                        theme.colorScheme.secondary.withValues(alpha: 0.15),
+                        theme.colorScheme.tertiary.withValues(alpha: 0.15),
+                        theme.colorScheme.primary.withValues(alpha: 0.15),
+                      ],
+                    ),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    character.typeCatchphrase,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyMedium!.copyWith(
+                      height: 1.6,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                GestureDetector(
+                  onTap: onTap,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 40),
+                    width: double.infinity,
+                    height: 48,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: theme.colorScheme.primary,
+                          width: 2,
+                        ),
+                        borderRadius: BorderRadius.circular(24),
+                        color: Colors.white,
+                      ),
+                      child: Center(
+                        child: Text(
+                          t.button.seeDetails,
+                          style: theme.textTheme.labelLarge!.copyWith(
+                            color: theme.colorScheme.primary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_notifier.g.dart
+++ b/reimi/frontend/reimi_app/lib/presentation/features/weather_report/notifiers/weather_report_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'weather_report_notifier.dart';
 // **************************************************************************
 
 String _$weatherReportNotifierHash() =>
-    r'fce38afdc9dff90c0c4c47c12ab4a7ee6d255891';
+    r'0ffbe9366448175eefa314a8d207b394e8acff14';
 
 /// See also [WeatherReportNotifier].
 @ProviderFor(WeatherReportNotifier)


### PR DESCRIPTION
## 対応Issue

- #184 

close #184 

## 対応したこと

<!-- このプルリクで何をしたのか記述する -->
- core
  - di
    - キャラクター取得系ユースケースのdi追加
 
- data
  - repository
    - キャラクター情報取得関連の項目追加 
   
- domain
  - repository
    - キャラクター情報取得関連の項目追加
  - read_model
    - キャラクター詳細情報を取得する時に使用するReadモデル作成
    - キャラクター一覧情報を取得する時に使用するReadモデル作成   
- application
  - usecase
    - キャラクター詳細取得のユースケース実装
    - キャラクター一覧取得のユースケース実装   
   
- presentation
  - account
    - page
      - ウェザーパーソナリティ診断やキャラクターを詳細に見れる導線を設けた 
    - widget
      - アカウント画面でListTile形式で表示させるウィジェット作成 
  - weather_personality
    - page
      - キャラクター詳細画面のUI実装
      - キャラクター紹介画面のUI実装 
    - state
      - キャラクター詳細画面を状態管理するstate実装
      - キャラクター紹介画面を状態管理するstate実装   
    - notifier
      - キャラクター詳細画面を状態管理するnotifier実装
      - キャラクター紹介画面を状態管理するnotifier実装
    - widget
      - キャラクター紹介で使用するカードウィジェット作成

- 修正
  - 診断コンセプト画面で、診断する時だけ診断開始ボタンを表示させるようにした 


## 参考資料
<!-- 参考にした資料のリンクを貼る -->

## 対応しきれなかったこと

<!-- 修正が必要そうな部分や別チケットで解決したい部分をあげる -->
- apiを叩くロジック実装

## 画面キャプチャ

<!-- 実装前と実装後でどう変わったかわかるキャプチャを貼る -->

| キャラクター紹介 | キャラクター詳細 |
| -- | -- |
| <img width="200" alt="IMG_5557" src="https://github.com/user-attachments/assets/e726a19b-e9de-4609-a285-4f90e9d89891" /> | <img width="200" alt="IMG_5559" src="https://github.com/user-attachments/assets/994b124c-6e0c-4356-b145-eed719de056e" /> |