### PR TITLE
【API設計】ウェザーパーソナリティ再診断のAPI設計（/user-weather-personality-type）

### DIFF
--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/WeatherPersonalityUseCase.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/application/usecase/WeatherPersonalityUseCase.java
@@ -8,4 +8,6 @@ public interface WeatherPersonalityUseCase {
     void diagnose(DiagnoseWeatherPersonalityCommand command);
 
     UserWeatherPersonalityType getUserResult();
+
+    void reDiagnose(DiagnoseWeatherPersonalityCommand command);
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
@@ -6,8 +6,8 @@ public class UserWeatherPersonalityType {
 
     private final UserWeatherPersonalityTypeId id;
     private final UserId userId;
-    private final WeatherPersonalityType type;
-    private final WeatherPersonalityScore weatherPersonalityScore;
+    private WeatherPersonalityType type;
+    private WeatherPersonalityScore weatherPersonalityScore;
 
     private UserWeatherPersonalityType(
         UserWeatherPersonalityTypeId id,
@@ -34,6 +34,14 @@ public class UserWeatherPersonalityType {
             weatherPersonalityScore
         );
 
+    }
+
+    public void update(
+        WeatherPersonalityType type,
+        WeatherPersonalityScore weatherPersonalityScore
+    ) {
+        this.type = type;
+        this.weatherPersonalityScore = weatherPersonalityScore;
     }
 
     public static UserWeatherPersonalityType reconstruct(

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
@@ -17,6 +17,8 @@ import com.reimi.reimi_app.domain.repository.UserRepository;
 import com.reimi.reimi_app.domain.repository.UserWeatherPersonalityTypeRepository;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
+import org.springframework.transaction.annotation.Transactional;
+
 @Service
 public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase {
 
@@ -83,5 +85,31 @@ public class WeatherPersonalityUseCaseImpl implements WeatherPersonalityUseCase 
         result.getWeatherPersonalityType().setTypeImageUrl(typeImageUrl);
 
         return result;
+    }
+
+    @Override
+    @Transactional
+    public void reDiagnose(DiagnoseWeatherPersonalityCommand command) {
+
+        // 既存の診断結果を取得
+        UserWeatherPersonalityType existing = userWeatherPersonalityTypeRepository
+            .findByUserId(command.userId())
+            .orElseThrow(() -> new ResourceNotFoundException("ウェザーパーソナリティ診断結果"));
+
+        // 診断ロジックがあるドメインサービスをインスタンス化して使う
+        WeatherPersonalityDiagnosis diagnosis = new WeatherPersonalityDiagnosis();
+
+        // 4つの軸ごとにスコアリングする
+        WeatherPersonalityScore weatherPersonalityScore = diagnosis.diagnoseScore(command.answers());
+
+        //スコアリングした結果からタイプコードを決定する
+        WeatherPersonalityCode code = diagnosis.decideType(weatherPersonalityScore, command.answers());
+
+        WeatherPersonalityType type = WeatherPersonalityType.from(code);
+
+        // 既存の診断結果を書き換える
+        existing.update(type, weatherPersonalityScore);
+
+        userWeatherPersonalityTypeRepository.save(existing);
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,7 @@ import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersona
 import com.reimi.reimi_app.infrastructure.web.dto.response.DiagnoseResultWeatherPersonalityResponse;
 import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.DiagnoseWeatherPersonalityTypeApi;
 import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.GetUserWeatherPersonalityTypeApi;
+import com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality.ReDiagnoseWeatherPersonalityTypeApi;
 import com.reimi.reimi_app.security.AuthenticatedUserProvider;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -111,5 +113,43 @@ public class WeatherPersonalityController extends ApiV1Controller {
             );
 
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/user-weather-personality-type")
+    @ReDiagnoseWeatherPersonalityTypeApi
+    public ResponseEntity<Void> reDiagnose(
+        @Valid @RequestBody DiagnoseWeatherPersonalityRequest request
+    ) {
+        List<AnswerChoice> answers = List.of(
+            request.q1Answer(),
+            request.q2Answer(),
+            request.q3Answer(),
+            request.q4Answer(),
+            request.q5Answer(),
+            request.q6Answer(),
+            request.q7Answer(),
+            request.q8Answer(),
+            request.q9Answer(),
+            request.q10Answer(),
+            request.q11Answer(),
+            request.q12Answer(),
+            request.q13Answer(),
+            request.q14Answer(),
+            request.q15Answer(),
+            request.q16Answer()
+        );
+
+        String myFirebaseUid = authenticatedUserProvider.getFirebaseUid();
+        User user = userUseCase.getUser(myFirebaseUid)
+            .orElseThrow(() -> new ResourceNotFoundException("ユーザー"));
+
+        weatherPersonalityUseCase.reDiagnose(
+            new DiagnoseWeatherPersonalityCommand(
+                user.getId(),
+                answers
+            )
+        );
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/ReDiagnoseWeatherPersonalityTypeApi.java
+++ b/reimi/backend/reimi_app/src/main/java/com/reimi/reimi_app/infrastructure/web/openapi/weatherpersonality/ReDiagnoseWeatherPersonalityTypeApi.java
@@ -1,0 +1,123 @@
+package com.reimi.reimi_app.infrastructure.web.openapi.weatherpersonality;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.reimi.reimi_app.infrastructure.web.dto.request.DiagnoseWeatherPersonalityRequest;
+import com.reimi.reimi_app.infrastructure.web.dto.response.ApiErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+    summary = "ウェザーパーソナリティ再診断",
+    description = "ユーザーのウェザーパーソナリティ再診断ができるAPI",
+    requestBody = @RequestBody(
+        required = true,
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = DiagnoseWeatherPersonalityRequest.class)
+        )
+    )
+)
+@ApiResponses({
+    @ApiResponse(
+        responseCode = "204",
+        description = "ユーザーのウェザーパーソナリティ再診断が正常に行われました",
+        content = @Content(
+            mediaType = "application/json"
+        )
+    ),
+    @ApiResponse(
+        responseCode = "400",
+        description = "無効なリクエスト",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = {
+                @ExampleObject(
+                    name = "フォーマット不正",
+                    description = "リクエスト形式が正しくない場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "無効なリクエストです"
+                    }
+                    """
+                ),
+                @ExampleObject(
+                    name = "バリデーションエラー",
+                    description = "入力値のバリデーションに失敗した場合",
+                    value = """
+                    {
+                        "code": "INVALID_REQUEST",
+                        "message": "入力値が不正です",
+                        "details": {
+                            "q1Answer": "Q1の回答は必須です"
+                        }
+                    }
+                    """
+                )
+            }
+        )
+    ),
+    @ApiResponse(
+        responseCode = "401",
+        description = "認証エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "UNAUTHENTICATED",
+                    "message": "認証されていません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "404",
+        description = "リソース不存在エラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "RESOURCE_NOT_FOUND",
+                    "message": "ウェザーパーソナリティ診断結果が見つかりません"
+                }
+                """
+            )
+        )
+    ),
+    @ApiResponse(
+        responseCode = "500",
+        description = "サーバーエラー",
+        content = @Content(
+            mediaType = "application/json",
+            schema = @Schema(implementation = ApiErrorResponse.class),
+            examples = @ExampleObject(
+                value = """
+                {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "予期しないエラーが発生しました"
+                }
+                """
+            )
+        )
+    )
+})
+public @interface ReDiagnoseWeatherPersonalityTypeApi {
+}


### PR DESCRIPTION
## 概要

API名：ウェザーパーソナリティ再診断

種別：API開発

関連Issue：

- #196

close #196

## API設計

### 【やったこと・開発メモ】

### ドメイン層

---

- UserWeatherPersonalityTypeドメインモデルの変更
    - 変更可能なフィールドのfinalを消す
        - type
        - weatherPersonalityScore
    - updateメソッドを作成

### アプリケーション層

---

- ウェザーパーソナリティユースケースのインターフェイスに業務を追加
    - ユーザーの再診断メソッド

### インフラストラクチャ層

---

- ウェザーパーソナリティの実装ユースケースにオーバーライドメソッドを定義
    - ユーザーの既存診断結果を取得
    - 診断ロジック等は初回診断時と同じ手順で処理
    - updateメソッドで既存の診断結果を書き換える
    - 更新された内容を保存
- Controllerにユーザーのウェザーパーソナリティ再診断ができるPUT APIを定義
- 定義アノテーションを作成

### 【エンドポイント定義】

| 項目 | 内容 |
| --- | --- |
| API名 | ウェザーパーソナリティ再診断 |
| URL | api/v1/user-weather-personality-type |
| HTTPメソッド | PUT |
| ステータスコード | 204 / 400 / 401 / 404 / 500 |

### 【リクエスト】

```json
{
  "q1Answer": string
  "q2Answer": string
  "q3Answer": string
  "q4Answer": string
  "q5Answer": string
  "q6Answer": string
  "q7Answer": string
  "q8Answer": string
  "q9Answer": string
  "q10Answer": string
  "q11Answer": string
  "q12Answer": string
  "q13Answer": string
  "q14Answer": string
  "q15Answer": string
  "q16Answer": string
}
```

### 【レスポンス】

特になし

### 【追加・変更した設定ファイル】

 - 追加したファイル
   - reimi_app/infrastructure/web/openapi/weatherpersonality/ReDiagnoseWeatherPersonalityTypeApi.java
 
 - 変更したファイル
   - reimi_app/application/usecase/WeatherPersonalityUseCase.java
   - reimi_app/domain/model/weatherpersonality/UserWeatherPersonalityType.java
   - reimi_app/infrastructure/service/WeatherPersonalityUseCaseImpl.java
   - reimi_app/infrastructure/web/controller/v1/WeatherPersonalityController.java